### PR TITLE
Implement GetBalanceByIndicator functionality

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -55,6 +55,7 @@ func (a Api) Router() *gin.Engine {
 	router.POST("/balances", a.CreateBalance)
 	router.GET("/balances", a.GetBalances)
 	router.GET("/balances/:id", a.GetBalance)
+	router.GET("/balances/indicator/:indicator/currency/:currency", a.GetBalanceByIndicator)
 	router.GET("/balances/:id/at", a.GetBalanceAtTime)
 	router.POST("/balances-snapshots", a.TakeBalanceSnapshots)
 

--- a/api/balance.go
+++ b/api/balance.go
@@ -374,3 +374,36 @@ func (a Api) GetBalanceAtTime(c *gin.Context) {
 		"from_source": fromSource,
 	})
 }
+
+// GetBalanceByIndicator retrieves a balance by its indicator and currency.
+// It extracts the indicator and currency from the route parameters.
+// If either parameter is missing or there's an error retrieving the balance,
+// it responds with an appropriate error message.
+//
+// Parameters:
+// - c: The Gin context containing the request and response.
+//
+// Responses:
+// - 400 Bad Request: If indicator or currency is missing or there's an error retrieving the balance.
+// - 200 OK: If the balance is successfully retrieved.
+func (a Api) GetBalanceByIndicator(c *gin.Context) {
+	indicator, indicatorPassed := c.Params.Get("indicator")
+	if !indicatorPassed {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "indicator is required. pass indicator in the route /indicator/:indicator"})
+		return
+	}
+
+	currency, currencyPassed := c.Params.Get("currency")
+	if !currencyPassed {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "currency is required. pass currency in the route /currency/:currency"})
+		return
+	}
+
+	resp, err := a.blnk.GetBalanceByIndicator(c.Request.Context(), indicator, currency)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, resp)
+}


### PR DESCRIPTION
- Added the GetBalanceByIndicator method in the Blnk service to retrieve balances based on indicator and currency.
- Updated the API to include a new endpoint for fetching balances by indicator and currency.
- Introduced a corresponding test case in balance_test.go to validate the new functionality, ensuring proper creation and retrieval of balances.
- Enhanced error handling in the API to return appropriate responses for missing parameters and retrieval errors.