### PR TITLE
refactor(queue): modularize transaction queue processing

### DIFF
--- a/database/balance.go
+++ b/database/balance.go
@@ -629,7 +629,7 @@ func updateBalance(ctx context.Context, tx *sql.Tx, balance *model.Balance) erro
 	query := `
         UPDATE blnk.balances
         SET balance = $2, credit_balance = $3, debit_balance = $4, inflight_balance = $5, inflight_credit_balance = $6, inflight_debit_balance = $7, currency = $8, currency_multiplier = $9, ledger_id = $10, created_at = $11, version = version + 1
-        WHERE balance_id = $1 AND version = $13
+        WHERE balance_id = $1 AND version = $12
     `
 
 	// Execute the update query within the provided transaction context

--- a/database/balance_test.go
+++ b/database/balance_test.go
@@ -208,7 +208,7 @@ func TestUpdateBalances_Success(t *testing.T) {
 	mock.ExpectExec(regexp.QuoteMeta(`
         UPDATE blnk.balances
         SET balance = $2, credit_balance = $3, debit_balance = $4, inflight_balance = $5, inflight_credit_balance = $6, inflight_debit_balance = $7, currency = $8, currency_multiplier = $9, ledger_id = $10, created_at = $11, version = version + 1
-        WHERE balance_id = $1 AND version = $13
+        WHERE balance_id = $1 AND version = $12
     `)).WithArgs(
 		sourceBalance.BalanceID,
 		sourceBalance.Balance.String(),
@@ -228,7 +228,7 @@ func TestUpdateBalances_Success(t *testing.T) {
 	mock.ExpectExec(regexp.QuoteMeta(`
         UPDATE blnk.balances
         SET balance = $2, credit_balance = $3, debit_balance = $4, inflight_balance = $5, inflight_credit_balance = $6, inflight_debit_balance = $7, currency = $8, currency_multiplier = $9, ledger_id = $10, created_at = $11, version = version + 1
-        WHERE balance_id = $1 AND version = $13
+        WHERE balance_id = $1 AND version = $12
     `)).WithArgs(
 		destBalance.BalanceID,
 		destBalance.Balance.String(),

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -74,7 +74,7 @@ func TestRecordTransaction(t *testing.T) {
 	mock.ExpectExec(regexp.QuoteMeta(`
 	  UPDATE blnk.balances
 	  SET balance = $2, credit_balance = $3, debit_balance = $4, inflight_balance = $5, inflight_credit_balance = $6, inflight_debit_balance = $7, currency = $8, currency_multiplier = $9, ledger_id = $10, created_at = $11, version = version + 1
-	  WHERE balance_id = $1 AND version = $13
+	  WHERE balance_id = $1 AND version = $12
 	`)).WithArgs(
 		source,
 		big.NewInt(9000).String(),
@@ -93,7 +93,7 @@ func TestRecordTransaction(t *testing.T) {
 	mock.ExpectExec(regexp.QuoteMeta(`
 	  UPDATE blnk.balances
 	  SET balance = $2, credit_balance = $3, debit_balance = $4, inflight_balance = $5, inflight_credit_balance = $6, inflight_debit_balance = $7, currency = $8, currency_multiplier = $9, ledger_id = $10, created_at = $11, version = version + 1
-	  WHERE balance_id = $1 AND version = $13
+	  WHERE balance_id = $1 AND version = $12
 	`)).WithArgs(
 		destination,
 		big.NewInt(1000).String(),
@@ -184,7 +184,7 @@ func TestRecordTransactionWithRate(t *testing.T) {
 	mock.ExpectExec(regexp.QuoteMeta(`
 	  UPDATE blnk.balances
 	  SET balance = $2, credit_balance = $3, debit_balance = $4, inflight_balance = $5, inflight_credit_balance = $6, inflight_debit_balance = $7, currency = $8, currency_multiplier = $9, ledger_id = $10, created_at = $11, version = version + 1
-	  WHERE balance_id = $1 AND version = $13
+	  WHERE balance_id = $1 AND version = $12
 	`)).WithArgs(
 		source,
 		big.NewInt(-100000000).String(),
@@ -203,7 +203,7 @@ func TestRecordTransactionWithRate(t *testing.T) {
 	mock.ExpectExec(regexp.QuoteMeta(`
 	  UPDATE blnk.balances
 	  SET balance = $2, credit_balance = $3, debit_balance = $4, inflight_balance = $5, inflight_credit_balance = $6, inflight_debit_balance = $7, currency = $8, currency_multiplier = $9, ledger_id = $10, created_at = $11, version = version + 1
-	  WHERE balance_id = $1 AND version = $13
+	  WHERE balance_id = $1 AND version = $12
 	`)).WithArgs(
 		destination,
 		big.NewInt(130000000000).String(),


### PR DESCRIPTION
- Break down QueueTransaction into smaller, focused functions
- Add prepareTransactionForQueue for initial setup
- Add createQueueCopy for handling transaction copies
- Add updateSplitTransactions for managing split transactions
- Persist transactions before queueing for better traceability
- Improve reference linking between original and queued transactions

MAJOR CHANGE: QueueTransaction now persists before queueing and maintains parent-child relationships through references