### PR TITLE
Refactor database connection handling

### DIFF
--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -65,7 +65,7 @@ func migrateUpCommands() *cobra.Command {
 			}
 
 			// Connect to the database.
-			db, err := database.ConnectDB(cnf.DataSource.Dns)
+			db, err := database.ConnectDB(cnf.DataSource)
 			if err != nil {
 				log.Printf("Error connecting to database: %v", err)
 				return
@@ -106,7 +106,7 @@ func migrateDownCommands() *cobra.Command {
 			}
 
 			// Connect to the database.
-			db, err := database.ConnectDB(cnf.DataSource.Dns)
+			db, err := database.ConnectDB(cnf.DataSource)
 			if err != nil {
 				log.Printf("Error connecting to database: %v", err)
 				return

--- a/config/config.go
+++ b/config/config.go
@@ -63,6 +63,13 @@ var (
 		NumberOfQueues:      20,
 		MonitoringPort:      DEFAULT_MONITORING_PORT,
 	}
+
+	defaultDatabase = DataSourceConfig{
+		MaxOpenConns:    25,
+		MaxIdleConns:    10,
+		ConnMaxLifetime: 30 * time.Minute,
+		ConnMaxIdleTime: 5 * time.Minute,
+	}
 )
 
 var ConfigStore atomic.Value
@@ -77,7 +84,11 @@ type ServerConfig struct {
 }
 
 type DataSourceConfig struct {
-	Dns string `json:"dns" envconfig:"BLNK_DATA_SOURCE_DNS"`
+	Dns             string        `json:"dns" envconfig:"BLNK_DATA_SOURCE_DNS"`
+	MaxOpenConns    int           `json:"max_open_conns" envconfig:"BLNK_DATABASE_MAX_OPEN_CONNS"`
+	MaxIdleConns    int           `json:"max_idle_conns" envconfig:"BLNK_DATABASE_MAX_IDLE_CONNS"`
+	ConnMaxLifetime time.Duration `json:"conn_max_lifetime" envconfig:"BLNK_DATABASE_CONN_MAX_LIFETIME"`
+	ConnMaxIdleTime time.Duration `json:"conn_max_idle_time" envconfig:"BLNK_DATABASE_CONN_MAX_IDLE_TIME"`
 }
 
 type RedisConfig struct {
@@ -270,6 +281,7 @@ func (cnf *Configuration) setDefaultValues() {
 	}
 
 	// Set module defaults
+	cnf.setDatabaseDefaults()
 	cnf.setTransactionDefaults()
 	cnf.setReconciliationDefaults()
 	cnf.setQueueDefaults()
@@ -341,6 +353,21 @@ func (cnf *Configuration) setQueueDefaults() {
 	}
 	if cnf.Queue.MonitoringPort == "" {
 		cnf.Queue.MonitoringPort = defaultQueue.MonitoringPort
+	}
+}
+
+func (cnf *Configuration) setDatabaseDefaults() {
+	if cnf.DataSource.MaxOpenConns == 0 {
+		cnf.DataSource.MaxOpenConns = defaultDatabase.MaxOpenConns
+	}
+	if cnf.DataSource.MaxIdleConns == 0 {
+		cnf.DataSource.MaxIdleConns = defaultDatabase.MaxIdleConns
+	}
+	if cnf.DataSource.ConnMaxLifetime == 0 {
+		cnf.DataSource.ConnMaxLifetime = defaultDatabase.ConnMaxLifetime
+	}
+	if cnf.DataSource.ConnMaxIdleTime == 0 {
+		cnf.DataSource.ConnMaxIdleTime = defaultDatabase.ConnMaxIdleTime
 	}
 }
 

--- a/database/db.go
+++ b/database/db.go
@@ -53,7 +53,7 @@ func NewDataSource(configuration *config.Configuration) (IDataSource, error) {
 func GetDBConnection(configuration *config.Configuration) (*Datasource, error) {
 	var err error
 	once.Do(func() {
-		con, errConn := ConnectDB(configuration.DataSource.Dns)
+		con, errConn := ConnectDB(configuration.DataSource)
 		if errConn != nil {
 			err = errConn
 			return
@@ -74,6 +74,6 @@ func GetDBConnection(configuration *config.Configuration) (*Datasource, error) {
 }
 
 // ConnectDB establishes a database connection with pooling.
-func ConnectDB(dsn string) (*sql.DB, error) {
-	return pgconn.ConnectDB(dsn)
+func ConnectDB(dsConfig config.DataSourceConfig) (*sql.DB, error) {
+	return pgconn.ConnectDB(dsConfig)
 }

--- a/database/db_test.go
+++ b/database/db_test.go
@@ -54,7 +54,7 @@ func TestConnectDB_Success(t *testing.T) {
 	// Provide a valid DNS string for your testing database
 	dns := "postgres://postgres:password@localhost/blnk?sslmode=disable"
 
-	db, err := ConnectDB(dns)
+	db, err := ConnectDB(config.DataSourceConfig{Dns: dns})
 	assert.NoError(t, err)
 	assert.NotNil(t, db)
 
@@ -68,7 +68,7 @@ func TestConnectDB_Failure(t *testing.T) {
 	// Provide an invalid DNS string to simulate a failure
 	invalidDNS := "invalid-dns"
 
-	db, err := ConnectDB(invalidDNS)
+	db, err := ConnectDB(config.DataSourceConfig{Dns: invalidDNS})
 	assert.Error(t, err)
 	assert.Nil(t, db)
 }


### PR DESCRIPTION
### Summary
This PR makes database connection pooling settings configurable through the existing `DataSourceConfig` structure, replacing previously hardcoded values with configurable options.

### Changes Made
- **Enhanced `DataSourceConfig`**: Added four new connection pooling fields:
  - `MaxOpenConns` - Maximum number of open database connections
  - `MaxIdleConns` - Maximum number of idle connections in the pool
  - `ConnMaxLifetime` - Maximum lifetime for database connections
  - `ConnMaxIdleTime` - Maximum idle time before closing connections

- **Updated Connection Logic**: Modified `internal/pg-conn/pg_conn.go` to use configurable values instead of hardcoded settings

- **Added Default Values**: Implemented sensible defaults that match the previous hardcoded values:
  - Max Open Connections: 25
  - Max Idle Connections: 10
  - Connection Max Lifetime: 30 minutes
  - Connection Max Idle Time: 5 minutes

### Configuration Options

#### JSON Configuration (blnk.json)
```json
{
  "data_source": {
    "dns": "postgres://user:password@localhost:5432/blnk",
    "max_open_conns": 50,
    "max_idle_conns": 20,
    "conn_max_lifetime": "1h",
    "conn_max_idle_time": "10m"
  }
}
```

#### Environment Variables
- `BLNK_DATABASE_MAX_OPEN_CONNS`
- `BLNK_DATABASE_MAX_IDLE_CONNS`
- `BLNK_DATABASE_CONN_MAX_LIFETIME`
- `BLNK_DATABASE_CONN_MAX_IDLE_TIME`

### Benefits
- **Performance Tuning**: Allows fine-tuning of database connection pooling based on workload requirements
- **Resource Management**: Better control over database connection resources
- **Environment-Specific Settings**: Different pooling settings for development, staging, and production
- **Backward Compatibility**: Maintains existing behavior through sensible defaults

### Testing
- Existing configuration tests continue to pass
- Default values are applied when settings are not specified
- Configuration can be overridden via environment variables or JSON config