### PR TITLE
feat(identity): honor caller-supplied identity_id for deterministic creates

### DIFF
--- a/database/identity.go
+++ b/database/identity.go
@@ -24,13 +24,28 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+
 	"github.com/blnkfinance/blnk/internal/apierror"
 	"github.com/blnkfinance/blnk/internal/filter"
 	"github.com/blnkfinance/blnk/model"
 )
 
 // CreateIdentity inserts a new identity record into the database.
-// It generates a unique IdentityID, sets the creation timestamp, and stores the identity metadata.
+//
+// IdentityID handling:
+//   - If the caller supplies identity.IdentityID, it is preserved as-is.
+//     The value must carry the canonical "idt_" prefix followed by a valid
+//     UUID; otherwise the request is rejected with a 400. This lets callers
+//     derive deterministic identity ids (e.g. UUIDv5 of an external holder
+//     key) and rely on the UNIQUE constraint on identity_id for safe
+//     concurrent creation: parallel requests for the same external holder
+//     produce identical ids, one wins the insert, the others receive 409
+//     Conflict and can fetch the existing row.
+//   - If identity.IdentityID is empty, a fresh id is generated (existing
+//     behaviour).
+//
 // Parameters:
 // - identity: The identity object to be inserted.
 // Returns:
@@ -42,8 +57,17 @@ func (d Datasource) CreateIdentity(identity model.Identity) (model.Identity, err
 		return identity, apierror.NewAPIError(apierror.ErrInternalServer, "Failed to marshal metadata", err)
 	}
 
-	// Generate a unique identity ID and set the creation timestamp
-	identity.IdentityID = model.GenerateUUIDWithSuffix("idt")
+	// Honor a caller-supplied id when present; otherwise generate one.
+	if identity.IdentityID == "" {
+		identity.IdentityID = model.GenerateUUIDWithSuffix("idt")
+	} else {
+		if !strings.HasPrefix(identity.IdentityID, "idt_") {
+			return identity, apierror.NewAPIError(apierror.ErrBadRequest, "identity_id must start with the 'idt_' prefix", nil)
+		}
+		if _, err := uuid.Parse(strings.TrimPrefix(identity.IdentityID, "idt_")); err != nil {
+			return identity, apierror.NewAPIError(apierror.ErrBadRequest, "identity_id suffix after 'idt_' must be a valid UUID", err)
+		}
+	}
 	identity.CreatedAt = time.Now()
 
 	// Insert the identity record into the database
@@ -51,8 +75,13 @@ func (d Datasource) CreateIdentity(identity model.Identity) (model.Identity, err
 		INSERT INTO blnk.identity (identity_id, identity_type, first_name, last_name, other_names, gender, dob, email_address, phone_number, nationality, organization_name, category, street, country, state, post_code, city, created_at, meta_data)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)
 	`, identity.IdentityID, identity.IdentityType, identity.FirstName, identity.LastName, identity.OtherNames, identity.Gender, identity.DOB, identity.EmailAddress, identity.PhoneNumber, identity.Nationality, identity.OrganizationName, identity.Category, identity.Street, identity.Country, identity.State, identity.PostCode, identity.City, identity.CreatedAt, metaDataJSON)
-	// Handle any errors that occur during insertion
 	if err != nil {
+		// Surface unique_violation on identity_id as 409 so callers using
+		// deterministic ids can detect "already created by a concurrent
+		// request" and fetch the existing row.
+		if pqErr, ok := err.(*pq.Error); ok && pqErr.Code.Name() == "unique_violation" {
+			return identity, apierror.NewAPIError(apierror.ErrConflict, fmt.Sprintf("Identity already exists: %s", identity.IdentityID), err)
+		}
 		return identity, apierror.NewAPIError(apierror.ErrInternalServer, "Failed to create identity", err)
 	}
 

--- a/database/identity_test.go
+++ b/database/identity_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/blnkfinance/blnk/internal/apierror"
 	"github.com/blnkfinance/blnk/model"
+	"github.com/lib/pq"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -91,6 +92,105 @@ func TestCreateIdentity_Fail(t *testing.T) {
 	_, err = ds.CreateIdentity(identity)
 	assert.Error(t, err)
 	assert.Equal(t, apierror.ErrInternalServer, err.(apierror.APIError).Code)
+}
+
+func TestCreateIdentity_CallerSuppliedID_Preserved(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	ds := Datasource{Conn: db}
+
+	const callerID = "idt_8c5a8e2f-3f1d-5a9b-9c3e-4d8f1e5a7b2c"
+	identity := model.Identity{
+		IdentityID:   callerID,
+		IdentityType: "individual",
+		FirstName:    "John",
+		LastName:     "Doe",
+	}
+
+	mock.ExpectExec("INSERT INTO blnk.identity").
+		WithArgs(callerID, identity.IdentityType, identity.FirstName, identity.LastName, sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	created, err := ds.CreateIdentity(identity)
+	assert.NoError(t, err)
+	assert.Equal(t, callerID, created.IdentityID, "caller-supplied identity_id must be preserved")
+}
+
+func TestCreateIdentity_CallerSuppliedID_BadPrefix(t *testing.T) {
+	db, _, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	ds := Datasource{Conn: db}
+
+	identity := model.Identity{
+		IdentityID:   "user_123", // missing idt_ prefix
+		IdentityType: "individual",
+		FirstName:    "John",
+		LastName:     "Doe",
+	}
+
+	_, err = ds.CreateIdentity(identity)
+	assert.Error(t, err)
+	assert.Equal(t, apierror.ErrBadRequest, err.(apierror.APIError).Code)
+}
+
+func TestCreateIdentity_CallerSuppliedID_BadUUID(t *testing.T) {
+	db, _, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	ds := Datasource{Conn: db}
+
+	cases := []string{
+		"idt_",                                       // empty suffix
+		"idt_not-a-uuid",                             // non-UUID suffix
+		"idt_8c5a8e2f-3f1d-5a9b-9c3e-4d8f1e5a7b2",    // truncated UUID
+		"idt_8c5a8e2f-3f1d-5a9b-9c3e-4d8f1e5a7b2cZZ", // trailing garbage
+		"idt_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",   // non-hex chars
+	}
+
+	for _, id := range cases {
+		identity := model.Identity{
+			IdentityID:   id,
+			IdentityType: "individual",
+			FirstName:    "John",
+			LastName:     "Doe",
+		}
+		_, err := ds.CreateIdentity(identity)
+		assert.Error(t, err, "expected error for id %q", id)
+		if apiErr, ok := err.(apierror.APIError); ok {
+			assert.Equal(t, apierror.ErrBadRequest, apiErr.Code, "expected 400 for id %q", id)
+		} else {
+			t.Errorf("expected apierror.APIError for id %q, got %T", id, err)
+		}
+	}
+}
+
+func TestCreateIdentity_CallerSuppliedID_DuplicateConflict(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	ds := Datasource{Conn: db}
+
+	const callerID = "idt_8c5a8e2f-3f1d-5a9b-9c3e-4d8f1e5a7b2c"
+	identity := model.Identity{
+		IdentityID:   callerID,
+		IdentityType: "individual",
+		FirstName:    "John",
+		LastName:     "Doe",
+	}
+
+	mock.ExpectExec("INSERT INTO blnk.identity").
+		WithArgs(callerID, identity.IdentityType, identity.FirstName, identity.LastName, sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnError(&pq.Error{Code: "23505", Message: "unique_violation"})
+
+	_, err = ds.CreateIdentity(identity)
+	assert.Error(t, err)
+	assert.Equal(t, apierror.ErrConflict, err.(apierror.APIError).Code)
 }
 
 func TestGetIdentityByID_NotFound(t *testing.T) {


### PR DESCRIPTION
## Summary

`CreateIdentity` unconditionally overwrites `identity.IdentityID` with a freshly generated UUID ([`database/identity.go:46`](https://github.com/blnkfinance/blnk/blob/main/database/identity.go#L46)), so callers cannot derive a deterministic identity id from external state (e.g. a UUIDv5 of an external holder key) and rely on the existing `UNIQUE` constraint on `identity_id` to safely deduplicate concurrent creates.

Today two parallel requests for the same external entity produce two distinct identity rows in `blnk.identity` — the server has no other dedup mechanism (no `UNIQUE` on email/phone/name, no SELECT-before-INSERT, no `ON CONFLICT`), so duplicates accumulate silently. See #286 for the full bug report and reproduction.

This PR:

- **Preserves `identity.IdentityID` when supplied; generates one only when empty.** Fully backward compatible — existing callers send no id and get the same behaviour as today.
- **Validates that a supplied id carries the canonical `idt_` prefix** and rejects mismatches with `400 BAD_REQUEST`, keeping the id-format invariant the rest of the codebase assumes.
- **Maps PostgreSQL `unique_violation` on `identity_id` to `409 CONFLICT`** so callers using deterministic ids can detect "another concurrent request won the race" and fetch the existing row. This mirrors the established pattern in [`database/balance.go:274-278`](https://github.com/blnkfinance/blnk/blob/main/database/balance.go#L274) and [`database/ledger.go:62-63`](https://github.com/blnkfinance/blnk/blob/main/database/ledger.go#L62).

Closes #286.

## Test plan

- [x] `TestCreateIdentity_Success` — existing behaviour unchanged (empty id → generated)
- [x] `TestCreateIdentity_Fail` — existing error path unchanged
- [x] `TestCreateIdentity_CallerSuppliedID_Preserved` — supplied id round-trips
- [x] `TestCreateIdentity_CallerSuppliedID_BadPrefix` — non-`idt_` prefix → 400
- [x] `TestCreateIdentity_CallerSuppliedID_DuplicateConflict` — `unique_violation` → 409
- [x] `go build ./...` clean
- [x] Full `go test ./database/` clean (excluding pre-existing real-Postgres connection tests)

## Notes

No migration required — the `UNIQUE` constraint on `identity_id` already exists ([`sql/1708676327.sql:32`](https://github.com/blnkfinance/blnk/blob/main/sql/1708676327.sql#L32)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)