### PR TITLE
feat: Add Kubernetes manifests for deployment and management

### DIFF
--- a/infrastructure/k8s-manifests/blnk-config.yaml
+++ b/infrastructure/k8s-manifests/blnk-config.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: blnk-config
+  namespace: blnk
+data:
+  blnk.json: |
+    {
+      "project_name": "Blnk",
+      "data_source": {
+        "dns": "postgres://postgres:password@postgres:5432/blnk?sslmode=disable"
+      },
+      "redis": {
+        "dns": "redis:6379"
+      },
+      "server": {
+        "port": "5001"
+      }
+    } 

--- a/infrastructure/k8s-manifests/jaeger-deployment.yaml
+++ b/infrastructure/k8s-manifests/jaeger-deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f docker-compose.yaml -o k8s-manifests/
+    kompose.version: 1.26.1 (a9d05d509)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: jaeger
+  name: jaeger
+  namespace: blnk
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: jaeger
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert -f docker-compose.yaml -o k8s-manifests/
+        kompose.version: 1.26.1 (a9d05d509)
+      creationTimestamp: null
+      labels:
+        io.kompose.service: jaeger
+    spec:
+      containers:
+        - env:
+            - name: COLLECTOR_OTLP_ENABLED
+              value: "true"
+          image: jaegertracing/all-in-one:latest
+          livenessProbe:
+            exec:
+              command:
+                - wget
+                - --spider
+                - http://localhost:16686
+            failureThreshold: 3
+            periodSeconds: 10
+            timeoutSeconds: 5
+          name: jaeger
+          ports:
+            - containerPort: 16686
+            - containerPort: 4317
+            - containerPort: 4318
+          resources: {}
+      restartPolicy: Always
+status: {}

--- a/infrastructure/k8s-manifests/jaeger-hpa.yaml
+++ b/infrastructure/k8s-manifests/jaeger-hpa.yaml
@@ -1,0 +1,42 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: jaeger-hpa
+  namespace: blnk
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: jaeger
+  minReplicas: 1
+  maxReplicas: 3
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 70
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: 80
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+      - type: Percent
+        value: 10
+        periodSeconds: 60
+    scaleUp:
+      stabilizationWindowSeconds: 0
+      policies:
+      - type: Percent
+        value: 100
+        periodSeconds: 60
+      - type: Pods
+        value: 2
+        periodSeconds: 60
+      selectPolicy: Max 

--- a/infrastructure/k8s-manifests/jaeger-service.yaml
+++ b/infrastructure/k8s-manifests/jaeger-service.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f docker-compose.yaml -o k8s-manifests/
+    kompose.version: 1.26.1 (a9d05d509)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: jaeger
+  name: jaeger
+  namespace: blnk
+spec:
+  ports:
+    - name: "16686"
+      port: 16686
+      targetPort: 16686
+    - name: "4317"
+      port: 4317
+      targetPort: 4317
+    - name: "4318"
+      port: 4318
+      targetPort: 4318
+  selector:
+    io.kompose.service: jaeger
+status:
+  loadBalancer: {}

--- a/infrastructure/k8s-manifests/namespace.yaml
+++ b/infrastructure/k8s-manifests/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: blnk 

--- a/infrastructure/k8s-manifests/pg-data-persistentvolumeclaim.yaml
+++ b/infrastructure/k8s-manifests/pg-data-persistentvolumeclaim.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: pg-data
+  name: pg-data
+  namespace: blnk
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+status: {}

--- a/infrastructure/k8s-manifests/postgres-service.yaml
+++ b/infrastructure/k8s-manifests/postgres-service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f docker-compose.yaml -o k8s-manifests/
+    kompose.version: 1.26.1 (a9d05d509)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: postgres
+  name: postgres
+  namespace: blnk
+spec:
+  ports:
+    - name: "5432"
+      port: 5432
+      targetPort: 5432
+  selector:
+    io.kompose.service: postgres
+status:
+  loadBalancer: {} 

--- a/infrastructure/k8s-manifests/postgres-statefulset.yaml
+++ b/infrastructure/k8s-manifests/postgres-statefulset.yaml
@@ -53,8 +53,12 @@ spec:
               name: pg-data
               subPath: pgdata
       restartPolicy: Always
-      volumes:
-        - name: pg-data
-          persistentVolumeClaim:
-            claimName: pg-data
+  volumeClaimTemplates:
+    - metadata:
+        name: pg-data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 10Gi
 status: {} 

--- a/infrastructure/k8s-manifests/postgres-statefulset.yaml
+++ b/infrastructure/k8s-manifests/postgres-statefulset.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f docker-compose.yaml -o k8s-manifests/
+    kompose.version: 1.26.1 (a9d05d509)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: postgres
+  name: postgres
+  namespace: blnk
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: postgres
+  serviceName: postgres
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert -f docker-compose.yaml -o k8s-manifests/
+        kompose.version: 1.26.1 (a9d05d509)
+      creationTimestamp: null
+      labels:
+        io.kompose.service: postgres
+    spec:
+      containers:
+        - env:
+            - name: POSTGRES_USER
+              value: postgres
+            - name: POSTGRES_PASSWORD
+              value: password
+            - name: POSTGRES_DB
+              value: blnk
+            - name: TZ
+              value: Etc/UTC
+          image: postgres:16
+          livenessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - postgres
+            failureThreshold: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+          name: postgres
+          ports:
+            - containerPort: 5432
+          resources: {}
+          volumeMounts:
+            - mountPath: /var/lib/postgresql/data
+              name: pg-data
+              subPath: pgdata
+      restartPolicy: Always
+      volumes:
+        - name: pg-data
+          persistentVolumeClaim:
+            claimName: pg-data
+status: {} 

--- a/infrastructure/k8s-manifests/redis-deployment.yaml
+++ b/infrastructure/k8s-manifests/redis-deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f docker-compose.yaml -o k8s-manifests/
+    kompose.version: 1.26.1 (a9d05d509)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: redis
+  name: redis
+  namespace: blnk
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: redis
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert -f docker-compose.yaml -o k8s-manifests/
+        kompose.version: 1.26.1 (a9d05d509)
+      creationTimestamp: null
+      labels:
+        io.kompose.service: redis
+    spec:
+      containers:
+        - image: redis:7.2.4
+          name: redis
+          resources: {}
+      restartPolicy: Always
+status: {}

--- a/infrastructure/k8s-manifests/redis-service.yaml
+++ b/infrastructure/k8s-manifests/redis-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f docker-compose.yaml -o k8s-manifests/
+    kompose.version: 1.26.1 (a9d05d509)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: redis
+  name: redis
+  namespace: blnk
+spec:
+  ports:
+    - name: "6379"
+      port: 6379
+      targetPort: 6379
+  selector:
+    io.kompose.service: redis
+status: {} 

--- a/infrastructure/k8s-manifests/server-claim0-persistentvolumeclaim.yaml
+++ b/infrastructure/k8s-manifests/server-claim0-persistentvolumeclaim.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: server-claim0
+  name: server-claim0
+  namespace: blnk
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+status: {}

--- a/infrastructure/k8s-manifests/server-deployment.yaml
+++ b/infrastructure/k8s-manifests/server-deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f docker-compose.yaml -o k8s-manifests/
+    kompose.version: 1.26.1 (a9d05d509)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: server
+  name: server
+  namespace: blnk
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: server
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert -f docker-compose.yaml -o k8s-manifests/
+        kompose.version: 1.26.1 (a9d05d509)
+      creationTimestamp: null
+      labels:
+        io.kompose.service: server
+    spec:
+      containers:
+        - args:
+            - blnk migrate up && blnk start
+          command:
+            - /bin/sh
+            - -c
+          env:
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://jaeger:4318
+            - name: TZ
+              value: Etc/UTC
+          image: jerryenebeli/blnk:0.10.1
+          name: server
+          ports:
+            - containerPort: 5001
+            - containerPort: 80
+            - containerPort: 443
+          resources: {}
+          volumeMounts:
+            - name: blnk-config
+              mountPath: /blnk.json
+              subPath: blnk.json
+      restartPolicy: Always
+      volumes:
+        - name: blnk-config
+          configMap:
+            name: blnk-config
+status: {} 

--- a/infrastructure/k8s-manifests/server-hpa.yaml
+++ b/infrastructure/k8s-manifests/server-hpa.yaml
@@ -1,0 +1,42 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: server-hpa
+  namespace: blnk
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: server
+  minReplicas: 2
+  maxReplicas: 10
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 70
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: 80
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+      - type: Percent
+        value: 10
+        periodSeconds: 60
+    scaleUp:
+      stabilizationWindowSeconds: 0
+      policies:
+      - type: Percent
+        value: 100
+        periodSeconds: 60
+      - type: Pods
+        value: 4
+        periodSeconds: 60
+      selectPolicy: Max 

--- a/infrastructure/k8s-manifests/server-service.yaml
+++ b/infrastructure/k8s-manifests/server-service.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f docker-compose.yaml -o k8s-manifests/
+    kompose.version: 1.26.1 (a9d05d509)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: server
+  name: server
+  namespace: blnk
+spec:
+  type: LoadBalancer                # ← expose externally via a GCP LB
+  ports:
+    - name: "5001"
+      port: 5001
+      targetPort: 5001
+    - name: "80"
+      port: 80
+      targetPort: 80
+    - name: "443"
+      port: 443
+      targetPort: 443
+  selector:
+    io.kompose.service: server
+status:
+  loadBalancer: {}

--- a/infrastructure/k8s-manifests/typesense-data-persistentvolumeclaim.yaml
+++ b/infrastructure/k8s-manifests/typesense-data-persistentvolumeclaim.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: typesense-data
+  name: typesense-data
+  namespace: blnk
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+status: {}

--- a/infrastructure/k8s-manifests/typesense-deployment.yaml
+++ b/infrastructure/k8s-manifests/typesense-deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f docker-compose.yaml -o k8s-manifests/
+    kompose.version: 1.26.1 (a9d05d509)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: typesense
+  name: typesense
+  namespace: blnk
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: typesense
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert -f docker-compose.yaml -o k8s-manifests/
+        kompose.version: 1.26.1 (a9d05d509)
+      creationTimestamp: null
+      labels:
+        io.kompose.service: typesense
+    spec:
+      containers:
+        - args:
+            - --data-dir
+            - /data
+            - --api-key=blnk-api-key
+            - --listen-port
+            - "8108"
+          image: typesense/typesense:0.23.1
+          livenessProbe:
+            exec:
+              command:
+                - curl
+                - -f
+                - http://localhost:8108/health
+            failureThreshold: 5
+            periodSeconds: 30
+            timeoutSeconds: 10
+          name: typesense
+          resources: {}
+          volumeMounts:
+            - mountPath: /data
+              name: typesense-data
+      restartPolicy: Always
+      volumes:
+        - name: typesense-data
+          persistentVolumeClaim:
+            claimName: typesense-data
+status: {}

--- a/infrastructure/k8s-manifests/typesense-hpa.yaml
+++ b/infrastructure/k8s-manifests/typesense-hpa.yaml
@@ -1,0 +1,42 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: typesense-hpa
+  namespace: blnk
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: typesense
+  minReplicas: 2
+  maxReplicas: 5
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 70
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: 80
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+      - type: Percent
+        value: 10
+        periodSeconds: 60
+    scaleUp:
+      stabilizationWindowSeconds: 0
+      policies:
+      - type: Percent
+        value: 100
+        periodSeconds: 60
+      - type: Pods
+        value: 2
+        periodSeconds: 60
+      selectPolicy: Max 

--- a/infrastructure/k8s-manifests/typesense-service.yaml
+++ b/infrastructure/k8s-manifests/typesense-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f docker-compose.yaml -o k8s-manifests/
+    kompose.version: 1.26.1 (a9d05d509)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: typesense
+  name: typesense
+  namespace: blnk
+spec:
+  ports:
+    - name: "8108"
+      port: 8108
+      targetPort: 8108
+  selector:
+    io.kompose.service: typesense
+status: {} 

--- a/infrastructure/k8s-manifests/worker-claim0-persistentvolumeclaim.yaml
+++ b/infrastructure/k8s-manifests/worker-claim0-persistentvolumeclaim.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: worker-claim0
+  name: worker-claim0
+  namespace: blnk
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+status: {}

--- a/infrastructure/k8s-manifests/worker-deployment.yaml
+++ b/infrastructure/k8s-manifests/worker-deployment.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f docker-compose.yaml -o k8s-manifests/
+    kompose.version: 1.26.1 (a9d05d509)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: worker
+  name: worker
+  namespace: blnk
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: worker
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert -f docker-compose.yaml -o k8s-manifests/
+        kompose.version: 1.26.1 (a9d05d509)
+      creationTimestamp: null
+      labels:
+        io.kompose.service: worker
+    spec:
+      containers:
+        - command:
+            - blnk
+            - workers
+          env:
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://jaeger:4318
+          image: jerryenebeli/blnk:0.10.1
+          name: worker
+          resources: {}
+          volumeMounts:
+            - name: blnk-config
+              mountPath: /blnk.json
+              subPath: blnk.json
+      restartPolicy: Always
+      volumes:
+        - name: blnk-config
+          configMap:
+            name: blnk-config
+status: {}

--- a/infrastructure/k8s-manifests/worker-hpa.yaml
+++ b/infrastructure/k8s-manifests/worker-hpa.yaml
@@ -1,0 +1,42 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: worker-hpa
+  namespace: blnk
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: worker
+  minReplicas: 2
+  maxReplicas: 10
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 70
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: 80
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+      - type: Percent
+        value: 10
+        periodSeconds: 60
+    scaleUp:
+      stabilizationWindowSeconds: 0
+      policies:
+      - type: Percent
+        value: 100
+        periodSeconds: 60
+      - type: Pods
+        value: 4
+        periodSeconds: 60
+      selectPolicy: Max 


### PR DESCRIPTION
This commit introduces Kubernetes (k8s) manifests to support the deployment, scaling, and management of the Blnk core. 
