### PR TITLE
fix(apikey): Bind api key revokation to owner id to bypass

### DIFF
--- a/apikey.go
+++ b/apikey.go
@@ -46,7 +46,7 @@ func (l *Blnk) ListAPIKeys(ctx context.Context, ownerID string) ([]*model.APIKey
 // Returns:
 // - error: An error if the operation fails
 func (l *Blnk) RevokeAPIKey(ctx context.Context, id, ownerID string) error {
-	return l.datasource.RevokeAPIKey(ctx, id)
+	return l.datasource.RevokeAPIKey(ctx, id, ownerID)
 }
 
 // GetAPIKeyByKey retrieves an API key by its key string

--- a/database/api_key.go
+++ b/database/api_key.go
@@ -39,7 +39,6 @@ func (s *Datasource) CreateAPIKey(ctx context.Context, name, ownerID string, sco
 		apiKey.LastUsedAt,
 		apiKey.IsRevoked,
 	)
-
 	if err != nil {
 		return nil, err
 	}
@@ -84,14 +83,14 @@ func (s *Datasource) GetAPIKey(ctx context.Context, key string) (*model.APIKey, 
 }
 
 // RevokeAPIKey revokes an API key
-func (s *Datasource) RevokeAPIKey(ctx context.Context, id string) error {
+func (s *Datasource) RevokeAPIKey(ctx context.Context, id, ownerID string) error {
 	query := `
 		UPDATE blnk.api_keys
 		SET is_revoked = true, revoked_at = $1
-		WHERE api_key_id = $2
+		WHERE api_key_id = $2 AND owner_id = $3
 	`
 
-	result, err := s.Conn.ExecContext(ctx, query, time.Now(), id)
+	result, err := s.Conn.ExecContext(ctx, query, time.Now(), id, ownerID)
 	if err != nil {
 		return err
 	}

--- a/database/mocks/repo_mocks.go
+++ b/database/mocks/repo_mocks.go
@@ -379,8 +379,8 @@ func (m *MockDataSource) ListAPIKeys(ctx context.Context, ownerID string) ([]*mo
 	return args.Get(0).([]*model.APIKey), args.Error(1)
 }
 
-func (m *MockDataSource) RevokeAPIKey(ctx context.Context, id string) error {
-	args := m.Called(ctx, id)
+func (m *MockDataSource) RevokeAPIKey(ctx context.Context, id, ownerID string) error {
+	args := m.Called(ctx, id, ownerID)
 	return args.Error(0)
 }
 

--- a/database/repository.go
+++ b/database/repository.go
@@ -134,7 +134,7 @@ type reconciliation interface {
 type apikey interface {
 	CreateAPIKey(ctx context.Context, name, ownerID string, scopes []string, expiresAt time.Time) (*model.APIKey, error) // Creates a new API key
 	GetAPIKey(ctx context.Context, key string) (*model.APIKey, error)                                                    // Retrieves an API key by its key string
-	RevokeAPIKey(ctx context.Context, id string) error                                                                   // Revokes an API key
+	RevokeAPIKey(ctx context.Context, id, ownerID string) error                                                          // Revokes an API key
 	ListAPIKeys(ctx context.Context, ownerID string) ([]*model.APIKey, error)                                            // Lists all API keys for a specific owner
 	UpdateLastUsed(ctx context.Context, id string) error                                                                 // Updates the last_used_at timestamp for an API key
 }

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/go-sql-driver/mysql v1.9.1
 	github.com/google/uuid v1.6.0
 	github.com/hibiken/asynq v0.25.1
+	github.com/hibiken/asynqmon v0.7.2
 	github.com/jarcoal/httpmock v1.3.1
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/lib/pq v1.10.9
@@ -65,7 +66,6 @@ require (
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.1 // indirect
-	github.com/hibiken/asynqmon v0.7.2 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect


### PR DESCRIPTION
This change binds api key revocation to key owner to eradicate authorization bypass, allowing the caller to delete any api key with matching key id.

Fixes #159 