### PR TITLE
Improve Redis URL parsing to handle username and password more effect…

### DIFF
--- a/internal/redis-db/redisdb.go
+++ b/internal/redis-db/redisdb.go
@@ -46,7 +46,14 @@ func ParseRedisURL(rawURL string) (*redis.Options, error) {
 	if strings.HasPrefix(rawURL, "redis://") && strings.Contains(rawURL, "@") {
 		parts := strings.Split(strings.TrimPrefix(rawURL, "redis://"), "@")
 		if len(parts) == 2 {
-			rawURL = fmt.Sprintf("redis://:%s@%s", parts[0], parts[1])
+			authParts := strings.Split(parts[0], ":")
+			if len(authParts) == 1 {
+				// No username, just password - keep original logic
+				rawURL = fmt.Sprintf("redis://:%s@%s", parts[0], parts[1])
+			} else if len(authParts) == 2 {
+				// Has username and password - pass through unchanged
+				// The format is already correct for redis.ParseURL
+			}
 		}
 	}
 


### PR DESCRIPTION
This pull request includes an enhancement to the `ParseRedisURL` function in the `internal/redis-db/redisdb.go` file to better handle Redis URLs with authentication information. The most important change is the addition of logic to correctly parse URLs with both username and password.

Enhancements to Redis URL parsing:

* [`internal/redis-db/redisdb.go`](diffhunk://#diff-7e4f923e9ead2a94839fbabdb626fc0b8c24de4617c3968206faa06f84a13cfbR49-R56): Added logic to handle Redis URLs that include both username and password, ensuring the format is correct for `redis.ParseURL`.