### PR TITLE
Enhance transaction metadata updates to merge with existing data and …

### DIFF
--- a/database/mocks/repo_mocks.go
+++ b/database/mocks/repo_mocks.go
@@ -387,3 +387,8 @@ func (m *MockDataSource) UpdateLastUsed(ctx context.Context, id string) error {
 	args := m.Called(ctx, id)
 	return args.Error(0)
 }
+
+func (m *MockDataSource) TransactionExistsByIDOrParentID(ctx context.Context, id string) (bool, error) {
+	args := m.Called(ctx, id)
+	return args.Bool(0), args.Error(1)
+}

--- a/database/repository.go
+++ b/database/repository.go
@@ -53,6 +53,7 @@ type transaction interface {
 	UpdateTransactionMetadata(ctx context.Context, id string, metadata map[string]interface{}) error
 	UpdateBalanceMetadata(ctx context.Context, id string, metadata map[string]interface{}) error
 	UpdateIdentityMetadata(id string, metadata map[string]interface{}) error
+	TransactionExistsByIDOrParentID(ctx context.Context, id string) (bool, error)
 }
 
 // ledger defines methods for handling ledgers.


### PR DESCRIPTION
This pull request includes several changes to improve metadata handling and transaction existence checks in the database. The most important changes include updating the metadata merge strategy, adding a method to check for transaction existence by ID or parent ID, and modifying tests to reflect these updates.

### Metadata Handling Improvements:
* [`database/metadata.go`](diffhunk://#diff-3a5aa92de14dbfa081def31232086d022d6db2fb5762a8e9e5094a586262a34dL32-R39): Updated `UpdateTransactionMetadata` to merge new metadata with existing metadata instead of replacing it. The update now applies to both the transaction with the provided ID and any transactions where this ID is set as the parent transaction. [[1]](diffhunk://#diff-3a5aa92de14dbfa081def31232086d022d6db2fb5762a8e9e5094a586262a34dL32-R39) [[2]](diffhunk://#diff-3a5aa92de14dbfa081def31232086d022d6db2fb5762a8e9e5094a586262a34dR49-R53)

### Transaction Existence Check:
* [`database/transaction.go`](diffhunk://#diff-0e49b99d82b3a2768be7749401b328b6056f269c92686fb082b206ab7291348bR856-R887): Added `TransactionExistsByIDOrParentID` method to check if a transaction exists either by its direct ID or as a parent transaction ID for other transactions.
* [`database/repository.go`](diffhunk://#diff-7259aefbd1f67d8e433914c3f387ff6f8617529b8c274d08f2809a2ab21bdae3R56): Updated the `transaction` interface to include the new `TransactionExistsByIDOrParentID` method.
* [`database/mocks/repo_mocks.go`](diffhunk://#diff-a816760aaf78035b1c6f55d2d6d0eddaea9f81131b2ed55ea63149192c8be337R390-R394): Added a mock implementation of the `TransactionExistsByIDOrParentID` method for testing purposes.

### Test Updates:
* [`database/metadata_test.go`](diffhunk://#diff-0c5c0877ad75a7b84f6cf19dffe5db80a3bb78b27f3c2b6103187551aef9876fL46-R50): Modified tests to verify the SQL uses the JSONB merge operator and updates both direct and parent matches. Updated tests to reflect the new metadata merge strategy and transaction existence checks. [[1]](diffhunk://#diff-0c5c0877ad75a7b84f6cf19dffe5db80a3bb78b27f3c2b6103187551aef9876fL46-R50) [[2]](diffhunk://#diff-2bc14e2bd9a6f810deee44c9d5d2d990b963deba3da58240629880cc6dbec3afL123-R73)