### PR TITLE
Enhance Redis client configuration by adding SkipTLSVerify option

### DIFF
--- a/api/transaction_api_test.go
+++ b/api/transaction_api_test.go
@@ -100,7 +100,7 @@ func (tl *testLogger) Fatal(args ...interface{}) {
 // It takes the testing object, configuration, Blnk instance, and the specific transaction queue name.
 // It returns a cleanup function that should be deferred by the caller to shut down the server.
 func StartTestAsynqWorker(t *testing.T, cnf *config.Configuration, blnkInstance *blnk.Blnk, transactionQueueName string) func() {
-	redisOption, err := redis_db.ParseRedisURL(cnf.Redis.Dns)
+	redisOption, err := redis_db.ParseRedisURL(cnf.Redis.Dns, cnf.Redis.SkipTLSVerify)
 	require.NoError(t, err, "Failed to parse Redis URL for Asynq")
 
 	queues := make(map[string]int)

--- a/blnk.go
+++ b/blnk.go
@@ -57,7 +57,7 @@ var SQLFiles embed.FS
 
 // initializeRedisClients sets up both the Redis client and Asynq client
 func initializeRedisClients(config *config.Configuration) (redis.UniversalClient, *asynq.Client, error) {
-	redisClient, err := redis_db.NewRedisClient([]string{config.Redis.Dns})
+	redisClient, err := redis_db.NewRedisClient([]string{config.Redis.Dns}, config.Redis.SkipTLSVerify)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/blnk.go
+++ b/blnk.go
@@ -62,7 +62,7 @@ func initializeRedisClients(config *config.Configuration) (redis.UniversalClient
 		return nil, nil, err
 	}
 
-	redisOption, err := redis_db.ParseRedisURL(config.Redis.Dns)
+	redisOption, err := redis_db.ParseRedisURL(config.Redis.Dns, config.Redis.SkipTLSVerify)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -82,7 +82,8 @@ type DataSourceConfig struct {
 }
 
 type RedisConfig struct {
-	Dns string `json:"dns" envconfig:"BLNK_REDIS_DNS"`
+	Dns           string `json:"dns" envconfig:"BLNK_REDIS_DNS"`
+	SkipTLSVerify bool   `json:"skip_tls_verify" envconfig:"BLNK_REDIS_SKIP_TLS_VERIFY"`
 }
 
 type TypeSenseConfig struct {

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -70,7 +70,7 @@ func NewCache() (Cache, error) {
 	}
 
 	// Initialize Redis cache with the configured Redis DNS
-	ca, err := newRedisCache([]string{cfg.Redis.Dns}, false) // Default to secure TLS verification for cache
+	ca, err := newRedisCache([]string{cfg.Redis.Dns}, cfg.Redis.SkipTLSVerify)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -70,7 +70,7 @@ func NewCache() (Cache, error) {
 	}
 
 	// Initialize Redis cache with the configured Redis DNS
-	ca, err := newRedisCache([]string{cfg.Redis.Dns})
+	ca, err := newRedisCache([]string{cfg.Redis.Dns}, false) // Default to secure TLS verification for cache
 	if err != nil {
 		return nil, err
 	}
@@ -84,9 +84,9 @@ const cacheSize = 128000
 // Parameters:
 // - addresses: The Redis server addresses to connect to.
 // Returns a RedisCache instance and an error if the connection fails.
-func newRedisCache(addresses []string) (*RedisCache, error) {
+func newRedisCache(addresses []string, skipTLSVerify bool) (*RedisCache, error) {
 	// Initialize the Redis client using the provided addresses
-	client, err := redis_db.NewRedisClient(addresses)
+	client, err := redis_db.NewRedisClient(addresses, skipTLSVerify)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/redis-db/redis_test.go
+++ b/internal/redis-db/redis_test.go
@@ -45,7 +45,7 @@ func TestParseRedisURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ParseRedisURL(tt.url)
+			got, err := ParseRedisURL(tt.url, false)
 			if tt.wantErr {
 				assert.Error(t, err)
 				return

--- a/internal/redis-db/redis_test.go
+++ b/internal/redis-db/redis_test.go
@@ -82,7 +82,7 @@ func TestNewRedisClient(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, err := NewRedisClient(tt.addresses)
+			client, err := NewRedisClient(tt.addresses, false)
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -99,7 +99,7 @@ func TestRedisIntegration(t *testing.T) {
 		t.Skip("skipping integration test")
 	}
 
-	client, err := NewRedisClient([]string{"localhost:6379"})
+	client, err := NewRedisClient([]string{"localhost:6379"}, false)
 	if err != nil {
 		t.Fatalf("Failed to create Redis client: %v", err)
 	}

--- a/internal/redis-db/redisdb.go
+++ b/internal/redis-db/redisdb.go
@@ -114,7 +114,9 @@ func NewRedisClient(addresses []string, skipTLSVerify bool) (*Redis, error) {
 
 		// Apply TLS skip verify if configured and TLS is enabled
 		if opts.TLSConfig != nil && skipTLSVerify {
-			opts.TLSConfig.InsecureSkipVerify = true
+			opts.TLSConfig = &tls.Config{
+				InsecureSkipVerify: skipTLSVerify,
+			}
 		}
 
 		client = redis.NewClient(opts)

--- a/queue.go
+++ b/queue.go
@@ -18,6 +18,7 @@ package blnk
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"hash/fnv"
@@ -53,6 +54,13 @@ func NewQueue(conf *config.Configuration) *Queue {
 	redisOption, err := redis_db.ParseRedisURL(conf.Redis.Dns)
 	if err != nil {
 		log.Fatalf("Error parsing Redis URL: %v", err)
+	}
+
+	// Apply TLS skip verify if configured and TLS is enabled
+	if redisOption.TLSConfig != nil && conf.Redis.SkipTLSVerify {
+		redisOption.TLSConfig = &tls.Config{
+			InsecureSkipVerify: conf.Redis.SkipTLSVerify,
+		}
 	}
 	queueOptions := asynq.RedisClientOpt{Addr: redisOption.Addr, Password: redisOption.Password, DB: redisOption.DB, TLSConfig: redisOption.TLSConfig}
 	client := asynq.NewClient(queueOptions)

--- a/queue.go
+++ b/queue.go
@@ -18,7 +18,6 @@ package blnk
 
 import (
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"hash/fnv"
@@ -51,17 +50,11 @@ type TransactionTypePayload struct {
 // Returns:
 // - *Queue: A pointer to the newly created Queue instance.
 func NewQueue(conf *config.Configuration) *Queue {
-	redisOption, err := redis_db.ParseRedisURL(conf.Redis.Dns)
+	redisOption, err := redis_db.ParseRedisURL(conf.Redis.Dns, conf.Redis.SkipTLSVerify)
 	if err != nil {
 		log.Fatalf("Error parsing Redis URL: %v", err)
 	}
 
-	// Apply TLS skip verify if configured and TLS is enabled
-	if redisOption.TLSConfig != nil && conf.Redis.SkipTLSVerify {
-		redisOption.TLSConfig = &tls.Config{
-			InsecureSkipVerify: conf.Redis.SkipTLSVerify,
-		}
-	}
 	queueOptions := asynq.RedisClientOpt{Addr: redisOption.Addr, Password: redisOption.Password, DB: redisOption.DB, TLSConfig: redisOption.TLSConfig}
 	client := asynq.NewClient(queueOptions)
 	inspector := asynq.NewInspector(queueOptions)

--- a/queue_test.go
+++ b/queue_test.go
@@ -40,7 +40,7 @@ func TestEnqueueImmediateTransactionSuccess(t *testing.T) {
 	}
 	config.ConfigStore.Store(cnf)
 
-	redisOption, err := redis_db.ParseRedisURL("localhost:6379")
+	redisOption, err := redis_db.ParseRedisURL("localhost:6379", false)
 	if err != nil {
 		log.Fatalf("Error parsing Redis URL: %v", err)
 	}

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -4395,7 +4395,7 @@ func (tl *testLogger) Fatal(args ...interface{}) {
 // It takes the testing object, configuration, Blnk instance, and the specific transaction queue name.
 // It returns a cleanup function that should be deferred by the caller to shut down the server.
 func startTestAsynqWorker(t *testing.T, cnf *config.Configuration, blnkInstance *Blnk, transactionQueueName string) func() {
-	redisOption, err := redis_db.ParseRedisURL(cnf.Redis.Dns)
+	redisOption, err := redis_db.ParseRedisURL(cnf.Redis.Dns, false)
 	require.NoError(t, err, "Failed to parse Redis URL for Asynq")
 
 	queues := make(map[string]int)


### PR DESCRIPTION
- Updated RedisConfig struct to include SkipTLSVerify field for TLS verification control.
- Modified NewRedisClient function to accept SkipTLSVerify parameter, allowing clients to specify whether to skip TLS certificate verification.
- Adjusted related functions and tests to accommodate the new parameter, ensuring consistent behavior across Redis client initialization.