### PR TITLE
feat: add DisableIndicatorAutoCreate flag to prevent implicit balance…

### DIFF
--- a/balance.go
+++ b/balance.go
@@ -146,6 +146,10 @@ func (l *Blnk) getOrCreateBalanceByIndicator(ctx context.Context, indicator, cur
 
 	balance, err := l.datasource.GetBalanceByIndicator(indicator, currency)
 	if err != nil {
+		if cfg.Transaction.DisableIndicatorAutoCreate {
+			span.RecordError(err)
+			return nil, fmt.Errorf("balance with indicator '%s' not found and auto-creation is disabled", indicator)
+		}
 		span.AddEvent("Creating new balance")
 		balance = &model.Balance{
 			Indicator: indicator,

--- a/config/config.go
+++ b/config/config.go
@@ -162,6 +162,7 @@ type TransactionConfig struct {
 	EnableCoalescing           bool          `json:"enable_coalescing" envconfig:"BLNK_TRANSACTION_ENABLE_COALESCING"`
 	EnableQueuedChecks         bool          `json:"enable_queued_checks" envconfig:"BLNK_TRANSACTION_ENABLE_QUEUED_CHECKS"`
 	DisableBatchReferenceCheck bool          `json:"disable_batch_reference_check" envconfig:"BLNK_TRANSACTION_DISABLE_BATCH_REFERENCE_CHECK"`
+	DisableIndicatorAutoCreate bool          `json:"disable_indicator_auto_create" envconfig:"BLNK_TRANSACTION_DISABLE_INDICATOR_AUTO_CREATE"`
 }
 
 type ReconciliationConfig struct {


### PR DESCRIPTION
### Protecting Money Supply Consistency

When using the @indicator syntax in transactions, the system automatically created a new balance if it didn't exist. This behavior is convenient during initial setup, but in a production environment, it poses a risk: an accidental typo in the indicator name or an intentional reference to a non-existent balance would silently create a new balance and credit funds "out of thin air"—without an appropriate source.

The **disable_indicator_auto_create: true** flag switches the system to strict mode: if a balance with the specified indicator isn't found, the transaction is rejected with an error. All balances must be explicitly created via the API before settlement. This ensures that the overall money supply in the system is changed only through explicit and controlled transactions.