### PR TITLE
add 'with_queued' parameter to GetBalanceByID for including queued am…

### DIFF
--- a/api/balance.go
+++ b/api/balance.go
@@ -71,16 +71,18 @@ func (a Api) CreateBalance(c *gin.Context) {
 // - 200 OK: If the balance is successfully retrieved.
 func (a Api) GetBalance(c *gin.Context) {
 	id, passed := c.Params.Get("id")
-
 	if !passed {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "id is required. pass id in the route /:id"})
 		return
 	}
 
-	// Extracting 'include' parameter from the query
+	// Extract 'include' parameter from the query
 	includes := c.QueryArray("include")
 
-	resp, err := a.blnk.GetBalanceByID(c.Request.Context(), id, includes)
+	// Extract 'with_queued' parameter from the query, default to false
+	withQueued := c.DefaultQuery("with_queued", "false") == "true"
+
+	resp, err := a.blnk.GetBalanceByID(c.Request.Context(), id, includes, withQueued)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return

--- a/api/balance_api_test.go
+++ b/api/balance_api_test.go
@@ -97,7 +97,7 @@ func TestCreateBalance(t *testing.T) {
 
 			if tt.expectedCode == http.StatusCreated {
 				// Verify that the balance is actually created in the database
-				balanceFromDB, err := b.GetBalanceByID(context.Background(), response.BalanceID, nil)
+				balanceFromDB, err := b.GetBalanceByID(context.Background(), response.BalanceID, nil, false)
 				if err != nil {
 					t.Errorf("Failed to retrieve balance by ID: %v", err)
 				} else {

--- a/balance.go
+++ b/balance.go
@@ -184,11 +184,11 @@ func (l *Blnk) CreateBalance(ctx context.Context, balance model.Balance) (model.
 // Returns:
 // - *model.Balance: A pointer to the Balance model if found.
 // - error: An error if the balance could not be retrieved.
-func (l *Blnk) GetBalanceByID(ctx context.Context, id string, include []string) (*model.Balance, error) {
+func (l *Blnk) GetBalanceByID(ctx context.Context, id string, include []string, withQueued bool) (*model.Balance, error) {
 	_, span := balanceTracer.Start(ctx, "GetBalanceByID")
 	defer span.End()
 
-	balance, err := l.datasource.GetBalanceByID(id, include)
+	balance, err := l.datasource.GetBalanceByID(id, include, withQueued)
 	if err != nil {
 		span.RecordError(err)
 		return nil, err

--- a/balance_test.go
+++ b/balance_test.go
@@ -206,7 +206,7 @@ func TestGetBalanceByID(t *testing.T) {
 
 	mock.ExpectCommit()
 
-	result, err := d.GetBalanceByID(context.Background(), balanceID, nil)
+	result, err := d.GetBalanceByID(context.Background(), balanceID, nil, false)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Equal(t, balanceID, result.BalanceID)

--- a/database/balance.go
+++ b/database/balance.go
@@ -280,12 +280,6 @@ func (d Datasource) GetBalanceByID(id string, include []string, withQueued bool)
 		}
 	}
 
-	// Commit the transaction
-	err = tx.Commit()
-	if err != nil {
-		return nil, apierror.NewAPIError(apierror.ErrInternalServer, "Failed to commit transaction", err)
-	}
-
 	// Get queued amounts only if requested
 	if withQueued {
 		queuedDebit, queuedCredit, err := d.GetQueuedAmounts(context.Background(), id)
@@ -294,6 +288,12 @@ func (d Datasource) GetBalanceByID(id string, include []string, withQueued bool)
 		}
 		balance.QueuedDebitBalance = queuedDebit
 		balance.QueuedCreditBalance = queuedCredit
+	}
+
+	// Commit the transaction
+	err = tx.Commit()
+	if err != nil {
+		return nil, apierror.NewAPIError(apierror.ErrInternalServer, "Failed to commit transaction", err)
 	}
 
 	return balance, nil

--- a/database/balance_test.go
+++ b/database/balance_test.go
@@ -142,7 +142,7 @@ func TestGetBalanceByID_Success(t *testing.T) {
 	// Mock the transaction commit call
 	mock.ExpectCommit()
 
-	retrievedBalance, err := ds.GetBalanceByID("bln1", []string{})
+	retrievedBalance, err := ds.GetBalanceByID("bln1", []string{}, false)
 	assert.NoError(t, err)
 	assert.Equal(t, balance.BalanceID, retrievedBalance.BalanceID)
 
@@ -164,7 +164,7 @@ func TestGetBalanceByID_NotFound(t *testing.T) {
 		WithArgs("bln1").
 		WillReturnError(sql.ErrNoRows)
 
-	_, err = ds.GetBalanceByID("bln1", []string{})
+	_, err = ds.GetBalanceByID("bln1", []string{}, false)
 	assert.Error(t, err)
 	apiErr, ok := err.(apierror.APIError)
 	assert.True(t, ok)

--- a/database/mocks/repo_mocks.go
+++ b/database/mocks/repo_mocks.go
@@ -134,8 +134,8 @@ func (m *MockDataSource) CreateBalance(balance model.Balance) (model.Balance, er
 	return args.Get(0).(model.Balance), args.Error(1)
 }
 
-func (m *MockDataSource) GetBalanceByID(id string, include []string) (*model.Balance, error) {
-	args := m.Called(id, include)
+func (m *MockDataSource) GetBalanceByID(id string, include []string, withQueued bool) (*model.Balance, error) {
+	args := m.Called(id, include, withQueued)
 	return args.Get(0).(*model.Balance), args.Error(1)
 }
 

--- a/database/repository.go
+++ b/database/repository.go
@@ -63,7 +63,7 @@ type ledger interface {
 // balance defines methods for handling balances.
 type balance interface {
 	CreateBalance(balance model.Balance) (model.Balance, error)                                 // Creates a new balance
-	GetBalanceByID(id string, include []string) (*model.Balance, error)                         // Retrieves a balance by ID with additional data
+	GetBalanceByID(id string, include []string, withQueued bool) (*model.Balance, error)        // Retrieves a balance by ID with additional data and queued status
 	GetBalanceByIDLite(id string) (*model.Balance, error)                                       // Retrieves a balance by ID with minimal data
 	GetAllBalances(limit, offset int) ([]model.Balance, error)                                  // Retrieves all balances
 	UpdateBalance(balance *model.Balance) error                                                 // Updates a balance

--- a/metadata.go
+++ b/metadata.go
@@ -67,7 +67,7 @@ func (l *Blnk) UpdateMetadata(ctx context.Context, entityID string, newMetadata 
 		currentMetadata = txn.MetaData
 
 	case "balances":
-		balance, err := l.GetBalanceByID(ctx, entityID, nil)
+		balance, err := l.GetBalanceByID(ctx, entityID, nil, false)
 		if err != nil {
 			return nil, errors.New("entity not found")
 		}

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -138,7 +138,7 @@ func TestUpdateMetadata(t *testing.T) {
 		existingMetadata := map[string]interface{}{"existing": "value"}
 		balance := &model.Balance{MetaData: existingMetadata}
 
-		mockDS.On("GetBalanceByID", "bln_123", mock.Anything).Return(balance, nil)
+		mockDS.On("GetBalanceByID", "bln_123", mock.Anything, false).Return(balance, nil)
 		mockDS.On("UpdateBalanceMetadata", mock.Anything, "bln_123", mock.Anything).Return(nil)
 
 		newMetadata := map[string]interface{}{"new": "value"}

--- a/model/balance.go
+++ b/model/balance.go
@@ -30,6 +30,8 @@ type Balance struct {
 	InflightCreditBalance *big.Int               `json:"inflight_credit_balance"`
 	DebitBalance          *big.Int               `json:"debit_balance"`
 	InflightDebitBalance  *big.Int               `json:"inflight_debit_balance"`
+	QueuedDebitBalance    *big.Int               `json:"queued_debit_balance,omitempty"`
+	QueuedCreditBalance   *big.Int               `json:"queued_credit_balance,omitempty"`
 	CurrencyMultiplier    float64                `json:"currency_multiplier"`
 	LedgerID              string                 `json:"ledger_id"`
 	IdentityID            string                 `json:"identity_id"`


### PR DESCRIPTION
This pull request introduces the capability to include queued amounts when retrieving balance information. The most important changes include modifications to the `GetBalanceByID` function across several files, updates to the corresponding tests, and the addition of a new method to retrieve queued amounts.

Enhancements to balance retrieval:

* [`api/balance.go`](diffhunk://#diff-69116c756d341d7298f3377a4b461a3b3c61654bf0711ee2428351f9284b3598L74-R85): Updated `GetBalanceByID` to accept a `withQueued` parameter, allowing the inclusion of queued amounts in the balance response.
* [`balance.go`](diffhunk://#diff-c62336e5da3f8c446d67f6d75b8ef6f35ad04ea3af43f0b3c36abdfa8b5ad6c3L187-R191): Modified `GetBalanceByID` to handle the new `withQueued` parameter and retrieve queued amounts if requested.
* [`database/balance.go`](diffhunk://#diff-54e85a7a07ed3069bea16ced98647430a61f9255205f913d6f91ebf5f06d945eR289-R298): Added logic to fetch queued debit and credit amounts when the `withQueued` parameter is true.
* [`model/balance.go`](diffhunk://#diff-f68355fb0b5065a42a1c206b45720602531298167b78c28b2eacc3d68e33d34cR33-R34): Introduced new fields `QueuedDebitBalance` and `QueuedCreditBalance` to the `Balance` struct to store queued amounts.

Updates to tests:

* [`api/balance_api_test.go`](diffhunk://#diff-a0be8b19146afb0d6aa781a9f21c700a9140eb1a6be178392254ebcfcf1ddcb7L100-R100): Adjusted tests to include the `withQueued` parameter in calls to `GetBalanceByID`.
* [`database/balance_test.go`](diffhunk://#diff-74837e8a2e42336c6166b63a42acbe58f173da28b6b64c2e713cb346fdeac068L145-R145): Updated tests to pass the `withQueued` parameter to `GetBalanceByID` and verify the correct handling of queued amounts. [[1]](diffhunk://#diff-74837e8a2e42336c6166b63a42acbe58f173da28b6b64c2e713cb346fdeac068L145-R145) [[2]](diffhunk://#diff-74837e8a2e42336c6166b63a42acbe58f173da28b6b64c2e713cb346fdeac068L167-R167)