### PR TITLE
fix(transactions): reject non-integer precision to prevent db failure and balance inconsistency

### DIFF
--- a/api/model/model.go
+++ b/api/model/model.go
@@ -17,6 +17,7 @@ package model
 
 import (
 	"errors"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -27,6 +28,21 @@ import (
 
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 )
+
+var ErrPrecisionMustBeInteger = errors.New("precision must be an integer value")
+
+func validatePrecisionIsInteger(value interface{}) error {
+	precision, ok := value.(float64)
+	if !ok {
+		return errors.New("invalid precision type")
+	}
+
+	if math.Trunc(precision) != precision {
+		return ErrPrecisionMustBeInteger
+	}
+
+	return nil
+}
 
 func sourceOrSourcesValidation(t *RecordTransaction) validation.RuleFunc {
 	return func(value interface{}) error {
@@ -130,6 +146,7 @@ func (t *RecordTransaction) ValidateRecordTransaction() error {
 
 			return nil
 		})),
+		validation.Field(&t.Precision, validation.By(validatePrecisionIsInteger)),
 		validation.Field(&t.Currency, validation.Required),
 		validation.Field(&t.Reference, validation.Required),
 		validation.Field(&t.Description, validation.Required),

--- a/api/model/model_test.go
+++ b/api/model/model_test.go
@@ -243,6 +243,32 @@ func TestValidateRecordTransaction(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "Valid Transaction - Integer Precision",
+			transaction: RecordTransaction{
+				Amount:      50,
+				Precision:   1000,
+				Currency:    "USD",
+				Reference:   "ref_precision_int",
+				Description: "Integer precision transaction",
+				Source:      "source1",
+				Destination: "dest1",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Invalid Transaction - Non-integer Precision",
+			transaction: RecordTransaction{
+				Amount:      50,
+				Precision:   10.5,
+				Currency:    "USD",
+				Reference:   "ref_precision_float",
+				Description: "Fractional precision transaction",
+				Source:      "source1",
+				Destination: "dest1",
+			},
+			wantErr: true,
+		},
+		{
 			name: "Invalid Transaction - Missing Required Fields",
 			transaction: RecordTransaction{
 				Amount: 100,


### PR DESCRIPTION
This PR fixes a bug where transactions with a non-integer precision caused pq: invalid input syntax for type bigint errors and inconsistent balance updates.
The change validates precision before processing and rejects float values with HTTP 400.

Fixes #203