### PR TITLE
Fix: Separate telemetry and observability concerns and default bug

### DIFF
--- a/cmd/workers.go
+++ b/cmd/workers.go
@@ -237,7 +237,7 @@ func workerCommands(b *blnkInstance) *cobra.Command {
 			}
 
 			// Initialize observability (tracing and PostHog)
-			phClient, shutdown, err := initializeObservability(ctx, conf)
+			phClient, shutdown, err := initializeTelemetryAndObservability(ctx, conf)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/config/config.go
+++ b/config/config.go
@@ -165,6 +165,7 @@ type Configuration struct {
 	Notification            Notification                  `json:"notification"`
 	RateLimit               RateLimitConfig               `json:"rate_limit"`
 	EnableTelemetry         bool                          `json:"enable_telemetry" envconfig:"BLNK_ENABLE_TELEMETRY"`
+	EnableObservability     bool                          `json:"enable_observability" envconfig:"BLNK_ENABLE_OBSERVABILITY"`
 	Transaction             TransactionConfig             `json:"transaction"`
 	Reconciliation          ReconciliationConfig          `json:"reconciliation"`
 	Queue                   QueueConfig                   `json:"queue"`
@@ -211,7 +212,7 @@ func Fetch() (*Configuration, error) {
 	config := ConfigStore.Load()
 	c, ok := config.(*Configuration)
 	if !ok {
-		return nil, errors.New("config not loaded from file. Create a json file called blnk.json with your config ❌")
+		return nil, errors.New("config not loaded from file. Create a json file called blnk.json with your config ")
 	}
 	return c, nil
 }
@@ -273,10 +274,17 @@ func (cnf *Configuration) setDefaultValues() {
 	cnf.setReconciliationDefaults()
 	cnf.setQueueDefaults()
 
-	// Enable telemetry by default
-	if !cnf.EnableTelemetry {
-		cnf.EnableTelemetry = true
-		log.Println("Warning: Telemetry setting not specified. Enabling by default.")
+	// For a financial application, telemetry is opt-in for privacy reasons, don't enable by default if it's not specified
+	if cnf.EnableTelemetry {
+		log.Println("Info: Telemetry enabled.")
+	} else {
+		log.Println("Info: Telemetry disabled.")
+	}
+
+	if cnf.EnableObservability {
+		log.Println("Info: Observability enabled.")
+	} else {
+		log.Println("Info: Observability disabled.")
 	}
 }
 


### PR DESCRIPTION
## Bug Fix: Separate Telemetry and Observability Controls

### Problem
Previously, both telemetry (PostHog analytics) and observability (OpenTelemetry tracing) were controlled by a single configuration flag (`EnableTelemetry`), which didn't allow users to enable/disable them independently. This flag would also always default to true, even when set to false in blnk.json or via the env var `BLNK_ENABLE_TELEMETRY`.

### Solution
- Added separate boolean flags:
  - `EnableTelemetry` controls PostHog analytics
  - `EnableObservability` controls Open Telemetry tracing (jaegar)
- Both flags are independently configurable via environment variables:
  - `BLNK_ENABLE_TELEMETRY`
  - `BLNK_ENABLE_OBSERVABILITY`
- Updated initialization logic to respect each flag independently
- If flag set to false, it would remain false
- Improved logging to clearly show the current state of each feature
- As this is a financial application, made telemetry opt-in

### Testing
Tested with all four possible combinations of the flags to verify independent control:
- Both enabled
- Telemetry disabled, observability enabled
- Telemetry enabled, observability disabled
- Both disabled