### PR TITLE
Add effective_date field to transactions and update related logic

### DIFF
--- a/api/model/model.go
+++ b/api/model/model.go
@@ -182,5 +182,5 @@ func (t *RecordTransaction) ToTransaction() *model.Transaction {
 
 	}
 
-	return &model.Transaction{Currency: t.Currency, Source: t.Source, Description: t.Description, Reference: t.Reference, ScheduledFor: scheduledFor, Destination: t.Destination, Amount: t.Amount, AllowOverdraft: t.AllowOverDraft, MetaData: t.MetaData, Sources: t.Sources, Destinations: t.Destinations, Inflight: t.Inflight, Precision: t.Precision, InflightExpiryDate: inflightExpiryDate, Rate: t.Rate, SkipQueue: t.SkipQueue}
+	return &model.Transaction{Currency: t.Currency, Source: t.Source, Description: t.Description, Reference: t.Reference, ScheduledFor: scheduledFor, Destination: t.Destination, Amount: t.Amount, AllowOverdraft: t.AllowOverDraft, MetaData: t.MetaData, Sources: t.Sources, Destinations: t.Destinations, Inflight: t.Inflight, Precision: t.Precision, InflightExpiryDate: inflightExpiryDate, Rate: t.Rate, SkipQueue: t.SkipQueue, EffectiveDate: t.EffectiveDate}
 }

--- a/api/model/transaction.go
+++ b/api/model/transaction.go
@@ -16,6 +16,8 @@ limitations under the License.
 package model
 
 import (
+	"time"
+
 	"github.com/jerry-enebeli/blnk/model"
 )
 
@@ -37,6 +39,7 @@ type RecordTransaction struct {
 	Sources            []model.Distribution   `json:"sources"`
 	Destinations       []model.Distribution   `json:"destinations"`
 	MetaData           map[string]interface{} `json:"meta_data"`
+	EffectiveDate      *time.Time             `json:"effective_date,omitempty"`
 }
 
 type InflightUpdate struct {

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -58,9 +58,9 @@ func (d Datasource) RecordTransaction(ctx context.Context, txn *model.Transactio
 
 	// Execute the SQL insert statement to record the transaction
 	_, err = d.Conn.ExecContext(ctx,
-		`INSERT INTO blnk.transactions(transaction_id, parent_transaction, source, reference, amount, precise_amount, precision, rate, currency, destination, description, status, created_at, meta_data, scheduled_for, hash) 
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)`,
-		txn.TransactionID, txn.ParentTransaction, txn.Source, txn.Reference, txn.Amount, txn.PreciseAmount, txn.Precision, txn.Rate, txn.Currency, txn.Destination, txn.Description, txn.Status, txn.CreatedAt, metaDataJSON, txn.ScheduledFor, txn.Hash,
+		`INSERT INTO blnk.transactions(transaction_id, parent_transaction, source, reference, amount, precise_amount, precision, rate, currency, destination, description, status, created_at, meta_data, scheduled_for, hash, effective_date) 
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)`,
+		txn.TransactionID, txn.ParentTransaction, txn.Source, txn.Reference, txn.Amount, txn.PreciseAmount, txn.Precision, txn.Rate, txn.Currency, txn.Destination, txn.Description, txn.Status, txn.CreatedAt, metaDataJSON, txn.ScheduledFor, txn.Hash, txn.EffectiveDate,
 	)
 
 	// Handle errors that may occur during the execution of the query

--- a/database/transactions_test.go
+++ b/database/transactions_test.go
@@ -59,13 +59,14 @@ func TestRecordTransaction_Success(t *testing.T) {
 		Precision:         2,
 		Rate:              1,
 		ParentTransaction: "parent123",
+		EffectiveDate:     nil,
 	}
 
 	metaDataJSON, err := json.Marshal(transaction.MetaData)
 	assert.NoError(t, err)
 
 	mock.ExpectExec("INSERT INTO blnk.transactions").
-		WithArgs(transaction.TransactionID, transaction.ParentTransaction, transaction.Source, transaction.Reference, transaction.Amount, transaction.PreciseAmount, transaction.Precision, transaction.Rate, transaction.Currency, transaction.Destination, transaction.Description, transaction.Status, transaction.CreatedAt, metaDataJSON, transaction.ScheduledFor, transaction.Hash).
+		WithArgs(transaction.TransactionID, transaction.ParentTransaction, transaction.Source, transaction.Reference, transaction.Amount, transaction.PreciseAmount, transaction.Precision, transaction.Rate, transaction.Currency, transaction.Destination, transaction.Description, transaction.Status, transaction.CreatedAt, metaDataJSON, transaction.ScheduledFor, transaction.Hash, transaction.EffectiveDate).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	result, err := ds.RecordTransaction(ctx, transaction)
@@ -101,13 +102,14 @@ func TestRecordTransaction_Failure(t *testing.T) {
 		Precision:         2,
 		Rate:              1,
 		ParentTransaction: "parent123",
+		EffectiveDate:     nil,
 	}
 
 	metaDataJSON, err := json.Marshal(transaction.MetaData)
 	assert.NoError(t, err)
 
 	mock.ExpectExec("INSERT INTO blnk.transactions").
-		WithArgs(transaction.TransactionID, transaction.ParentTransaction, transaction.Source, transaction.Reference, transaction.Amount, transaction.PreciseAmount, transaction.Precision, transaction.Rate, transaction.Currency, transaction.Destination, transaction.Description, transaction.Status, transaction.CreatedAt, metaDataJSON, transaction.ScheduledFor, transaction.Hash).
+		WithArgs(transaction.TransactionID, transaction.ParentTransaction, transaction.Source, transaction.Reference, transaction.Amount, transaction.PreciseAmount, transaction.Precision, transaction.Rate, transaction.Currency, transaction.Destination, transaction.Description, transaction.Status, transaction.CreatedAt, metaDataJSON, transaction.ScheduledFor, transaction.Hash, transaction.EffectiveDate).
 		WillReturnError(errors.New("db error"))
 
 	_, err = ds.RecordTransaction(ctx, transaction)

--- a/model/transaction.go
+++ b/model/transaction.go
@@ -60,6 +60,7 @@ type Transaction struct {
 	Sources            []Distribution         `json:"sources,omitempty"`
 	Destinations       []Distribution         `json:"destinations,omitempty"`
 	CreatedAt          time.Time              `json:"created_at"`
+	EffectiveDate      *time.Time             `json:"effective_date,omitempty"`
 	ScheduledFor       time.Time              `json:"scheduled_for,omitempty"`
 	InflightExpiryDate time.Time              `json:"inflight_expiry_date,omitempty"`
 	MetaData           map[string]interface{} `json:"meta_data,omitempty"`
@@ -346,4 +347,11 @@ func CalculateDistributions(ctx context.Context, totalAmount float64, distributi
 	))
 
 	return resultDistributions, nil
+}
+
+func (t *Transaction) GetEffectiveDate() time.Time {
+	if t.EffectiveDate != nil {
+		return *t.EffectiveDate
+	}
+	return t.CreatedAt // Fall back to CreatedAt for old records
 }

--- a/sql/1741007609.sql
+++ b/sql/1741007609.sql
@@ -1,0 +1,20 @@
+-- Copyright 2024 Blnk Finance Authors.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- +migrate Up
+ALTER TABLE blnk.transactions ADD COLUMN effective_date TIMESTAMP;
+
+
+-- +migrate Down
+ALTER TABLE blnk.transactions DROP COLUMN effective_date;

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -140,7 +140,7 @@ func TestRecordTransaction(t *testing.T) {
     FROM blnk.balance_monitors WHERE balance_id = $1
 `)).WithArgs(source).WillReturnRows(sqlmock.NewRows([]string{"monitor_id", "balance_id", "field", "operator", "value", "description", "call_back_url", "created_at", "precision", "precise_value"}))
 
-	expectedSQL := `INSERT INTO blnk.transactions(transaction_id, parent_transaction, source, reference, amount, precise_amount, precision, rate, currency, destination, description, status, created_at, meta_data, scheduled_for, hash) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)`
+	expectedSQL := `INSERT INTO blnk.transactions(transaction_id, parent_transaction, source, reference, amount, precise_amount, precision, rate, currency, destination, description, status, created_at, meta_data, scheduled_for, hash, effective_date) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)`
 	mock.ExpectExec(regexp.QuoteMeta(expectedSQL)).WithArgs(
 		sqlmock.AnyArg(),
 		sqlmock.AnyArg(),
@@ -152,6 +152,7 @@ func TestRecordTransaction(t *testing.T) {
 		float64(1),
 		txn.Currency,
 		txn.Destination,
+		sqlmock.AnyArg(),
 		sqlmock.AnyArg(),
 		sqlmock.AnyArg(),
 		sqlmock.AnyArg(),
@@ -268,7 +269,7 @@ func TestRecordTransactionWithRate(t *testing.T) {
     FROM blnk.balance_monitors WHERE balance_id = $1
 `)).WithArgs(source).WillReturnRows(sqlmock.NewRows([]string{"monitor_id", "balance_id", "field", "operator", "value", "description", "call_back_url", "created_at", "precision", "precise_value"}))
 
-	expectedSQL := `INSERT INTO blnk.transactions(transaction_id, parent_transaction, source, reference, amount, precise_amount, precision, rate, currency, destination, description, status, created_at, meta_data, scheduled_for, hash) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)`
+	expectedSQL := `INSERT INTO blnk.transactions(transaction_id, parent_transaction, source, reference, amount, precise_amount, precision, rate, currency, destination, description, status, created_at, meta_data, scheduled_for, hash, effective_date) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)`
 	mock.ExpectExec(regexp.QuoteMeta(expectedSQL)).WithArgs(
 		sqlmock.AnyArg(),
 		sqlmock.AnyArg(),
@@ -280,6 +281,7 @@ func TestRecordTransactionWithRate(t *testing.T) {
 		float64(1300),
 		txn.Currency,
 		txn.Destination,
+		sqlmock.AnyArg(),
 		sqlmock.AnyArg(),
 		sqlmock.AnyArg(),
 		sqlmock.AnyArg(),


### PR DESCRIPTION
This pull request introduces the concept of an "effective date" for transactions, which is used to determine the actual date a transaction should be considered effective, falling back to the creation date if not specified. This change impacts multiple files across the codebase, including models, database interactions, and tests.

Key changes include:

### Model Updates:
* Added `EffectiveDate` field to `RecordTransaction` and `Transaction` structs in `api/model/transaction.go` and `model/transaction.go` respectively. [[1]](diffhunk://#diff-3cf7c52fdf6171b8ceba8abd2093285697cd49f76d9e91b5220707263366e4e9R42) [[2]](diffhunk://#diff-914e012915e214a2f422191525f93acb9d57d11de49c84be358fdee79a34c879R63)
* Updated `ToTransaction` method in `api/model/model.go` to include the `EffectiveDate` field.
* Introduced `GetEffectiveDate` method in `model/transaction.go` to return the effective date or fall back to the creation date if not set.

### Database Changes:
* Modified SQL queries in `database/balance.go` to use `effective_date` if available, otherwise fall back to `created_at`. [[1]](diffhunk://#diff-54e85a7a07ed3069bea16ced98647430a61f9255205f913d6f91ebf5f06d945eR1097-R1108) [[2]](diffhunk://#diff-54e85a7a07ed3069bea16ced98647430a61f9255205f913d6f91ebf5f06d945eR1124-R1131) [[3]](diffhunk://#diff-54e85a7a07ed3069bea16ced98647430a61f9255205f913d6f91ebf5f06d945eR1164-R1167)
* Updated `RecordTransaction` method in `database/transaction.go` to include `effective_date` in the insert statement.

### Migration Script:
* Added a new migration script `sql/1741007609.sql` to add the `effective_date` column to the `transactions` table.

### Test Updates:
* Updated test cases in `database/transactions_test.go` and `transaction_test.go` to account for the new `effective_date` field. [[1]](diffhunk://#diff-a3f5485635ae51ed482a5303c0c72f5f6ad11638ea39f28c5da18039de7df9aaR62-R69) [[2]](diffhunk://#diff-a3f5485635ae51ed482a5303c0c72f5f6ad11638ea39f28c5da18039de7df9aaR105-R112) [[3]](diffhunk://#diff-fa3545436305a9d76b9af6bfe8d963d15c8f223bebfecf7a82f353eff5e792daL143-R143) [[4]](diffhunk://#diff-fa3545436305a9d76b9af6bfe8d963d15c8f223bebfecf7a82f353eff5e792daR161) [[5]](diffhunk://#diff-fa3545436305a9d76b9af6bfe8d963d15c8f223bebfecf7a82f353eff5e792daL271-R272) [[6]](diffhunk://#diff-fa3545436305a9d76b9af6bfe8d963d15c8f223bebfecf7a82f353eff5e792daR290)