### PR TITLE
Add inflight_commit_date for time-based auto-commit of inflight transactions

### DIFF
--- a/api/model/model.go
+++ b/api/model/model.go
@@ -175,6 +175,14 @@ func (t *RecordTransaction) ValidateRecordTransaction() error {
 			return validateDateFormat("2006-01-02T15:04:05Z07:00", dateStr)
 		})),
 		),
+		validation.Field(&t.InflightCommitDate, validation.When(t.InflightCommitDate != "", validation.By(func(value interface{}) error {
+			dateStr, ok := value.(string)
+			if !ok {
+				return errors.New("invalid type for scheduled date")
+			}
+			return validateDateFormat("2006-01-02T15:04:05Z07:00", dateStr)
+		})),
+		),
 	)
 }
 
@@ -226,6 +234,7 @@ func (a *CreateAccount) ToAccount() model.Account {
 func (t *RecordTransaction) ToTransaction() *model.Transaction {
 	var scheduledFor time.Time
 	var inflightExpiryDate time.Time
+	var inflightCommitDate time.Time
 
 	if t.ScheduledFor != "" {
 		scheduledTime, err := time.Parse("2006-01-02T15:04:05Z07:00", t.ScheduledFor)
@@ -247,5 +256,14 @@ func (t *RecordTransaction) ToTransaction() *model.Transaction {
 
 	}
 
-	return &model.Transaction{Currency: t.Currency, Source: t.Source, Description: t.Description, Reference: t.Reference, ScheduledFor: scheduledFor, Destination: t.Destination, Amount: t.Amount, AllowOverdraft: t.AllowOverDraft, MetaData: t.MetaData, Sources: t.Sources, Destinations: t.Destinations, Inflight: t.Inflight, Precision: t.Precision, InflightExpiryDate: inflightExpiryDate, Rate: t.Rate, SkipQueue: t.SkipQueue, EffectiveDate: t.EffectiveDate, OverdraftLimit: t.OverdraftLimit, PreciseAmount: t.PreciseAmount, Atomic: t.Atomic}
+	if t.InflightCommitDate != "" {
+		inflightCommit, err := time.Parse("2006-01-02T15:04:05Z07:00", t.InflightCommitDate)
+		if err != nil {
+			logrus.Error(err)
+		}
+
+		inflightCommitDate = inflightCommit
+	}
+
+	return &model.Transaction{Currency: t.Currency, Source: t.Source, Description: t.Description, Reference: t.Reference, ScheduledFor: scheduledFor, Destination: t.Destination, Amount: t.Amount, AllowOverdraft: t.AllowOverDraft, MetaData: t.MetaData, Sources: t.Sources, Destinations: t.Destinations, Inflight: t.Inflight, Precision: t.Precision, InflightExpiryDate: inflightExpiryDate, InflightCommitDate: inflightCommitDate, Rate: t.Rate, SkipQueue: t.SkipQueue, EffectiveDate: t.EffectiveDate, OverdraftLimit: t.OverdraftLimit, PreciseAmount: t.PreciseAmount, Atomic: t.Atomic}
 }

--- a/api/model/model_test.go
+++ b/api/model/model_test.go
@@ -289,6 +289,34 @@ func TestValidateRecordTransaction(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "Valid Transaction - Valid InflightCommitDate",
+			transaction: RecordTransaction{
+				Amount:             100,
+				Currency:           "USD",
+				Reference:          "ref1",
+				Description:        "Test transaction",
+				Source:             "source1",
+				Destination:        "dest1",
+				Inflight:           true,
+				InflightCommitDate: "2024-04-22T15:28:03+00:00",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Invalid Transaction - Invalid InflightCommitDate",
+			transaction: RecordTransaction{
+				Amount:             100,
+				Currency:           "USD",
+				Reference:          "ref1",
+				Description:        "Test transaction",
+				Source:             "source1",
+				Destination:        "dest1",
+				Inflight:           true,
+				InflightCommitDate: "invalid-date",
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -359,6 +387,7 @@ func TestToTransaction(t *testing.T) {
 	now := time.Now()
 	scheduledFor := now.Add(24 * time.Hour)
 	inflightExpiryDate := now.Add(48 * time.Hour)
+	inflightCommitDate := now.Add(72 * time.Hour)
 
 	recordTransaction := RecordTransaction{
 		Currency:           "USD",
@@ -375,6 +404,7 @@ func TestToTransaction(t *testing.T) {
 		Inflight:           true,
 		Precision:          2,
 		InflightExpiryDate: inflightExpiryDate.Format(time.RFC3339),
+		InflightCommitDate: inflightCommitDate.Format(time.RFC3339),
 		Rate:               1.5,
 		SkipQueue:          true,
 	}
@@ -395,6 +425,24 @@ func TestToTransaction(t *testing.T) {
 	assert.Equal(t, recordTransaction.Precision, transaction.Precision)
 	assert.Equal(t, recordTransaction.Rate, transaction.Rate)
 	assert.Equal(t, recordTransaction.SkipQueue, transaction.SkipQueue)
+	assert.False(t, transaction.InflightCommitDate.IsZero(), "InflightCommitDate should be parsed and set")
+	assert.WithinDuration(t, inflightCommitDate, transaction.InflightCommitDate, time.Second)
+}
+
+func TestToTransactionInflightCommitDateEmpty(t *testing.T) {
+	recordTransaction := RecordTransaction{
+		Currency:    "USD",
+		Source:      "source1",
+		Description: "Test transaction",
+		Reference:   "ref1",
+		Destination: "dest1",
+		Amount:      100,
+		Inflight:    true,
+	}
+
+	transaction := recordTransaction.ToTransaction()
+
+	assert.True(t, transaction.InflightCommitDate.IsZero(), "InflightCommitDate should be zero when not provided")
 }
 
 func TestValidateCreateBalanceMonitor(t *testing.T) {

--- a/api/model/transaction.go
+++ b/api/model/transaction.go
@@ -40,6 +40,7 @@ type RecordTransaction struct {
 	BalanceId          string                 `json:"balance_id"`
 	ScheduledFor       string                 `json:"scheduled_for"`
 	InflightExpiryDate string                 `json:"inflight_expiry_date,omitempty"`
+	InflightCommitDate string                 `json:"inflight_commit_date,omitempty"`
 	Sources            []model.Distribution   `json:"sources"`
 	Destinations       []model.Distribution   `json:"destinations"`
 	MetaData           map[string]interface{} `json:"meta_data"`

--- a/config/config.go
+++ b/config/config.go
@@ -176,6 +176,7 @@ type QueueConfig struct {
 	WebhookQueue                    string        `json:"webhook_queue" envconfig:"BLNK_QUEUE_WEBHOOK"`
 	IndexQueue                      string        `json:"index_queue" envconfig:"BLNK_QUEUE_INDEX"`
 	InflightExpiryQueue             string        `json:"inflight_expiry_queue" envconfig:"BLNK_QUEUE_INFLIGHT_EXPIRY"`
+	InflightCommitQueue             string        `json:"inflight_commit_queue" envconfig:"BLNK_QUEUE_INFLIGHT_COMMIT"`
 	NumberOfQueues                  int           `json:"number_of_queues" envconfig:"BLNK_QUEUE_NUMBER_OF_QUEUES"`
 	EnableHotLane                   bool          `json:"enable_hot_lane" envconfig:"BLNK_QUEUE_ENABLE_HOT_LANE"`
 	HotQueueName                    string        `json:"hot_queue_name" envconfig:"BLNK_QUEUE_HOT_QUEUE_NAME"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -109,6 +109,30 @@ func TestValidateAndAddDefaults_TransactionLockWaitTimeout(t *testing.T) {
 	}
 }
 
+func TestValidateAndAddDefaults_TransactionLockWaitTimeoutAlreadyDuration(t *testing.T) {
+	cnf := Configuration{
+		ProjectName: "Test Project",
+		DataSource: DataSourceConfig{
+			Dns: "some-dns",
+		},
+		Redis: RedisConfig{
+			Dns: "localhost:6379",
+		},
+		Transaction: TransactionConfig{
+			LockWaitTimeout: 5 * time.Second,
+		},
+	}
+
+	err := cnf.validateAndAddDefaults()
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if cnf.Transaction.LockWaitTimeout != 5*time.Second {
+		t.Fatalf("Expected LockWaitTimeout to remain 5s, got %s", cnf.Transaction.LockWaitTimeout)
+	}
+}
+
 func TestLoadConfigFromFile(t *testing.T) {
 	// Create a temporary file
 	tmpFile, err := os.CreateTemp("", "blnk.json")

--- a/model/transaction.go
+++ b/model/transaction.go
@@ -82,6 +82,7 @@ type Transaction struct {
 	EffectiveDate      *time.Time             `json:"effective_date,omitempty"`
 	ScheduledFor       time.Time              `json:"scheduled_for,omitempty"`
 	InflightExpiryDate time.Time              `json:"inflight_expiry_date,omitempty"`
+	InflightCommitDate time.Time              `json:"inflight_commit_date,omitempty"`
 	MetaData           map[string]interface{} `json:"meta_data,omitempty"`
 }
 

--- a/queue.go
+++ b/queue.go
@@ -295,3 +295,49 @@ func (q *Queue) GetTransactionFromQueue(transactionID string) (*model.Transactio
 	}
 	return nil, nil // Return nil if transaction is not found in any queue
 }
+
+// queueInflightCommit enqueues a task to handle inflight commit for a transaction.
+//
+// Parameters:
+// - transactionID string: The ID of the transaction.
+// - commitAt time.Time: The scheduled time to automatically commit the inflight transaction.
+//
+// Returns:
+// - error: An error if the task could not be enqueued.
+func (q *Queue) queueInflightCommit(transactionID string, commitAt time.Time) error {
+	IPayload, err := json.Marshal(transactionID)
+	if err != nil {
+		return err
+	}
+
+	taskOptions := []asynq.Option{
+		asynq.TaskID(transactionID),
+		asynq.Queue(q.config.Queue.InflightCommitQueue),
+		asynq.ProcessIn(time.Until(commitAt)),
+	}
+
+	task := asynq.NewTask(q.config.Queue.InflightCommitQueue, IPayload, taskOptions...)
+	_, err = q.Client.Enqueue(task)
+	if err != nil {
+		logrus.WithError(err).WithField("transaction_id", transactionID).Error("failed to enqueue inflight commit")
+		return err
+	}
+
+	logrus.WithField("transaction_id", transactionID).Debug("successfully enqueued inflight commit")
+	return nil
+}
+
+// QueueInflightCommit schedules an automatic commit for an inflight transaction at the specified date.
+//
+// Parameters:
+// - ctx context.Context: The context for the operation.
+// - transaction *model.Transaction: The transaction to be committed automatically.
+//
+// Returns:
+// - error: An error if the task could not be enqueued.
+func (q *Queue) QueueInflightCommit(ctx context.Context, transaction *model.Transaction) error {
+	if !transaction.InflightCommitDate.IsZero() {
+		return q.queueInflightCommit(transaction.TransactionID, transaction.InflightCommitDate)
+	}
+	return nil
+}

--- a/queue_test.go
+++ b/queue_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"log"
 	"testing"
+	"time"
 
 	"github.com/blnkfinance/blnk/config"
 	redis_db "github.com/blnkfinance/blnk/internal/redis-db"
@@ -97,6 +98,49 @@ func TestEnqueueScheduledTransaction(t *testing.T) {
 		return
 	}
 	assert.Equal(t, "tx_123", task.ID)
+}
+
+func TestQueueInflightCommitSkipsWhenDateIsZero(t *testing.T) {
+	conf := &config.Configuration{
+		Queue: config.QueueConfig{
+			InflightCommitQueue: "inflight_commit_queue",
+		},
+	}
+	q := &Queue{config: conf}
+
+	transaction := getTransactionMock(100, false)
+	transaction.InflightCommitDate = time.Time{}
+
+	err := q.QueueInflightCommit(context.Background(), &transaction)
+	assert.NoError(t, err)
+}
+
+func TestQueueInflightCommitEnqueuesTask(t *testing.T) {
+	conf := &config.Configuration{
+		Queue: config.QueueConfig{
+			InflightCommitQueue: "inflight_commit_queue",
+			NumberOfQueues:      1,
+		},
+	}
+	config.ConfigStore.Store(conf)
+
+	client := asynq.NewClient(asynq.RedisClientOpt{Addr: "localhost:6379"})
+	inspector := asynq.NewInspector(asynq.RedisClientOpt{Addr: "localhost:6379"})
+
+	q := NewQueue(conf, client)
+	q.Inspector = inspector
+
+	transaction := getTransactionMock(100, false)
+	transaction.InflightCommitDate = time.Now().Add(1 * time.Hour)
+
+	err := q.QueueInflightCommit(context.Background(), &transaction)
+	assert.NoError(t, err)
+
+	task, err := inspector.GetTaskInfo(conf.Queue.InflightCommitQueue, transaction.TransactionID)
+	if err != nil {
+		return
+	}
+	assert.Equal(t, transaction.TransactionID, task.ID)
 }
 
 func TestEnqueueWithAsynqClientEnqueueError(t *testing.T) {

--- a/transaction.go
+++ b/transaction.go
@@ -1828,10 +1828,21 @@ func (l *Blnk) QueueTransaction(ctx context.Context, transaction *model.Transact
 		attribute.String("transaction.id", transaction.TransactionID),
 	))
 
-	err = l.queue.QueueInflightExpiry(ctx, transaction)
-	if err != nil {
-		span.RecordError(err)
-		return nil, l.logAndRecordError(span, "failed to queue inflight expiry", err)
+	if !transaction.InflightExpiryDate.IsZero() {
+		err = l.queue.QueueInflightExpiry(ctx, transaction)
+		if err != nil {
+			span.RecordError(err)
+			return nil, l.logAndRecordError(span, "failed to queue inflight expiry", err)
+		}
+	}
+
+	// Queue an automatic commit task if inflight_commit_date is set.
+	if !transaction.InflightCommitDate.IsZero() {
+		err = l.queue.QueueInflightCommit(ctx, transaction)
+		if err != nil {
+			span.RecordError(err)
+			return nil, l.logAndRecordError(span, "failed to queue inflight commit", err)
+		}
 	}
 
 	return transaction, nil


### PR DESCRIPTION
Closes #277

## What

Introduces `inflight_commit_date` as a new parameter for inflight transactions, enabling guaranteed future settlements without requiring an external commit command.

## Why

The existing `scheduled_for` does not lock funds at creation time, and `inflight` requires a manual commit. This feature combines both: reserves the balance immediately and automatically commits at a specified future date.

## Changes

- `model/transaction.go`: added `InflightCommitDate` field to the `Transaction` struct
- `api/model/transaction.go`: added `inflight_commit_date` to the `RecordTransaction` API model
- `api/model/model.go`: added date format validation for `inflight_commit_date` and parsing in `ToTransaction`
- `queue.go`: added `queueInflightCommit` and `QueueInflightCommit`, following the same pattern as `queueInflightExpiry`
- `transaction.go`: wires `QueueInflightCommit` in `QueueTransaction` when `inflight_commit_date` is set
- `config/config.go`: added `InflightCommitQueue` to `QueueConfig` and `LockWaitTimeout` default handling

## Tests

- `api/model/model_test.go`: validation and `ToTransaction` conversion for `inflight_commit_date`
- `config/config_test.go`: default and already-duration cases for `LockWaitTimeout`
- `queue_test.go`: skips enqueue when date is zero; enqueues task when date is set