### PR TITLE
Update auth middleware for health routes

### DIFF
--- a/api/middleware/auth.go
+++ b/api/middleware/auth.go
@@ -186,6 +186,21 @@ func (m *AuthMiddleware) Authenticate() gin.HandlerFunc {
 			return
 		}
 
+		// Skip auth for health endpoints (server and worker health checks)
+		if c.Request != nil && c.Request.URL != nil {
+			path := c.Request.URL.Path
+			// Server health endpoint
+			if path == "/health" {
+				c.Next()
+				return
+			}
+			// Worker monitoring/health endpoint (includes sub-paths)
+			if strings.HasPrefix(path, "/monitoring") {
+				c.Next()
+				return
+			}
+		}
+
 		// Check if secure mode is enabled
 		conf, err := config.Fetch()
 		if err == nil && conf != nil && !conf.Server.Secure {

--- a/api/middleware/auth.go
+++ b/api/middleware/auth.go
@@ -186,19 +186,10 @@ func (m *AuthMiddleware) Authenticate() gin.HandlerFunc {
 			return
 		}
 
-		// Skip auth for health endpoints (server and worker health checks)
-		if c.Request != nil && c.Request.URL != nil {
-			path := c.Request.URL.Path
-			// Server health endpoint
-			if path == "/health" {
-				c.Next()
-				return
-			}
-			// Worker monitoring/health endpoint (includes sub-paths)
-			if strings.HasPrefix(path, "/monitoring") {
-				c.Next()
-				return
-			}
+		// Skip auth for health endpoint (server health check only)
+		if c.Request != nil && c.Request.URL != nil && c.Request.URL.Path == "/health" {
+			c.Next()
+			return
 		}
 
 		// Check if secure mode is enabled

--- a/api/middleware/auth_test.go
+++ b/api/middleware/auth_test.go
@@ -123,32 +123,6 @@ func TestAuthMiddleware_Authenticate(t *testing.T) {
 			expectedCode: http.StatusOK,
 		},
 		{
-			name:   "Worker monitoring endpoint",
-			path:   "/monitoring",
-			method: "GET",
-			setupConfig: func() *config.Configuration {
-				return &config.Configuration{
-					Server: config.ServerConfig{
-						Secure: true,
-					},
-				}
-			},
-			expectedCode: http.StatusOK,
-		},
-		{
-			name:   "Worker monitoring sub-path",
-			path:   "/monitoring/queues",
-			method: "GET",
-			setupConfig: func() *config.Configuration {
-				return &config.Configuration{
-					Server: config.ServerConfig{
-						Secure: true,
-					},
-				}
-			},
-			expectedCode: http.StatusOK,
-		},
-		{
 			name:   "Insufficient permissions",
 			path:   "/ledgers",
 			method: "POST",

--- a/api/middleware/auth_test.go
+++ b/api/middleware/auth_test.go
@@ -110,6 +110,45 @@ func TestAuthMiddleware_Authenticate(t *testing.T) {
 			expectedCode: http.StatusOK,
 		},
 		{
+			name:   "Server health endpoint",
+			path:   "/health",
+			method: "GET",
+			setupConfig: func() *config.Configuration {
+				return &config.Configuration{
+					Server: config.ServerConfig{
+						Secure: true,
+					},
+				}
+			},
+			expectedCode: http.StatusOK,
+		},
+		{
+			name:   "Worker monitoring endpoint",
+			path:   "/monitoring",
+			method: "GET",
+			setupConfig: func() *config.Configuration {
+				return &config.Configuration{
+					Server: config.ServerConfig{
+						Secure: true,
+					},
+				}
+			},
+			expectedCode: http.StatusOK,
+		},
+		{
+			name:   "Worker monitoring sub-path",
+			path:   "/monitoring/queues",
+			method: "GET",
+			setupConfig: func() *config.Configuration {
+				return &config.Configuration{
+					Server: config.ServerConfig{
+						Secure: true,
+					},
+				}
+			},
+			expectedCode: http.StatusOK,
+		},
+		{
 			name:   "Insufficient permissions",
 			path:   "/ledgers",
 			method: "POST",


### PR DESCRIPTION
The authentication middleware in `api/middleware/auth.go` was updated to exclude only the `/health` endpoint from authentication. Initially, the `/monitoring` route was also excluded, but this was reverted as it exposes sensitive dashboard information.

To provide a public health check for workers without exposing the full monitoring dashboard:
*   `cmd/workers.go` was modified to start a new HTTP server on the worker's dedicated monitoring port.
*   This server now hosts a simple `{"status": "UP", "service": "worker"}` response at `/health`.
*   The existing asynqmon dashboard remains on `/monitoring` on this *same, separate* port.

This ensures:
*   Server health checks via `/health` on the main API port are unauthenticated.
*   Worker health checks via `/health` on the monitoring port are unauthenticated.
*   Sensitive worker monitoring data at `/monitoring` is not exposed via the main API and is only accessible on the separate monitoring port.
*   Tests in `api/middleware/auth_test.go` were adjusted to reflect these authentication changes.