### PR TITLE
fix(filter): reject unknown filter operators instead of silently dropping the filter

### DIFF
--- a/internal/filter/filter_test.go
+++ b/internal/filter/filter_test.go
@@ -325,6 +325,57 @@ func TestValidate(t *testing.T) {
 			t.Error("expected error for invalid logical_operator")
 		}
 	})
+
+	t.Run("rejects unknown filter operator", func(t *testing.T) {
+		// e.g. clients sending "equals" instead of "eq" used to be silently
+		// dropped, leaving the query unfiltered (issue #282).
+		filters := &QueryFilterSet{
+			Filters: []QueryFilter{
+				{Field: "status", Operator: Operator("equals"), Value: "APPLIED"},
+			},
+		}
+
+		err := Validate(filters, "transactions")
+		if err == nil {
+			t.Error("expected error for unknown operator 'equals'")
+		}
+	})
+
+	t.Run("rejects empty filter operator", func(t *testing.T) {
+		filters := &QueryFilterSet{
+			Filters: []QueryFilter{
+				{Field: "status", Operator: Operator(""), Value: "APPLIED"},
+			},
+		}
+
+		err := Validate(filters, "transactions")
+		if err == nil {
+			t.Error("expected error for empty operator")
+		}
+	})
+}
+
+func TestIsValidOperator(t *testing.T) {
+	valid := []Operator{
+		OpEqual, OpNotEqual,
+		OpGreaterThan, OpGreaterThanOrEqual,
+		OpLessThan, OpLessThanOrEqual,
+		OpIn, OpBetween,
+		OpLike, OpILike,
+		OpIsNull, OpIsNotNull,
+	}
+	for _, op := range valid {
+		if !IsValidOperator(op) {
+			t.Errorf("expected %q to be a valid operator", op)
+		}
+	}
+
+	invalid := []Operator{"", "equals", "EQ", "==", "not_equals", "contains"}
+	for _, op := range invalid {
+		if IsValidOperator(op) {
+			t.Errorf("expected %q to be invalid", op)
+		}
+	}
 }
 
 func TestValidateSortField(t *testing.T) {
@@ -587,6 +638,23 @@ func TestBuild(t *testing.T) {
 		_, err := Build(filters, "transactions", "t", 1)
 		if err == nil {
 			t.Error("expected error for invalid field")
+		}
+	})
+
+	t.Run("returns error for unknown operator instead of silently dropping filter", func(t *testing.T) {
+		// Regression for issue #282: a filter with an unknown operator (e.g.
+		// "equals" rather than "eq") used to fall through buildStandardCondition's
+		// default branch, returning an empty condition. The filter was silently
+		// dropped and the query ran unfiltered, returning a misleading first row.
+		filters := &QueryFilterSet{
+			Filters: []QueryFilter{
+				{Field: "status", Operator: Operator("equals"), Value: "APPLIED"},
+			},
+		}
+
+		_, err := Build(filters, "transactions", "t", 1)
+		if err == nil {
+			t.Error("expected error for unknown operator 'equals'; instead the filter was likely silently dropped")
 		}
 	})
 }

--- a/internal/filter/operators.go
+++ b/internal/filter/operators.go
@@ -47,3 +47,17 @@ func ResolveLogicalOperator(s string) LogicalOperator {
 func IsValidLogicalOperator(op LogicalOperator) bool {
 	return op == "" || op == LogicalAnd || op == LogicalOr
 }
+
+// IsValidOperator reports whether op is one of the supported filter operators.
+func IsValidOperator(op Operator) bool {
+	switch op {
+	case OpEqual, OpNotEqual,
+		OpGreaterThan, OpGreaterThanOrEqual,
+		OpLessThan, OpLessThanOrEqual,
+		OpIn, OpBetween,
+		OpLike, OpILike,
+		OpIsNull, OpIsNotNull:
+		return true
+	}
+	return false
+}

--- a/internal/filter/validation.go
+++ b/internal/filter/validation.go
@@ -23,6 +23,10 @@ func Validate(filters *QueryFilterSet, table string) error {
 	}
 
 	for _, f := range filters.Filters {
+		if !IsValidOperator(f.Operator) {
+			return fmt.Errorf("invalid operator '%s' for field '%s': must be one of eq, ne, gt, gte, lt, lte, in, between, like, ilike, isnull, isnotnull", f.Operator, f.Field)
+		}
+
 		if strings.HasPrefix(f.Field, "meta_data.") && validFields["meta_data"] {
 			jsonKey := strings.TrimPrefix(f.Field, "meta_data.")
 			if !jsonKeyRegex.MatchString(jsonKey) {


### PR DESCRIPTION
## Summary

Closes #282.

When a JSON request body specifies a filter with an unrecognized operator
(e.g. `\"equals\"` instead of `\"eq\"`), the filter package was silently
dropping that filter and running the query unfiltered. Endpoints that
return the first matching row therefore looked successful even though the
user's filter never reached the database.

The reproduction in the issue is exactly this:

```json
{ \"filters\": [ { \"field\": \"meta_data.name\", \"operator\": \"equals\", \"value\": \"...\" } ] }
```

The body parses successfully (operator is just a string), `Validate`
checks logical_operator and field but not the per-filter operator, and
`buildStandardCondition` falls through its `default` branch returning an
empty condition. `Build` skips empty conditions, so the resulting SQL has
no WHERE clause for that filter — the API returns the first row it finds
with no error.

## Fix

- Add `IsValidOperator` in `internal/filter/operators.go`, the
  operator-side counterpart to the existing `IsValidLogicalOperator`.
- Reject unknown operators in `Validate` with a descriptive error that
  lists the supported operators (`eq`, `ne`, `gt`, `gte`, `lt`, `lte`,
  `in`, `between`, `like`, `ilike`, `isnull`, `isnotnull`).
- This propagates as a `400 Bad Request` from any endpoint that calls
  `Build` / `BuildWithOptions`, matching the existing handling of invalid
  fields and invalid logical operators.

The fix is minimal and additive — no signatures changed, no behavior
changes for valid operators, no new error categories.

## Test plan

- [x] New unit tests cover unknown operator (`\"equals\"`) and empty
      operator on both \`Validate\` and \`Build\`.
- [x] New \`TestIsValidOperator\` covers the operator-validation predicate.
- [x] Existing tests still pass (\`go test ./internal/filter/... ./api/...\`).
- [x] Verified regression: stashing the \`Validate\` change makes the new
      tests fail with the silent-drop behavior the issue describes.
- [x] \`go vet ./internal/filter/...\` and \`gofmt -l internal/filter/\` clean.