### PR TITLE
feat: allow search results to be ordered by `effective_date`

### DIFF
--- a/effective_date_test.go
+++ b/effective_date_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2024 Blnk Finance Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package blnk
+
+import (
+	"testing"
+	"time"
+
+	"github.com/blnkfinance/blnk/model"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSetTransactionMetadata_EffectiveDateDefault tests that setTransactionMetadata
+// sets EffectiveDate to CreatedAt when EffectiveDate is nil
+func TestSetTransactionMetadata_EffectiveDateDefault(t *testing.T) {
+	t.Run("EffectiveDate nil - should default to CreatedAt", func(t *testing.T) {
+		txn := &model.Transaction{
+			Amount:        100.0,
+			Precision:     100,
+			EffectiveDate: nil, // Not set
+		}
+
+		setTransactionMetadata(txn)
+
+		// CreatedAt should be set
+		assert.False(t, txn.CreatedAt.IsZero(), "CreatedAt should be set")
+
+		// EffectiveDate should now be set and equal to CreatedAt
+		assert.NotNil(t, txn.EffectiveDate, "EffectiveDate should be set when nil")
+		assert.True(t, txn.EffectiveDate.Equal(txn.CreatedAt),
+			"EffectiveDate should equal CreatedAt when defaulted")
+	})
+
+	t.Run("EffectiveDate already set - should not be overwritten", func(t *testing.T) {
+		customDate := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+		txn := &model.Transaction{
+			Amount:        100.0,
+			Precision:     100,
+			EffectiveDate: &customDate, // Explicitly set
+		}
+
+		setTransactionMetadata(txn)
+
+		// CreatedAt should be set to now
+		assert.False(t, txn.CreatedAt.IsZero(), "CreatedAt should be set")
+
+		// EffectiveDate should remain unchanged
+		assert.NotNil(t, txn.EffectiveDate, "EffectiveDate should still be set")
+		assert.True(t, txn.EffectiveDate.Equal(customDate),
+			"EffectiveDate should remain as the custom date, got %v", txn.EffectiveDate)
+	})
+
+	t.Run("Backdated transaction - EffectiveDate before CreatedAt", func(t *testing.T) {
+		// Simulate a backdated transaction (e.g., importing historical data)
+		pastDate := time.Now().Add(-7 * 24 * time.Hour) // 7 days ago
+		txn := &model.Transaction{
+			Amount:        100.0,
+			Precision:     100,
+			EffectiveDate: &pastDate,
+		}
+
+		setTransactionMetadata(txn)
+
+		// EffectiveDate should remain in the past
+		assert.True(t, txn.EffectiveDate.Before(txn.CreatedAt),
+			"Backdated EffectiveDate should remain before CreatedAt")
+		assert.True(t, txn.EffectiveDate.Equal(pastDate),
+			"EffectiveDate should not be modified for backdated transactions")
+	})
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -69,7 +69,7 @@ func init() {
 			Schema:  getTransactionSchema(),
 			IDField: "transaction_id",
 			TimeFields: []string{
-				"created_at", "scheduled_for", "inflight_expiry_date",
+				"created_at", "scheduled_for", "inflight_expiry_date", "effective_date",
 			},
 			BigIntFields: []string{"precise_amount"},
 		},
@@ -465,6 +465,7 @@ func getTransactionSchema() *api.CollectionSchema {
 			{Name: "created_at", Type: "int64", Facet: &facet},
 			{Name: "scheduled_for", Type: "int64", Facet: &facet},
 			{Name: "inflight_expiry_date", Type: "int64", Facet: &facet},
+			{Name: "effective_date", Type: "int64", Facet: &facet},
 			{Name: "meta_data", Type: "object", Facet: &facet, Optional: &enableNested},
 		},
 		DefaultSortingField: &sortBy,

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2024 Blnk Finance Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package search
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestTransactionSchemaHasEffectiveDate verifies that the transaction schema
+// includes the effective_date field for sorting support
+func TestTransactionSchemaHasEffectiveDate(t *testing.T) {
+	schema := getTransactionSchema()
+
+	// Find effective_date field in schema
+	var foundEffectiveDate bool
+	var effectiveDateType string
+
+	for _, field := range schema.Fields {
+		if field.Name == "effective_date" {
+			foundEffectiveDate = true
+			effectiveDateType = field.Type
+			break
+		}
+	}
+
+	assert.True(t, foundEffectiveDate, "Transaction schema should include effective_date field")
+	assert.Equal(t, "int64", effectiveDateType, "effective_date should be int64 type for Unix timestamp")
+}
+
+// TestTransactionCollectionConfigHasEffectiveDateInTimeFields verifies that
+// effective_date is included in the TimeFields for proper timestamp normalization
+func TestTransactionCollectionConfigHasEffectiveDateInTimeFields(t *testing.T) {
+	config, ok := collectionConfigs[CollectionTransactions]
+	assert.True(t, ok, "Transaction collection config should exist")
+
+	// Check that effective_date is in TimeFields
+	var foundInTimeFields bool
+	for _, field := range config.TimeFields {
+		if field == "effective_date" {
+			foundInTimeFields = true
+			break
+		}
+	}
+
+	assert.True(t, foundInTimeFields,
+		"effective_date should be in TimeFields for timestamp normalization. Current TimeFields: %v",
+		config.TimeFields)
+}
+
+// TestTransactionSchemaDefaultSortField verifies that created_at remains
+// the default sort field (no breaking change)
+func TestTransactionSchemaDefaultSortField(t *testing.T) {
+	schema := getTransactionSchema()
+
+	assert.NotNil(t, schema.DefaultSortingField, "Default sorting field should be set")
+	assert.Equal(t, "created_at", *schema.DefaultSortingField,
+		"Default sorting field should remain created_at to avoid breaking changes")
+}
+
+// TestTransactionSchemaTimeFieldsComplete verifies all time-related fields
+// are properly configured
+func TestTransactionSchemaTimeFieldsComplete(t *testing.T) {
+	config := collectionConfigs[CollectionTransactions]
+
+	expectedTimeFields := []string{
+		"created_at",
+		"scheduled_for",
+		"inflight_expiry_date",
+		"effective_date",
+	}
+
+	for _, expected := range expectedTimeFields {
+		var found bool
+		for _, actual := range config.TimeFields {
+			if actual == expected {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "TimeFields should include %s", expected)
+	}
+}

--- a/model/transaction_test.go
+++ b/model/transaction_test.go
@@ -20,6 +20,7 @@ import (
 	"math"
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/shopspring/decimal"
 )
@@ -279,5 +280,46 @@ func TestSplitTransactionPrecise(t *testing.T) {
 				break
 			}
 		}
+	}
+}
+
+// TestGetEffectiveDate tests the GetEffectiveDate helper method
+func TestGetEffectiveDate(t *testing.T) {
+	now := time.Now()
+	yesterday := now.Add(-24 * time.Hour)
+
+	tests := []struct {
+		name          string
+		transaction   Transaction
+		expectedTime  time.Time
+		description   string
+	}{
+		{
+			name: "EffectiveDate is set - should return EffectiveDate",
+			transaction: Transaction{
+				CreatedAt:     now,
+				EffectiveDate: &yesterday,
+			},
+			expectedTime: yesterday,
+			description:  "When EffectiveDate is explicitly set, it should be returned",
+		},
+		{
+			name: "EffectiveDate is nil - should return CreatedAt",
+			transaction: Transaction{
+				CreatedAt:     now,
+				EffectiveDate: nil,
+			},
+			expectedTime: now,
+			description:  "When EffectiveDate is nil, CreatedAt should be returned as fallback",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.transaction.GetEffectiveDate()
+			if !result.Equal(tt.expectedTime) {
+				t.Errorf("GetEffectiveDate() = %v, want %v. %s", result, tt.expectedTime, tt.description)
+			}
+		})
 	}
 }

--- a/sql/1766887982.sql
+++ b/sql/1766887982.sql
@@ -1,0 +1,22 @@
+-- Copyright 2024 Blnk Finance Authors.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- +migrate Up
+-- Backfill effective_date with created_at for existing transactions where it is NULL
+UPDATE blnk.transactions
+SET effective_date = created_at
+WHERE effective_date IS NULL;
+
+-- +migrate Down
+-- No rollback needed for data backfill

--- a/transaction.go
+++ b/transaction.go
@@ -1290,6 +1290,9 @@ func (l *Blnk) finalizeCommitment(ctx context.Context, transaction *model.Transa
 	transaction.Status = StatusCommit
 	transaction.ParentTransaction = transaction.TransactionID
 	transaction.CreatedAt = time.Now()
+	if transaction.EffectiveDate == nil {
+		transaction.EffectiveDate = &transaction.CreatedAt
+	}
 	transaction.TransactionID = model.GenerateUUIDWithSuffix("txn")
 	transaction.Reference = model.GenerateUUIDWithSuffix("ref")
 	transaction.Hash = transaction.HashTxn()
@@ -1486,6 +1489,9 @@ func (l *Blnk) finalizeVoidTransaction(ctx context.Context, transaction *model.T
 	transaction.Status = StatusVoid
 	transaction.PreciseAmount = amountLeft
 	transaction.CreatedAt = time.Now()
+	if transaction.EffectiveDate == nil {
+		transaction.EffectiveDate = &transaction.CreatedAt
+	}
 	transaction.ParentTransaction = transaction.TransactionID
 	transaction.TransactionID = model.GenerateUUIDWithSuffix("txn")
 	transaction.Reference = model.GenerateUUIDWithSuffix("ref")
@@ -1761,6 +1767,9 @@ func setTransactionStatus(transaction *model.Transaction) {
 // - transaction *model.Transaction: The transaction for which to set metadata.
 func setTransactionMetadata(transaction *model.Transaction) {
 	transaction.CreatedAt = time.Now()
+	if transaction.EffectiveDate == nil {
+		transaction.EffectiveDate = &transaction.CreatedAt
+	}
 	transaction.Hash = transaction.HashTxn()
 	transaction.PreciseAmount = model.ApplyPrecision(transaction)
 	if transaction.TransactionID == "" {


### PR DESCRIPTION
## Summary
- Add `effective_date` field to Typesense transaction schema for sorting support
- Set `EffectiveDate` to `CreatedAt` when nil during transaction creation
- Add SQL migration to backfill existing NULL `effective_date` values
- Add tests for effective_date default behavior and schema configuration

> N.B. This backfills all transaction record `effective_date`, and also prevents `effective_date` from having a null value when a transaction is created.

## Changes
| File | Change |
|------|--------|
| `sql/1766887982.sql` | Migration to backfill NULL effective_dates with created_at |
| `transaction.go` | Set EffectiveDate = CreatedAt when nil (3 locations) |
| `internal/search/search.go` | Add effective_date to schema + TimeFields |
| `model/transaction_test.go` | Test for GetEffectiveDate helper |
| `effective_date_test.go` | Tests for EffectiveDate default behavior |
| `internal/search/search_test.go` | Tests for Typesense schema configuration |

## Usage
After deployment, clients can sort by effective_date:
```json
{
  "q": "*",
  "sort_by": "effective_date:desc"
}
```

## Test plan
- [x] Run migration - verify existing NULL effective_dates are backfilled
- [x] Create transaction without effective_date - defaults to CreatedAt
- [x] Create transaction with explicit effective_date - uses provided value
- [x] All new tests pass

Closes #223