### PR TITLE
webhook client fix

### DIFF
--- a/balance.go
+++ b/balance.go
@@ -71,7 +71,7 @@ func (l *Blnk) checkBalanceMonitors(ctx context.Context, updatedBalance *model.B
 		if monitor.CheckCondition(updatedBalance) {
 			span.AddEvent(fmt.Sprintf("Condition met for balance: %s", monitor.MonitorID))
 			go func(monitor model.BalanceMonitor) {
-				err := SendWebhook(NewWebhook{
+				err := l.SendWebhook(NewWebhook{
 					Event:   "balance.monitor",
 					Payload: monitor,
 				})
@@ -141,7 +141,7 @@ func (l *Blnk) postBalanceActions(ctx context.Context, balance *model.Balance) {
 			span.RecordError(err)
 			notification.NotifyError(err)
 		}
-		err = SendWebhook(NewWebhook{
+		err = l.SendWebhook(NewWebhook{
 			Event:   "balance.created",
 			Payload: balance,
 		})

--- a/blnk.go
+++ b/blnk.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"embed"
 
+	"github.com/hibiken/asynq"
 	"github.com/typesense/typesense-go/typesense/api"
 
 	"github.com/jerry-enebeli/blnk/config"
@@ -34,13 +35,14 @@ import (
 
 // Blnk represents the main struct for the Blnk application.
 type Blnk struct {
-	queue      *Queue
-	search     *TypesenseClient
-	redis      redis.UniversalClient
-	datasource database.IDataSource
-	bt         *model.BalanceTracker
-	tokenizer  *tokenization.TokenizationService
-	Hooks      hooks.HookManager
+	queue       *Queue
+	search      *TypesenseClient
+	redis       redis.UniversalClient
+	asynqClient *asynq.Client
+	datasource  database.IDataSource
+	bt          *model.BalanceTracker
+	tokenizer   *tokenization.TokenizationService
+	Hooks       hooks.HookManager
 }
 
 const (
@@ -68,6 +70,18 @@ func NewBlnk(db database.IDataSource) (*Blnk, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	redisOption, err := redis_db.ParseRedisURL(configuration.Redis.Dns)
+	if err != nil {
+		return nil, err
+	}
+	asynqClient := asynq.NewClient(asynq.RedisClientOpt{
+		Addr:      redisOption.Addr,
+		Password:  redisOption.Password,
+		DB:        redisOption.DB,
+		TLSConfig: redisOption.TLSConfig,
+	})
+
 	bt := NewBalanceTracker()
 	newQueue := NewQueue(configuration)
 	newSearch := NewTypesenseClient(configuration.TypeSenseKey, []string{configuration.TypeSense.Dns})
@@ -82,13 +96,14 @@ func NewBlnk(db database.IDataSource) (*Blnk, error) {
 	}
 
 	newBlnk := &Blnk{
-		datasource: db,
-		bt:         bt,
-		queue:      newQueue,
-		redis:      redisClient.Client(),
-		search:     newSearch,
-		tokenizer:  tokenization.NewTokenizationService(tokenizationKey),
-		Hooks:      hookManager,
+		datasource:  db,
+		bt:          bt,
+		queue:       newQueue,
+		redis:       redisClient.Client(),
+		asynqClient: asynqClient,
+		search:      newSearch,
+		tokenizer:   tokenization.NewTokenizationService(tokenizationKey),
+		Hooks:       hookManager,
 	}
 	return newBlnk, nil
 }
@@ -109,4 +124,12 @@ func (l *Blnk) Search(collection string, query *api.SearchCollectionParams) (int
 // MultiSearch performs a multi-search operation across collections.
 func (l *Blnk) MultiSearch(searchParams *api.MultiSearchSearchesParameter) (*api.MultiSearchResult, error) {
 	return l.search.MultiSearch(context.Background(), *searchParams)
+}
+
+// Close properly closes all connections and resources used by the Blnk instance.
+func (b *Blnk) Close() error {
+	if b.asynqClient != nil {
+		return b.asynqClient.Close()
+	}
+	return nil
 }

--- a/cmd/workers.go
+++ b/cmd/workers.go
@@ -93,7 +93,7 @@ func handleTransactionRejection(ctx context.Context, b *blnkInstance, txn *model
 		return rejectErr
 	}
 
-	webhookErr := blnk.SendWebhook(blnk.NewWebhook{
+	webhookErr := b.blnk.SendWebhook(blnk.NewWebhook{
 		Event:   "transaction.rejected",
 		Payload: *txn,
 	})

--- a/identity.go
+++ b/identity.go
@@ -36,7 +36,7 @@ func (l *Blnk) postIdentityActions(_ context.Context, identity *model.Identity) 
 		if err != nil {
 			notification.NotifyError(err)
 		}
-		err = SendWebhook(NewWebhook{
+		err = l.SendWebhook(NewWebhook{
 			Event:   "identity.created",
 			Payload: identity,
 		})

--- a/ledger.go
+++ b/ledger.go
@@ -36,7 +36,7 @@ func (l *Blnk) postLedgerActions(_ context.Context, ledger *model.Ledger) {
 		if err != nil {
 			notification.NotifyError(err)
 		}
-		err = SendWebhook(NewWebhook{
+		err = l.SendWebhook(NewWebhook{
 			Event:   "ledger.created",
 			Payload: ledger,
 		})

--- a/transaction.go
+++ b/transaction.go
@@ -268,7 +268,7 @@ func (l *Blnk) postTransactionActions(ctx context.Context, transaction *model.Tr
 			span.RecordError(err)
 			notification.NotifyError(err)
 		}
-		err = SendWebhook(NewWebhook{
+		err = l.SendWebhook(NewWebhook{
 			Event:   getEventFromStatus(transaction.Status),
 			Payload: transaction,
 		})
@@ -2066,7 +2066,7 @@ func (l *Blnk) sendBulkTransactionWebhook(batchID, status, errorMsg string, tran
 		payload["error"] = errorMsg
 	}
 
-	err := SendWebhook(NewWebhook{
+	err := l.SendWebhook(NewWebhook{
 		Event:   "bulk_transaction." + status,
 		Payload: payload,
 	})

--- a/webhooks_test.go
+++ b/webhooks_test.go
@@ -62,8 +62,10 @@ func TestSendWebhook(t *testing.T) {
 		Event:   "transaction.queued",
 		Payload: getTransactionMock(10000, false),
 	}
+	blnk, err := NewBlnk(nil)
+	assert.NoError(t, err)
 
-	err = SendWebhook(testData)
+	err = blnk.SendWebhook(testData)
 	assert.NoError(t, err)
 
 	// Verify that the task was enqueued


### PR DESCRIPTION
This pull request refactors the `SendWebhook` function to use the `Blnk` instance's `asynqClient`, introduces proper resource management by adding a `Close` method to the `Blnk` struct, and integrates the `asynq` library for task queuing. Additionally, it modifies the `Blnk` struct and its initialization to support the new changes.

closes #149 

### Refactoring and Resource Management:
* [`webhooks.go`](diffhunk://#diff-e85c105363b73024c790df70d8aacca74ab579760892e3f57a2a94187f483e34L134-R140): Refactored `SendWebhook` to use the `Blnk` instance's `asynqClient`, removing redundant Redis client initialization. Added comments to clarify the function's behavior. [[1]](diffhunk://#diff-e85c105363b73024c790df70d8aacca74ab579760892e3f57a2a94187f483e34L134-R140) [[2]](diffhunk://#diff-e85c105363b73024c790df70d8aacca74ab579760892e3f57a2a94187f483e34L151-R156)
* [`blnk.go`](diffhunk://#diff-81f59b1e01d80981f38e7ef6e5fbbe323f44133e6f81d9f9960e3f81391d2150R128-R135): Added a `Close` method to the `Blnk` struct to properly close connections and resources, ensuring better resource management.

### Integration of `asynq` Library:
* [`blnk.go`](diffhunk://#diff-81f59b1e01d80981f38e7ef6e5fbbe323f44133e6f81d9f9960e3f81391d2150R41): Updated the `Blnk` struct to include an `asynqClient` field and modified the `NewBlnk` function to initialize the `asynqClient` using Redis configuration. [[1]](diffhunk://#diff-81f59b1e01d80981f38e7ef6e5fbbe323f44133e6f81d9f9960e3f81391d2150R41) [[2]](diffhunk://#diff-81f59b1e01d80981f38e7ef6e5fbbe323f44133e6f81d9f9960e3f81391d2150R73-R84) [[3]](diffhunk://#diff-81f59b1e01d80981f38e7ef6e5fbbe323f44133e6f81d9f9960e3f81391d2150R103)
* [`blnk.go`](diffhunk://#diff-81f59b1e01d80981f38e7ef6e5fbbe323f44133e6f81d9f9960e3f81391d2150R23): Imported the `asynq` library for task queuing.

### Webhook Function Updates Across Files:
* Replaced calls to the global `SendWebhook` function with the instance method `l.SendWebhook` in `balance.go`, `identity.go`, `ledger.go`, and `transaction.go` for consistency and improved encapsulation. [[1]](diffhunk://#diff-c62336e5da3f8c446d67f6d75b8ef6f35ad04ea3af43f0b3c36abdfa8b5ad6c3L74-R74) [[2]](diffhunk://#diff-c62336e5da3f8c446d67f6d75b8ef6f35ad04ea3af43f0b3c36abdfa8b5ad6c3L144-R144) [[3]](diffhunk://#diff-2de96e48bc2537386b67ba8481b1566bbc2876c46b0b36a7dfd9cadd55f3a050L39-R39) [[4]](diffhunk://#diff-0597fe8ebad2cd8888b3532c782a0600d952b8b3b19b2b7edd2b66c13ad901d2L39-R39) [[5]](diffhunk://#diff-63ab601287b8b9c040760fe0bdd288f55b73f37cd7e4f1e519bea2bd43a18bbaL271-R271) [[6]](diffhunk://#diff-63ab601287b8b9c040760fe0bdd288f55b73f37cd7e4f1e519bea2bd43a18bbaL2069-R2069)
* Updated `cmd/workers.go` to use the instance method `b.blnk.SendWebhook` for webhook calls.

### Testing Updates:
* [`webhooks_test.go`](diffhunk://#diff-8b6cb16f1efd37322050d2518c2660ead7618ea92687959f4fbdd9004d5a19e6R65-R68): Modified the `TestSendWebhook` test to use the `Blnk` instance's `SendWebhook` method, ensuring the test aligns with the refactored implementation.