### PR TITLE
Inject API key ID into metadata for POST requests

### DIFF
--- a/api/middleware/auth.go
+++ b/api/middleware/auth.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/jerry-enebeli/blnk"
 	"github.com/jerry-enebeli/blnk/config"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -237,8 +238,7 @@ func (m *AuthMiddleware) Authenticate() gin.HandlerFunc {
 		// For POST requests, inject the API key ID into the metadata
 		if c.Request.Method == "POST" {
 			if err := injectAPIKeyToMetadata(c, apiKey.APIKeyID); err != nil {
-				// Log the error but continue with the request
-				// You may want to add proper logging here
+				logrus.Error("Failed to inject API key ID into metadata:", err)
 			}
 		}
 

--- a/api/middleware/auth.go
+++ b/api/middleware/auth.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 Blnk Finance Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package middleware
 
 import (


### PR DESCRIPTION
This pull request includes several changes to the `api/middleware/auth.go` file, focusing on injecting the API key ID into the metadata of POST request bodies and improving the code documentation.

### Enhancements to API key handling:

* Added the `injectAPIKeyToMetadata` function to modify the request body by including the API key ID in the `meta_data` field for POST requests. This function reads, modifies, and sets the request body back to the request.
* Updated the `Authenticate` middleware function to call `injectAPIKeyToMetadata` for POST requests, ensuring the API key ID is injected into the metadata.

### Code documentation and cleanup:
* Enhanced the documentation for the `Authenticate` middleware function to include details about injecting the API key ID into the metadata for POST requests.