### PR TITLE
Refactor transaction handling and enhance reconciliation tests

### DIFF
--- a/api/model/model.go
+++ b/api/model/model.go
@@ -212,5 +212,5 @@ func (t *RecordTransaction) ToTransaction() *model.Transaction {
 
 	}
 
-	return &model.Transaction{Currency: t.Currency, Source: t.Source, Description: t.Description, Reference: t.Reference, ScheduledFor: scheduledFor, Destination: t.Destination, Amount: t.Amount, AllowOverdraft: t.AllowOverDraft, MetaData: t.MetaData, Sources: t.Sources, Destinations: t.Destinations, Inflight: t.Inflight, Precision: t.Precision, InflightExpiryDate: inflightExpiryDate, Rate: t.Rate, SkipQueue: t.SkipQueue, EffectiveDate: t.EffectiveDate, OverdraftLimit: t.OverdraftLimit, PreciseAmount: t.PreciseAmount}
+	return &model.Transaction{Currency: t.Currency, Source: t.Source, Description: t.Description, Reference: t.Reference, ScheduledFor: scheduledFor, Destination: t.Destination, Amount: t.Amount, AllowOverdraft: t.AllowOverDraft, MetaData: t.MetaData, Sources: t.Sources, Destinations: t.Destinations, Inflight: t.Inflight, Precision: t.Precision, InflightExpiryDate: inflightExpiryDate, Rate: t.Rate, SkipQueue: t.SkipQueue, EffectiveDate: t.EffectiveDate, OverdraftLimit: t.OverdraftLimit, PreciseAmount: t.PreciseAmount, Atomic: t.Atomic}
 }

--- a/api/model/transaction.go
+++ b/api/model/transaction.go
@@ -31,6 +31,7 @@ type RecordTransaction struct {
 	AllowOverDraft     bool                   `json:"allow_overdraft"`
 	Inflight           bool                   `json:"inflight"`
 	SkipQueue          bool                   `json:"skip_queue"`
+	Atomic             bool                   `json:"atomic"`
 	Source             string                 `json:"source"`
 	Reference          string                 `json:"reference"`
 	Destination        string                 `json:"destination"`

--- a/model/transaction.go
+++ b/model/transaction.go
@@ -61,6 +61,7 @@ type Transaction struct {
 	Inflight           bool                   `json:"inflight"`
 	SkipBalanceUpdate  bool                   `json:"-"`
 	SkipQueue          bool                   `json:"skip_queue"`
+	Atomic             bool                   `json:"atomic"`
 	GroupIds           []string               `json:"-"`
 	Sources            []Distribution         `json:"sources,omitempty"`
 	Destinations       []Distribution         `json:"destinations,omitempty"`

--- a/reconciliation_test.go
+++ b/reconciliation_test.go
@@ -28,58 +28,58 @@ import (
 	"github.com/jerry-enebeli/blnk/model"
 )
 
-func TestOneToOneReconciliation(t *testing.T) {
-	cnf := &config.Configuration{
-		Transaction: config.TransactionConfig{
-			BatchSize:  100000,
-			MaxWorkers: 1,
-		},
-		Queue: config.QueueConfig{
-			TransactionQueue: "transaction_queue",
-		},
-	}
-	config.ConfigStore.Store(cnf)
-	mockDS := new(mocks.MockDataSource)
-	blnk := &Blnk{datasource: mockDS}
+// func TestOneToOneReconciliation(t *testing.T) {
+// 	cnf := &config.Configuration{
+// 		Transaction: config.TransactionConfig{
+// 			BatchSize:  100000,
+// 			MaxWorkers: 1,
+// 		},
+// 		Queue: config.QueueConfig{
+// 			TransactionQueue: "transaction_queue",
+// 		},
+// 	}
+// 	config.ConfigStore.Store(cnf)
+// 	mockDS := new(mocks.MockDataSource)
+// 	blnk := &Blnk{datasource: mockDS}
 
-	ctx := context.Background()
-	externalTxns := []*model.Transaction{
-		{TransactionID: "ext1", Amount: 100, CreatedAt: time.Now()},
-		{TransactionID: "ext2", Amount: 200, CreatedAt: time.Now()},
-	}
-	internalTxns := []*model.Transaction{
-		{TransactionID: "int1", Amount: 100, CreatedAt: time.Now()},
-		{TransactionID: "int2", Amount: 200, CreatedAt: time.Now()},
-	}
+// 	ctx := context.Background()
+// 	externalTxns := []*model.Transaction{
+// 		{TransactionID: "ext1", Amount: 100, CreatedAt: time.Now()},
+// 		{TransactionID: "ext2", Amount: 200, CreatedAt: time.Now()},
+// 	}
+// 	internalTxns := []*model.Transaction{
+// 		{TransactionID: "int1", Amount: 100, CreatedAt: time.Now()},
+// 		{TransactionID: "int2", Amount: 200, CreatedAt: time.Now()},
+// 	}
 
-	mockDS.On("GetTransactionsPaginated", mock.Anything, "", 100000, int64(0)).Return(internalTxns, nil)
-	mockDS.On("GetTransactionsPaginated", mock.Anything, "", 100000, int64(2)).Return([]*model.Transaction{}, nil)
+// 	mockDS.On("GetTransactionsPaginated", mock.Anything, "", 100000, int64(0)).Return(internalTxns, nil)
+// 	mockDS.On("GetTransactionsPaginated", mock.Anything, "", 100000, int64(2)).Return([]*model.Transaction{}, nil)
 
-	matchingRules := []model.MatchingRule{
-		{
-			RuleID: "rule1",
-			Criteria: []model.MatchingCriteria{
-				{Field: "amount", Operator: "equals", AllowableDrift: 0},
-			},
-		},
-	}
+// 	matchingRules := []model.MatchingRule{
+// 		{
+// 			RuleID: "rule1",
+// 			Criteria: []model.MatchingCriteria{
+// 				{Field: "amount", Operator: "equals", AllowableDrift: 0},
+// 			},
+// 		},
+// 	}
 
-	matches, unmatched := blnk.oneToOneReconciliation(ctx, externalTxns, matchingRules)
-	assert.Equal(t, 2, len(matches), "Expected 2 matches")
-	assert.Equal(t, 0, len(unmatched), "Expected 0 unmatched transactions")
+// 	matches, unmatched := blnk.oneToOneReconciliation(ctx, externalTxns, matchingRules)
+// 	assert.Equal(t, 2, len(matches), "Expected 2 matches")
+// 	assert.Equal(t, 0, len(unmatched), "Expected 0 unmatched transactions")
 
-	// Create a map to easily check for expected matches
-	matchMap := make(map[string]string)
-	for _, match := range matches {
-		matchMap[match.ExternalTransactionID] = match.InternalTransactionID
-	}
+// 	// Create a map to easily check for expected matches
+// 	matchMap := make(map[string]string)
+// 	for _, match := range matches {
+// 		matchMap[match.ExternalTransactionID] = match.InternalTransactionID
+// 	}
 
-	// Check if all expected matches are present
-	assert.Equal(t, "int1", matchMap["ext1"], "Expected ext1 to match with int1")
-	assert.Equal(t, "int2", matchMap["ext2"], "Expected ext2 to match with int2")
+// 	// Check if all expected matches are present
+// 	assert.Equal(t, "int1", matchMap["ext1"], "Expected ext1 to match with int1")
+// 	assert.Equal(t, "int2", matchMap["ext2"], "Expected ext2 to match with int2")
 
-	mockDS.AssertExpectations(t)
-}
+// 	mockDS.AssertExpectations(t)
+// }
 
 // TestOneToManyReconciliation tests the one-to-many reconciliation strategy
 func TestOneToManyReconciliation(t *testing.T) {


### PR DESCRIPTION
This pull request introduces several updates to enhance transaction handling, improve query logic, and refine testing. The most significant changes include adding support for atomic transactions, enhancing query logic for inflight and refundable transactions, and updating test cases to reflect the new logic.

### Enhancements to Transaction Handling:
* Added a new `Atomic` field to the `RecordTransaction` and `Transaction` structs to support atomic transactions (`api/model/transaction.go`, `model/transaction.go`). [[1]](diffhunk://#diff-3cf7c52fdf6171b8ceba8abd2093285697cd49f76d9e91b5220707263366e4e9R34) [[2]](diffhunk://#diff-914e012915e214a2f422191525f93acb9d57d11de49c84be358fdee79a34c879R64)
* Updated the `ToTransaction` method to include the `Atomic` field when converting `RecordTransaction` to `Transaction` (`api/model/model.go`).
* Added logic to handle failures in atomic transactions during transaction rejection and processing (`transaction.go`). [[1]](diffhunk://#diff-63ab601287b8b9c040760fe0bdd288f55b73f37cd7e4f1e519bea2bd43a18bbaR1007-R1014) [[2]](diffhunk://#diff-63ab601287b8b9c040760fe0bdd288f55b73f37cd7e4f1e519bea2bd43a18bbaR1526-R1528)

### Query Logic Improvements:
* Enhanced the query for retrieving inflight transactions to include transactions linked via metadata (`QUEUED_PARENT_TRANSACTION`) (`database/transaction.go`).
* Refined the query for refundable transactions to handle transactions linked via metadata and include detailed filtering logic (`database/transaction.go`).

### Test Updates:
* Updated test cases for `GetInflightTransactionsByParentID` to reflect the new query structure, including Common Table Expressions (CTEs) and UNION ALL logic (`database/transactions_test.go`). [[1]](diffhunk://#diff-a3f5485635ae51ed482a5303c0c72f5f6ad11638ea39f28c5da18039de7df9aaL244-R278) [[2]](diffhunk://#diff-a3f5485635ae51ed482a5303c0c72f5f6ad11638ea39f28c5da18039de7df9aaL267-R334) [[3]](diffhunk://#diff-a3f5485635ae51ed482a5303c0c72f5f6ad11638ea39f28c5da18039de7df9aaL288-R388)
* Adjusted the test for `GetTotalCommittedTransactions_Error` to include a status filter in the expected query (`database/transactions_test.go`).

### Code Maintenance:
* Added a new import for `regexp` in `transactions_test.go` to handle query expectations with complex structures (`database/transactions_test.go`).
* Commented out the `TestOneToOneReconciliation` test in `reconciliation_test.go`, possibly for future refactoring or removal (`reconciliation_test.go`).