### PR TITLE
Add TLS configuration support for Redis client options

### DIFF
--- a/cmd/workers.go
+++ b/cmd/workers.go
@@ -179,9 +179,10 @@ func initializeWorkerServer(conf *config.Configuration, queues map[string]int) (
 
 	return asynq.NewServer(
 		asynq.RedisClientOpt{
-			Addr:     redisOption.Addr,
-			Password: redisOption.Password,
-			DB:       redisOption.DB,
+			Addr:      redisOption.Addr,
+			Password:  redisOption.Password,
+			DB:        redisOption.DB,
+			TLSConfig: redisOption.TLSConfig,
 		},
 		asynq.Config{
 			Concurrency: 1,

--- a/queue.go
+++ b/queue.go
@@ -54,7 +54,7 @@ func NewQueue(conf *config.Configuration) *Queue {
 	if err != nil {
 		log.Fatalf("Error parsing Redis URL: %v", err)
 	}
-	queueOptions := asynq.RedisClientOpt{Addr: redisOption.Addr, Password: redisOption.Password, DB: redisOption.DB}
+	queueOptions := asynq.RedisClientOpt{Addr: redisOption.Addr, Password: redisOption.Password, DB: redisOption.DB, TLSConfig: redisOption.TLSConfig}
 	client := asynq.NewClient(queueOptions)
 	inspector := asynq.NewInspector(queueOptions)
 	return &Queue{
@@ -125,7 +125,7 @@ func (q *Queue) queueIndexData(id string, collection string, data interface{}) e
 	task := asynq.NewTask(cfg.Queue.IndexQueue, IPayload, taskOptions...)
 	info, err := q.Client.Enqueue(task)
 	if err != nil {
-		log.Println(err, info)
+		log.Println("here", err, info)
 		return err
 	}
 	log.Printf(" [*] Successfully enqueued index data: %+v", id)

--- a/queue_test.go
+++ b/queue_test.go
@@ -44,7 +44,7 @@ func TestEnqueueImmediateTransactionSuccess(t *testing.T) {
 	if err != nil {
 		log.Fatalf("Error parsing Redis URL: %v", err)
 	}
-	queueOptions := asynq.RedisClientOpt{Addr: redisOption.Addr, Password: redisOption.Password, DB: redisOption.DB}
+	queueOptions := asynq.RedisClientOpt{Addr: redisOption.Addr, Password: redisOption.Password, DB: redisOption.DB, TLSConfig: redisOption.TLSConfig}
 	client := asynq.NewClient(queueOptions)
 	inspector := asynq.NewInspector(queueOptions)
 

--- a/webhooks.go
+++ b/webhooks.go
@@ -152,7 +152,7 @@ func SendWebhook(newWebhook NewWebhook) error {
 	if err != nil {
 		log.Fatalf("Error parsing Redis URL: %v", err)
 	}
-	queueOptions := asynq.RedisClientOpt{Addr: redisOption.Addr, Password: redisOption.Password, DB: redisOption.DB}
+	queueOptions := asynq.RedisClientOpt{Addr: redisOption.Addr, Password: redisOption.Password, DB: redisOption.DB, TLSConfig: redisOption.TLSConfig}
 	client := asynq.NewClient(queueOptions)
 
 	payload, err := json.Marshal(newWebhook)


### PR DESCRIPTION
This pull request includes several changes to enhance the security of Redis connections by adding TLS configuration support. Additionally, there is a minor logging change in the `queue.go` file.

Closes #109 

Enhancements to Redis connections:

* [`cmd/workers.go`](diffhunk://#diff-a0b4239ba8fac21aa578d6cce88a3a0b4a2f88d31731627167d5e537e8ec2af4R185): Added `TLSConfig` to the Redis client options in the `initializeWorkerServer` function.
* [`queue.go`](diffhunk://#diff-979cedf61ccaba8f637a393ae99a88eae86eeb9817cab20e334a25a825913695L57-R57): Added `TLSConfig` to the Redis client options in the `NewQueue` function.
* [`queue_test.go`](diffhunk://#diff-b73379c0f2e16cf60d20fbb7ff888018ae3f1db95126f6718b09274487cad2bbL47-R47): Added `TLSConfig` to the Redis client options in the `TestEnqueueImmediateTransactionSuccess` function.
* [`webhooks.go`](diffhunk://#diff-e85c105363b73024c790df70d8aacca74ab579760892e3f57a2a94187f483e34L155-R155): Added `TLSConfig` to the Redis client options in the `SendWebhook` function.

Logging improvement:

* [`queue.go`](diffhunk://#diff-979cedf61ccaba8f637a393ae99a88eae86eeb9817cab20e334a25a825913695L128-R128): Changed the log message in the `queueIndexData` function to include a static string "here" for better debugging.