### PR TITLE
Add overdraft limit

### DIFF
--- a/api/model/model.go
+++ b/api/model/model.go
@@ -182,5 +182,5 @@ func (t *RecordTransaction) ToTransaction() *model.Transaction {
 
 	}
 
-	return &model.Transaction{Currency: t.Currency, Source: t.Source, Description: t.Description, Reference: t.Reference, ScheduledFor: scheduledFor, Destination: t.Destination, Amount: t.Amount, AllowOverdraft: t.AllowOverDraft, MetaData: t.MetaData, Sources: t.Sources, Destinations: t.Destinations, Inflight: t.Inflight, Precision: t.Precision, InflightExpiryDate: inflightExpiryDate, Rate: t.Rate, SkipQueue: t.SkipQueue, EffectiveDate: t.EffectiveDate}
+	return &model.Transaction{Currency: t.Currency, Source: t.Source, Description: t.Description, Reference: t.Reference, ScheduledFor: scheduledFor, Destination: t.Destination, Amount: t.Amount, AllowOverdraft: t.AllowOverDraft, MetaData: t.MetaData, Sources: t.Sources, Destinations: t.Destinations, Inflight: t.Inflight, Precision: t.Precision, InflightExpiryDate: inflightExpiryDate, Rate: t.Rate, SkipQueue: t.SkipQueue, EffectiveDate: t.EffectiveDate, OverdraftLimit: t.OverdraftLimit}
 }

--- a/api/model/transaction.go
+++ b/api/model/transaction.go
@@ -25,6 +25,7 @@ type RecordTransaction struct {
 	Amount             float64                `json:"amount"`
 	Rate               float64                `json:"rate"`
 	Precision          float64                `json:"precision"`
+	OverdraftLimit     float64                `json:"overdraft_limit"`
 	AllowOverDraft     bool                   `json:"allow_overdraft"`
 	Inflight           bool                   `json:"inflight"`
 	SkipQueue          bool                   `json:"skip_queue"`

--- a/cmd/workers.go
+++ b/cmd/workers.go
@@ -73,6 +73,10 @@ func (b *blnkInstance) processTransaction(ctx context.Context, t *asynq.Task) er
 			return err // This will trigger a retry
 		}
 
+		if strings.Contains(strings.ToLower(err.Error()), "transaction exceeds overdraft limit") {
+			return handleTransactionRejection(ctx, b, &txn, err)
+		}
+
 		logrus.Infof("Transaction %s pushed back for retry due to error: %v", txn.TransactionID, err)
 		return err
 	}

--- a/model/transaction.go
+++ b/model/transaction.go
@@ -43,6 +43,7 @@ type Transaction struct {
 	Amount             float64                `json:"amount"`
 	Rate               float64                `json:"rate"`
 	Precision          float64                `json:"precision"`
+	OverdraftLimit     float64                `json:"overdraft_limit"`
 	TransactionID      string                 `json:"transaction_id"`
 	ParentTransaction  string                 `json:"parent_transaction"`
 	Source             string                 `json:"source,omitempty"`


### PR DESCRIPTION
This pull request introduces the concept of an overdraft limit to transactions, allowing for more controlled overdraft scenarios. Key changes include updating the transaction model to include an overdraft limit, modifying the transaction processing logic to respect this limit, and adding relevant test cases.

**Model Updates:**

* Added `OverdraftLimit` field to the `RecordTransaction` and `Transaction` structs in `api/model/transaction.go` and `model/transaction.go` respectively. [[1]](diffhunk://#diff-3cf7c52fdf6171b8ceba8abd2093285697cd49f76d9e91b5220707263366e4e9R28) [[2]](diffhunk://#diff-914e012915e214a2f422191525f93acb9d57d11de49c84be358fdee79a34c879R46)

**Transaction Processing Logic:**

* Updated `ToTransaction` method in `api/model/model.go` to include `OverdraftLimit` when converting `RecordTransaction` to `Transaction`.
* Enhanced `canProcessTransaction` function in `model/model.go` to check if a transaction exceeds the overdraft limit and handle it accordingly.
* Added logic in `processTransaction` function in `cmd/workers.go` to handle transactions that exceed the overdraft limit by invoking `handleTransactionRejection`.

**Testing:**

* Added multiple test cases in `model/model_test.go` to cover scenarios such as sufficient funds, insufficient funds with no overdraft, unconditional overdraft, overdraft within limit, and overdraft exceeding limit. [[1]](diffhunk://#diff-261992f780b0563aea8800f78dd6d39466511838b2fda8becc9a0746efdd5d19R86) [[2]](diffhunk://#diff-261992f780b0563aea8800f78dd6d39466511838b2fda8becc9a0746efdd5d19R95-R147)