### PR TITLE
Add balance snapshotting and historical retrieval functionality

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -51,7 +51,7 @@ func (a Api) Router() *gin.Engine {
 	router.POST("/balances", a.CreateBalance)
 	router.GET("/balances", a.GetBalances)
 	router.GET("/balances/:id", a.GetBalance)
-	router.GET("/balances/:id/at", a.GetBalanceAtTime) // Add this line
+	router.GET("/balances/:id/at", a.GetBalanceAtTime)
 	router.POST("/balances-snapshots", a.TakeBalanceSnapshots)
 
 	// Balance Monitor routes

--- a/api/api.go
+++ b/api/api.go
@@ -51,6 +51,8 @@ func (a Api) Router() *gin.Engine {
 	router.POST("/balances", a.CreateBalance)
 	router.GET("/balances", a.GetBalances)
 	router.GET("/balances/:id", a.GetBalance)
+	router.GET("/balances/:id/at", a.GetBalanceAtTime) // Add this line
+	router.POST("/balances-snapshots", a.TakeBalanceSnapshots)
 
 	// Balance Monitor routes
 	router.POST("/balance-monitors", a.CreateBalanceMonitor)

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -76,6 +76,7 @@ func migrateUpCommands() *cobra.Command {
 
 			// Apply the migrations.
 			n, err := migrate.Exec(db, "postgres", migrations, migrate.Up)
+			fmt.Println(n, err)
 			if err != nil {
 				log.Printf("Error migrating up: %v", err)
 			} else {

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -76,7 +76,6 @@ func migrateUpCommands() *cobra.Command {
 
 			// Apply the migrations.
 			n, err := migrate.Exec(db, "postgres", migrations, migrate.Up)
-			fmt.Println(n, err)
 			if err != nil {
 				log.Printf("Error migrating up: %v", err)
 			} else {

--- a/database/mocks/repo_mocks.go
+++ b/database/mocks/repo_mocks.go
@@ -17,6 +17,7 @@ package mocks
 
 import (
 	"context"
+	"time"
 
 	"github.com/jerry-enebeli/blnk/model"
 	"github.com/stretchr/testify/mock"
@@ -167,6 +168,11 @@ func (m *MockDataSource) UpdateBalances(ctx context.Context, sourceBalance, dest
 func (m *MockDataSource) GetSourceDestination(sourceId, destinationId string) ([]*model.Balance, error) {
 	args := m.Called(sourceId, destinationId)
 	return args.Get(0).([]*model.Balance), args.Error(1)
+}
+
+func (m *MockDataSource) GetBalanceAtTime(ctx context.Context, balanceID string, targetTime time.Time) (*model.Balance, error) {
+	args := m.Called(ctx, balanceID, targetTime)
+	return args.Get(0).(*model.Balance), args.Error(1)
 }
 
 // Account methods
@@ -350,4 +356,9 @@ func (m *MockDataSource) LoadReconciliationProgress(ctx context.Context, reconci
 func (m *MockDataSource) FetchAndGroupExternalTransactions(ctx context.Context, uploadID string, groupCriteria string, batchSize int, offset int64) (map[string][]*model.Transaction, error) {
 	args := m.Called(ctx, uploadID, groupCriteria, batchSize, offset)
 	return args.Get(0).(map[string][]*model.Transaction), args.Error(1)
+}
+
+func (m *MockDataSource) TakeBalanceSnapshots(ctx context.Context, batchSize int) (int, error) {
+	args := m.Called(ctx, batchSize)
+	return args.Get(0).(int), args.Error(1)
 }

--- a/database/repository.go
+++ b/database/repository.go
@@ -18,6 +18,7 @@ package database
 
 import (
 	"context"
+	"time"
 
 	"github.com/jerry-enebeli/blnk/model"
 )
@@ -70,6 +71,8 @@ type balance interface {
 	GetBalanceByIndicator(indicator, currency string) (*model.Balance, error)                   // Retrieves a balance by indicator and currency
 	UpdateBalances(ctx context.Context, sourceBalance, destinationBalance *model.Balance) error // Updates multiple balances
 	GetSourceDestination(sourceId, destinationId string) ([]*model.Balance, error)              // Retrieves balances between source and destination
+	TakeBalanceSnapshots(ctx context.Context, batchSize int) (int, error)                       // Takes balance snapshots
+	GetBalanceAtTime(ctx context.Context, balanceID string, targetTime time.Time) (*model.Balance, error)
 }
 
 // account defines methods for handling accounts.

--- a/sql/1740373196.sql
+++ b/sql/1740373196.sql
@@ -1,0 +1,43 @@
+-- Copyright 2024 Blnk Finance Authors.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- +migrate Up
+CREATE TABLE IF NOT EXISTS blnk.balance_snapshots
+(
+    id                      SERIAL PRIMARY KEY,
+    balance_id              TEXT      NOT NULL REFERENCES blnk.balances (balance_id),
+    ledger_id              TEXT      NOT NULL REFERENCES blnk.ledgers (ledger_id),
+    balance                 BIGINT    NOT NULL,
+    credit_balance         BIGINT    NOT NULL,
+    debit_balance          BIGINT    NOT NULL,
+    inflight_balance       BIGINT    NOT NULL,
+    inflight_credit_balance BIGINT    NOT NULL,
+    inflight_debit_balance  BIGINT    NOT NULL,
+    currency               TEXT      NOT NULL,
+    snapshot_time          TIMESTAMP WITH TIME ZONE NOT NULL,
+    created_at             TIMESTAMP NOT NULL,
+    last_tx_id             TEXT,
+    meta_data              JSONB
+);
+
+-- +migrate Up
+CREATE INDEX idx_balance_snapshots_balance_id ON blnk.balance_snapshots(balance_id);
+CREATE INDEX idx_balance_snapshots_snapshot_time ON blnk.balance_snapshots(snapshot_time);
+CREATE INDEX idx_balance_snapshots_ledger_time ON blnk.balance_snapshots(ledger_id, snapshot_time);
+
+-- +migrate Down
+DROP INDEX IF EXISTS blnk.idx_balance_snapshots_ledger_time;
+DROP INDEX IF EXISTS blnk.idx_balance_snapshots_snapshot_time;
+DROP INDEX IF EXISTS blnk.idx_balance_snapshots_balance_id;
+DROP TABLE IF EXISTS blnk.balance_snapshots;

--- a/sql/1740373636.sql
+++ b/sql/1740373636.sql
@@ -1,0 +1,104 @@
+-- +migrate Up
+
+-- +migrate StatementBegin
+CREATE OR REPLACE FUNCTION blnk.take_daily_balance_snapshots_batched(batch_size INTEGER DEFAULT 1000)
+    RETURNS INTEGER
+    LANGUAGE plpgsql
+    STRICT
+AS $$
+DECLARE
+    v_last_processed_id BIGINT := 0;
+    v_max_id BIGINT;
+    v_total_processed INTEGER := 0;
+    v_batch_count INTEGER;
+BEGIN
+    -- Get the maximum ID first to know when to stop
+    SELECT MAX(id) INTO v_max_id FROM blnk.balances;
+    
+    LOOP
+        WITH batch AS (
+            SELECT 
+                b.id,
+                b.balance_id,
+                b.ledger_id,
+                b.balance,
+                b.credit_balance,
+                b.debit_balance,
+                b.inflight_balance,
+                b.inflight_credit_balance,
+                b.inflight_debit_balance,
+                b.currency,
+                b.created_at,
+                b.meta_data
+            FROM blnk.balances b
+            WHERE b.id > v_last_processed_id
+            AND NOT EXISTS (
+                SELECT 1 
+                FROM blnk.balance_snapshots bs
+                WHERE bs.balance_id = b.balance_id
+                AND DATE_TRUNC('day', bs.snapshot_time) = DATE_TRUNC('day', NOW())
+            )
+            ORDER BY b.id
+            LIMIT batch_size
+        )
+        INSERT INTO blnk.balance_snapshots (
+            balance_id,
+            ledger_id,
+            balance,
+            credit_balance,
+            debit_balance,
+            inflight_balance,
+            inflight_credit_balance,
+            inflight_debit_balance,
+            currency,
+            snapshot_time,
+            created_at,
+            last_tx_id,
+            meta_data
+        )
+        SELECT 
+            b.balance_id,
+            b.ledger_id,
+            b.balance,
+            b.credit_balance,
+            b.debit_balance,
+            b.inflight_balance,
+            b.inflight_credit_balance,
+            b.inflight_debit_balance,
+            b.currency,
+            DATE_TRUNC('day', NOW()),
+            b.created_at,
+            COALESCE((
+                SELECT t.transaction_id 
+                FROM blnk.transactions t
+                WHERE t.source = b.balance_id OR t.destination = b.balance_id
+                ORDER BY t.created_at DESC 
+                LIMIT 1
+            ), NULL),
+            b.meta_data
+        FROM batch b;
+
+        GET DIAGNOSTICS v_batch_count = ROW_COUNT;
+        v_total_processed := v_total_processed + v_batch_count;
+        
+        -- Get the last ID processed in this batch
+        SELECT COALESCE(MAX(id), v_max_id) INTO v_last_processed_id
+        FROM blnk.balances
+        WHERE id > v_last_processed_id
+        ORDER BY id
+        LIMIT batch_size;
+
+        -- Exit if we've processed everything or no more records to process
+        EXIT WHEN v_batch_count = 0 OR v_last_processed_id >= v_max_id;
+    END LOOP;
+
+    RETURN v_total_processed;
+END;
+$$;
+-- +migrate StatementEnd
+
+-- +migrate Down
+
+-- +migrate StatementBegin
+DROP FUNCTION IF EXISTS blnk.take_daily_balance_snapshots_batched;
+-- +migrate StatementEnd


### PR DESCRIPTION
This pull request introduces new functionalities for handling balance snapshots and retrieving historical balance states at specific points in time. The changes span multiple files and include updates to the API, service layer, database interactions, and SQL migrations.

### API Enhancements:
* Added new endpoints `GET /balances/:id/at` and `POST /balances-snapshots` in `api/api.go` to retrieve balance at a specific time and create balance snapshots, respectively.
* Implemented `GetBalanceAtTime` and `TakeBalanceSnapshots` methods in `api/balance.go` to handle the new endpoints.

### Service Layer Updates:
* Added `TakeBalanceSnapshots` and `GetBalanceAtTime` methods in `balance.go` to process balance snapshots and retrieve historical balance states.

### Database Interactions:
* Implemented `TakeBalanceSnapshots` and `GetBalanceAtTime` methods in `database/balance.go` to interact with the database for the new functionalities.
* Updated `database/repository.go` to include the new methods in the balance interface.

### SQL Migrations:
* Created new SQL migration files to add `balance_snapshots` table and a function for taking daily balance snapshots in batches. [[1]](diffhunk://#diff-04d8ae731b6427f54b4c169063e2ffb85d93c8d35827aff4fea761d08068d038R1-R43) [[2]](diffhunk://#diff-b045785007cffb768fe11f6c21caacccd8dd48e38fe2d0f5362699e7ad346cb8R1-R104)

These changes collectively enhance the system's ability to manage and query historical balance data efficiently.