### PR TITLE
feat(inflight): add bulk void/commit endpoints for independently-created inflight transactions

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -79,8 +79,8 @@ func (a Api) Router() *gin.Engine {
 	router.GET("/transactions/:id", a.GetTransaction)
 	router.GET("/transactions/reference/:reference", a.GetTransactionByRef)
 	router.PUT("/transactions/inflight/:txID", a.UpdateInflightStatus)
-	router.POST("/transactions/inflight/bulk-void", a.BulkVoidInflight)
-	router.POST("/transactions/inflight/bulk-commit", a.BulkCommitInflight)
+	router.POST("/transactions/inflight/bulk/void", a.BulkVoidInflight)
+	router.POST("/transactions/inflight/bulk/commit", a.BulkCommitInflight)
 	router.GET("/transactions/:id/lineage", a.GetTransactionLineage)
 
 	// Recovery routes

--- a/api/api.go
+++ b/api/api.go
@@ -79,6 +79,8 @@ func (a Api) Router() *gin.Engine {
 	router.GET("/transactions/:id", a.GetTransaction)
 	router.GET("/transactions/reference/:reference", a.GetTransactionByRef)
 	router.PUT("/transactions/inflight/:txID", a.UpdateInflightStatus)
+	router.POST("/transactions/inflight/bulk-void", a.BulkVoidInflight)
+	router.POST("/transactions/inflight/bulk-commit", a.BulkCommitInflight)
 	router.GET("/transactions/:id/lineage", a.GetTransactionLineage)
 
 	// Recovery routes

--- a/api/model/transaction.go
+++ b/api/model/transaction.go
@@ -54,7 +54,7 @@ type InflightUpdate struct {
 }
 
 // MaxBulkInflightItems caps the number of transactions accepted in a single
-// bulk-commit or bulk-void call. Bulk calls are processed synchronously, so
+// bulk commit or bulk void call. Bulk calls are processed synchronously, so
 // the cap exists to keep request latency and lock-holding bounded.
 const MaxBulkInflightItems = 100
 
@@ -66,7 +66,7 @@ type BulkInflightVoidRequest struct {
 	TransactionIDs []string `json:"transaction_ids"`
 }
 
-// BulkInflightCommitItem describes one transaction in a bulk-commit request.
+// BulkInflightCommitItem describes one transaction in a bulk commit request.
 // Amount/PreciseAmount carry the same semantics as the single-tx endpoint:
 // zero means commit the full remaining inflight amount; non-zero performs a
 // partial commit. PreciseAmount, when set, wins over Amount.
@@ -80,7 +80,7 @@ type BulkInflightCommitItem struct {
 // transactions in one call. Unlike the void variant, each item can carry
 // its own amount for partial commits.
 type BulkInflightCommitRequest struct {
-	Items []BulkInflightCommitItem `json:"items"`
+	Transactions []BulkInflightCommitItem `json:"transactions"`
 }
 
 // BulkInflightResult is the per-item outcome reported in BulkInflightResponse.

--- a/api/model/transaction.go
+++ b/api/model/transaction.go
@@ -52,3 +52,52 @@ type InflightUpdate struct {
 	Amount        float64  `json:"amount"`
 	PreciseAmount *big.Int `json:"precise_amount,omitempty"`
 }
+
+// MaxBulkInflightItems caps the number of transactions accepted in a single
+// bulk-commit or bulk-void call. Bulk calls are processed synchronously, so
+// the cap exists to keep request latency and lock-holding bounded.
+const MaxBulkInflightItems = 100
+
+// BulkInflightVoidRequest voids many independently-created inflight
+// transactions in one call. Each id is processed independently; partial
+// failures are reported per-item in the response and do not abort the rest
+// of the batch.
+type BulkInflightVoidRequest struct {
+	TransactionIDs []string `json:"transaction_ids"`
+}
+
+// BulkInflightCommitItem describes one transaction in a bulk-commit request.
+// Amount/PreciseAmount carry the same semantics as the single-tx endpoint:
+// zero means commit the full remaining inflight amount; non-zero performs a
+// partial commit. PreciseAmount, when set, wins over Amount.
+type BulkInflightCommitItem struct {
+	TransactionID string   `json:"transaction_id"`
+	Amount        float64  `json:"amount,omitempty"`
+	PreciseAmount *big.Int `json:"precise_amount,omitempty"`
+}
+
+// BulkInflightCommitRequest commits many independently-created inflight
+// transactions in one call. Unlike the void variant, each item can carry
+// its own amount for partial commits.
+type BulkInflightCommitRequest struct {
+	Items []BulkInflightCommitItem `json:"items"`
+}
+
+// BulkInflightResult is the per-item outcome reported in BulkInflightResponse.
+// On success Status == "succeeded" and Code is empty. On failure Status ==
+// "failed" with a stable Code (e.g. "ALREADY_VOIDED", "NOT_FOUND") that
+// callers can branch on, plus a human-readable Message.
+type BulkInflightResult struct {
+	TransactionID string `json:"transaction_id"`
+	Status        string `json:"status"`
+	Code          string `json:"code,omitempty"`
+	Message       string `json:"message,omitempty"`
+}
+
+// BulkInflightResponse is the envelope returned by both bulk endpoints.
+// Succeeded + Failed == len(Results).
+type BulkInflightResponse struct {
+	Succeeded int                  `json:"succeeded"`
+	Failed    int                  `json:"failed"`
+	Results   []BulkInflightResult `json:"results"`
+}

--- a/api/transaction_api_test.go
+++ b/api/transaction_api_test.go
@@ -32,6 +32,7 @@ import (
 	redis_db "github.com/blnkfinance/blnk/internal/redis-db"
 	"github.com/blnkfinance/blnk/internal/request"
 	"github.com/brianvoe/gofakeit/v6"
+	"github.com/gin-gonic/gin"
 	"github.com/hibiken/asynq"
 
 	"github.com/blnkfinance/blnk/model"
@@ -932,4 +933,165 @@ func TestRefundTransaction_API(t *testing.T) {
 // does not depend on the unexported refundTransactionRequest type.
 type refundBody struct {
 	SkipQueue bool `json:"skip_queue"`
+}
+
+// createInflightForBulk is a small helper that mirrors the inflight-creation
+// dance used elsewhere in this file, returning the resulting transaction id.
+func createInflightForBulk(t *testing.T, router *gin.Engine, source, dest, currency string, amount float64) string {
+	t.Helper()
+	payload := model2.RecordTransaction{
+		Amount:         amount,
+		Precision:      100,
+		Reference:      "inflight_bulk_" + gofakeit.UUID(),
+		Description:    "bulk inflight seed",
+		Currency:       currency,
+		Source:         source,
+		Destination:    dest,
+		AllowOverDraft: true,
+		Inflight:       true,
+		SkipQueue:      true,
+	}
+	payloadBytes, _ := request.ToJsonReq(&payload)
+	var resp model.Transaction
+	req := TestRequest{
+		Payload:  payloadBytes,
+		Response: &resp,
+		Method:   "POST",
+		Route:    "/transactions",
+		Router:   router,
+	}
+	rec, err := SetUpTestRequest(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, rec.Code)
+	require.Equal(t, "INFLIGHT", resp.Status)
+	return resp.TransactionID
+}
+
+// TestBulkVoidInflight_Integration end-to-end verifies that the bulk-void
+// endpoint voids N independently-created inflight transactions in one call
+// and reports per-item success in the response body.
+func TestBulkVoidInflight_Integration(t *testing.T) {
+	router, b, err := setupRouter()
+	if err != nil {
+		t.Fatalf("Failed to setup router: %v", err)
+	}
+
+	ctx := context.Background()
+	ledger, err := b.CreateLedger(model.Ledger{Name: gofakeit.Name()})
+	assert.NoError(t, err)
+
+	src, err := b.CreateBalance(ctx, model.Balance{LedgerID: ledger.LedgerID, Currency: "USD"})
+	assert.NoError(t, err)
+	dst, err := b.CreateBalance(ctx, model.Balance{LedgerID: ledger.LedgerID, Currency: "USD"})
+	assert.NoError(t, err)
+
+	// 1. Create 3 independent inflight transactions
+	ids := []string{
+		createInflightForBulk(t, router, src.BalanceID, dst.BalanceID, "USD", 100),
+		createInflightForBulk(t, router, src.BalanceID, dst.BalanceID, "USD", 200),
+		createInflightForBulk(t, router, src.BalanceID, dst.BalanceID, "USD", 50),
+	}
+
+	// 2. Bulk-void them
+	voidReq := model2.BulkInflightVoidRequest{TransactionIDs: ids}
+	voidBytes, _ := request.ToJsonReq(&voidReq)
+	var voidResp model2.BulkInflightResponse
+	rec, err := SetUpTestRequest(TestRequest{
+		Payload:  voidBytes,
+		Response: &voidResp,
+		Method:   "POST",
+		Route:    "/transactions/inflight/bulk-void",
+		Router:   router,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, 3, voidResp.Succeeded)
+	assert.Equal(t, 0, voidResp.Failed)
+	require.Len(t, voidResp.Results, 3)
+	for _, r := range voidResp.Results {
+		assert.Equal(t, "succeeded", r.Status, "transaction %s should have succeeded", r.TransactionID)
+	}
+
+	// 3. Double-void: every id should now report ALREADY_VOIDED (per-item
+	//    idempotency, not a bulk-level error). voidBytes is a *bytes.Buffer
+	//    drained by the first ServeHTTP, so rebuild it for the retry.
+	voidBytes2, _ := request.ToJsonReq(&voidReq)
+	rec2, err := SetUpTestRequest(TestRequest{
+		Payload:  voidBytes2,
+		Response: &voidResp,
+		Method:   "POST",
+		Route:    "/transactions/inflight/bulk-void",
+		Router:   router,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec2.Code)
+	assert.Equal(t, 0, voidResp.Succeeded)
+	assert.Equal(t, 3, voidResp.Failed)
+	for _, r := range voidResp.Results {
+		assert.Equal(t, "failed", r.Status)
+		assert.Equal(t, "ALREADY_VOIDED", r.Code, "expected stable code on retry of voided txn")
+	}
+
+	// 4. Balances are back to zero (all inflight cleared)
+	sb, _ := b.GetBalanceByID(ctx, src.BalanceID, nil, false)
+	db, _ := b.GetBalanceByID(ctx, dst.BalanceID, nil, false)
+	assert.Equal(t, int64(0), sb.InflightBalance.Int64())
+	assert.Equal(t, int64(0), db.InflightBalance.Int64())
+}
+
+// TestBulkCommitInflight_Integration end-to-end verifies that the
+// bulk-commit endpoint commits N independent inflight transactions and
+// surfaces per-id errors (e.g. NOT_FOUND for an unknown id mixed in)
+// without aborting the rest of the batch.
+func TestBulkCommitInflight_Integration(t *testing.T) {
+	router, b, err := setupRouter()
+	if err != nil {
+		t.Fatalf("Failed to setup router: %v", err)
+	}
+
+	cnf, err := config.Fetch()
+	require.NoError(t, err)
+	cleanup := StartTestAsynqWorker(t, cnf, b, fmt.Sprintf("%s_%d", cnf.Queue.TransactionQueue, 1))
+	defer cleanup()
+
+	ctx := context.Background()
+	ledger, err := b.CreateLedger(model.Ledger{Name: gofakeit.Name()})
+	assert.NoError(t, err)
+
+	src, err := b.CreateBalance(ctx, model.Balance{LedgerID: ledger.LedgerID, Currency: "GBP"})
+	assert.NoError(t, err)
+	dst, err := b.CreateBalance(ctx, model.Balance{LedgerID: ledger.LedgerID, Currency: "GBP"})
+	assert.NoError(t, err)
+
+	// 1. Create 2 independent inflight transactions
+	id1 := createInflightForBulk(t, router, src.BalanceID, dst.BalanceID, "GBP", 100)
+	id2 := createInflightForBulk(t, router, src.BalanceID, dst.BalanceID, "GBP", 200)
+
+	// 2. Bulk-commit them, plus a deliberately-unknown id to verify partial
+	//    failure handling.
+	commitReq := model2.BulkInflightCommitRequest{
+		Items: []model2.BulkInflightCommitItem{
+			{TransactionID: id1},
+			{TransactionID: id2},
+			{TransactionID: "txn_does_not_exist"},
+		},
+	}
+	commitBytes, _ := request.ToJsonReq(&commitReq)
+	var resp model2.BulkInflightResponse
+	rec, err := SetUpTestRequest(TestRequest{
+		Payload:  commitBytes,
+		Response: &resp,
+		Method:   "POST",
+		Route:    "/transactions/inflight/bulk-commit",
+		Router:   router,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, 2, resp.Succeeded)
+	assert.Equal(t, 1, resp.Failed)
+	require.Len(t, resp.Results, 3)
+	assert.Equal(t, "succeeded", resp.Results[0].Status)
+	assert.Equal(t, "succeeded", resp.Results[1].Status)
+	assert.Equal(t, "failed", resp.Results[2].Status)
+	assert.Equal(t, "NOT_FOUND", resp.Results[2].Code)
 }

--- a/api/transaction_api_test.go
+++ b/api/transaction_api_test.go
@@ -967,7 +967,7 @@ func createInflightForBulk(t *testing.T, router *gin.Engine, source, dest, curre
 	return resp.TransactionID
 }
 
-// TestBulkVoidInflight_Integration end-to-end verifies that the bulk-void
+// TestBulkVoidInflight_Integration end-to-end verifies that the bulk void
 // endpoint voids N independently-created inflight transactions in one call
 // and reports per-item success in the response body.
 func TestBulkVoidInflight_Integration(t *testing.T) {
@@ -1000,7 +1000,7 @@ func TestBulkVoidInflight_Integration(t *testing.T) {
 		Payload:  voidBytes,
 		Response: &voidResp,
 		Method:   "POST",
-		Route:    "/transactions/inflight/bulk-void",
+		Route:    "/transactions/inflight/bulk/void",
 		Router:   router,
 	})
 	assert.NoError(t, err)
@@ -1020,7 +1020,7 @@ func TestBulkVoidInflight_Integration(t *testing.T) {
 		Payload:  voidBytes2,
 		Response: &voidResp,
 		Method:   "POST",
-		Route:    "/transactions/inflight/bulk-void",
+		Route:    "/transactions/inflight/bulk/void",
 		Router:   router,
 	})
 	assert.NoError(t, err)
@@ -1040,7 +1040,7 @@ func TestBulkVoidInflight_Integration(t *testing.T) {
 }
 
 // TestBulkCommitInflight_Integration end-to-end verifies that the
-// bulk-commit endpoint commits N independent inflight transactions and
+// bulk commit endpoint commits N independent inflight transactions and
 // surfaces per-id errors (e.g. NOT_FOUND for an unknown id mixed in)
 // without aborting the rest of the batch.
 func TestBulkCommitInflight_Integration(t *testing.T) {
@@ -1070,7 +1070,7 @@ func TestBulkCommitInflight_Integration(t *testing.T) {
 	// 2. Bulk-commit them, plus a deliberately-unknown id to verify partial
 	//    failure handling.
 	commitReq := model2.BulkInflightCommitRequest{
-		Items: []model2.BulkInflightCommitItem{
+		Transactions: []model2.BulkInflightCommitItem{
 			{TransactionID: id1},
 			{TransactionID: id2},
 			{TransactionID: "txn_does_not_exist"},
@@ -1082,7 +1082,7 @@ func TestBulkCommitInflight_Integration(t *testing.T) {
 		Payload:  commitBytes,
 		Response: &resp,
 		Method:   "POST",
-		Route:    "/transactions/inflight/bulk-commit",
+		Route:    "/transactions/inflight/bulk/commit",
 		Router:   router,
 	})
 	assert.NoError(t, err)

--- a/api/transaction_bulk_inflight_test.go
+++ b/api/transaction_bulk_inflight_test.go
@@ -32,8 +32,8 @@ func newBulkTestRouter() *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
 	a := Api{} // blnk service intentionally nil; validation paths must not touch it.
-	r.POST("/transactions/inflight/bulk-void", a.BulkVoidInflight)
-	r.POST("/transactions/inflight/bulk-commit", a.BulkCommitInflight)
+	r.POST("/transactions/inflight/bulk/void", a.BulkVoidInflight)
+	r.POST("/transactions/inflight/bulk/commit", a.BulkCommitInflight)
 	return r
 }
 
@@ -51,7 +51,7 @@ func doJSON(r *gin.Engine, method, path string, body interface{}) *httptest.Resp
 
 func TestBulkVoidInflight_RejectsEmptyList(t *testing.T) {
 	r := newBulkTestRouter()
-	w := doJSON(r, "POST", "/transactions/inflight/bulk-void",
+	w := doJSON(r, "POST", "/transactions/inflight/bulk/void",
 		model2.BulkInflightVoidRequest{TransactionIDs: []string{}})
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Contains(t, w.Body.String(), "cannot be empty")
@@ -63,7 +63,7 @@ func TestBulkVoidInflight_RejectsOversizedList(t *testing.T) {
 	for i := range ids {
 		ids[i] = fmt.Sprintf("txn_%d", i)
 	}
-	w := doJSON(r, "POST", "/transactions/inflight/bulk-void",
+	w := doJSON(r, "POST", "/transactions/inflight/bulk/void",
 		model2.BulkInflightVoidRequest{TransactionIDs: ids})
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Contains(t, w.Body.String(), "too many transaction_ids")
@@ -71,7 +71,7 @@ func TestBulkVoidInflight_RejectsOversizedList(t *testing.T) {
 
 func TestBulkVoidInflight_RejectsMalformedJSON(t *testing.T) {
 	r := newBulkTestRouter()
-	req := httptest.NewRequest("POST", "/transactions/inflight/bulk-void",
+	req := httptest.NewRequest("POST", "/transactions/inflight/bulk/void",
 		strings.NewReader(`{"transaction_ids": "not-an-array"}`))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
@@ -81,8 +81,8 @@ func TestBulkVoidInflight_RejectsMalformedJSON(t *testing.T) {
 
 func TestBulkCommitInflight_RejectsEmptyList(t *testing.T) {
 	r := newBulkTestRouter()
-	w := doJSON(r, "POST", "/transactions/inflight/bulk-commit",
-		model2.BulkInflightCommitRequest{Items: nil})
+	w := doJSON(r, "POST", "/transactions/inflight/bulk/commit",
+		model2.BulkInflightCommitRequest{Transactions: nil})
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Contains(t, w.Body.String(), "cannot be empty")
 }
@@ -93,8 +93,8 @@ func TestBulkCommitInflight_RejectsOversizedList(t *testing.T) {
 	for i := range items {
 		items[i] = model2.BulkInflightCommitItem{TransactionID: fmt.Sprintf("txn_%d", i)}
 	}
-	w := doJSON(r, "POST", "/transactions/inflight/bulk-commit",
-		model2.BulkInflightCommitRequest{Items: items})
+	w := doJSON(r, "POST", "/transactions/inflight/bulk/commit",
+		model2.BulkInflightCommitRequest{Transactions: items})
 	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Contains(t, w.Body.String(), "too many items")
+	assert.Contains(t, w.Body.String(), "too many transactions")
 }

--- a/api/transaction_bulk_inflight_test.go
+++ b/api/transaction_bulk_inflight_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2024 Blnk Finance Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+
+	model2 "github.com/blnkfinance/blnk/api/model"
+)
+
+// newBulkTestRouter builds a minimal gin engine wired to the bulk inflight
+// handlers, without going through setupRouter() (which requires Postgres +
+// Redis). The handlers themselves bail at request validation for the cases
+// covered here, so no real service backing is needed.
+func newBulkTestRouter() *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	a := Api{} // blnk service intentionally nil; validation paths must not touch it.
+	r.POST("/transactions/inflight/bulk-void", a.BulkVoidInflight)
+	r.POST("/transactions/inflight/bulk-commit", a.BulkCommitInflight)
+	return r
+}
+
+func doJSON(r *gin.Engine, method, path string, body interface{}) *httptest.ResponseRecorder {
+	var buf bytes.Buffer
+	if body != nil {
+		_ = json.NewEncoder(&buf).Encode(body)
+	}
+	req := httptest.NewRequest(method, path, &buf)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestBulkVoidInflight_RejectsEmptyList(t *testing.T) {
+	r := newBulkTestRouter()
+	w := doJSON(r, "POST", "/transactions/inflight/bulk-void",
+		model2.BulkInflightVoidRequest{TransactionIDs: []string{}})
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "cannot be empty")
+}
+
+func TestBulkVoidInflight_RejectsOversizedList(t *testing.T) {
+	r := newBulkTestRouter()
+	ids := make([]string, model2.MaxBulkInflightItems+1)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("txn_%d", i)
+	}
+	w := doJSON(r, "POST", "/transactions/inflight/bulk-void",
+		model2.BulkInflightVoidRequest{TransactionIDs: ids})
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "too many transaction_ids")
+}
+
+func TestBulkVoidInflight_RejectsMalformedJSON(t *testing.T) {
+	r := newBulkTestRouter()
+	req := httptest.NewRequest("POST", "/transactions/inflight/bulk-void",
+		strings.NewReader(`{"transaction_ids": "not-an-array"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestBulkCommitInflight_RejectsEmptyList(t *testing.T) {
+	r := newBulkTestRouter()
+	w := doJSON(r, "POST", "/transactions/inflight/bulk-commit",
+		model2.BulkInflightCommitRequest{Items: nil})
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "cannot be empty")
+}
+
+func TestBulkCommitInflight_RejectsOversizedList(t *testing.T) {
+	r := newBulkTestRouter()
+	items := make([]model2.BulkInflightCommitItem, model2.MaxBulkInflightItems+1)
+	for i := range items {
+		items[i] = model2.BulkInflightCommitItem{TransactionID: fmt.Sprintf("txn_%d", i)}
+	}
+	w := doJSON(r, "POST", "/transactions/inflight/bulk-commit",
+		model2.BulkInflightCommitRequest{Items: items})
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "too many items")
+}

--- a/api/transactions.go
+++ b/api/transactions.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	blnk "github.com/blnkfinance/blnk"
 	model2 "github.com/blnkfinance/blnk/api/model"
 	"github.com/blnkfinance/blnk/config"
 	"github.com/blnkfinance/blnk/database"
@@ -558,4 +559,129 @@ func (a Api) RecoverQueuedTransactions(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{"recovered": recovered, "threshold": threshold.String()})
+}
+
+// bulkInflightMaxWorkers caps the worker-pool size used by the bulk handlers.
+// 8 is a deliberate compromise: large enough to win meaningful concurrency
+// vs sequential N round-trips, small enough not to flood the lock service or
+// connection pool when many bulk calls are in flight.
+const bulkInflightMaxWorkers = 8
+
+// toAPIResults converts service-layer BulkInflightOutcome values to the
+// public BulkInflightResult shape returned by the handlers.
+func toAPIResults(outcomes []blnk.BulkInflightOutcome) (model2.BulkInflightResponse, int) {
+	resp := model2.BulkInflightResponse{
+		Results: make([]model2.BulkInflightResult, len(outcomes)),
+	}
+	for i, o := range outcomes {
+		r := model2.BulkInflightResult{TransactionID: o.TransactionID}
+		if o.Err == nil {
+			r.Status = "succeeded"
+			resp.Succeeded++
+		} else {
+			r.Status = "failed"
+			r.Code = o.Code
+			r.Message = o.Err.Error()
+			resp.Failed++
+		}
+		resp.Results[i] = r
+	}
+	return resp, resp.Failed
+}
+
+// BulkVoidInflight voids many independently-created inflight transactions
+// in a single call. Each id is processed in its own worker; per-item
+// failures are reported in the response body and do not abort the rest of
+// the batch. Returns 200 with the breakdown even when some items fail.
+//
+// Responses:
+// - 400 Bad Request: malformed payload, empty list, or > MaxBulkInflightItems.
+// - 200 OK: bulk processed; see succeeded/failed counts in body.
+func (a Api) BulkVoidInflight(c *gin.Context) {
+	var req model2.BulkInflightVoidRequest
+	if err := c.BindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if len(req.TransactionIDs) == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "transaction_ids cannot be empty"})
+		return
+	}
+	if len(req.TransactionIDs) > model2.MaxBulkInflightItems {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "too many transaction_ids; max is " + strconv.Itoa(model2.MaxBulkInflightItems),
+		})
+		return
+	}
+
+	items := make([]blnk.BulkInflightItem, len(req.TransactionIDs))
+	for i, id := range req.TransactionIDs {
+		items[i] = blnk.BulkInflightItem{TransactionID: id}
+	}
+
+	outcomes, err := a.blnk.BulkInflightUpdate(c.Request.Context(), blnk.BulkInflightVoid, items, bulkInflightMaxWorkers)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	resp, _ := toAPIResults(outcomes)
+	c.JSON(http.StatusOK, resp)
+}
+
+// BulkCommitInflight commits many independently-created inflight
+// transactions in a single call. Unlike the void variant, each item may
+// carry an optional `amount` / `precise_amount` for partial commits; zero
+// or missing means commit the full remaining inflight amount.
+//
+// Responses:
+// - 400 Bad Request: malformed payload, empty list, or > MaxBulkInflightItems.
+// - 200 OK: bulk processed; see succeeded/failed counts in body.
+func (a Api) BulkCommitInflight(c *gin.Context) {
+	var req model2.BulkInflightCommitRequest
+	if err := c.BindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if len(req.Items) == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "items cannot be empty"})
+		return
+	}
+	if len(req.Items) > model2.MaxBulkInflightItems {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "too many items; max is " + strconv.Itoa(model2.MaxBulkInflightItems),
+		})
+		return
+	}
+
+	cnf, err := config.Fetch()
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	ds, err := database.GetDBConnection(cnf)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	items := make([]blnk.BulkInflightItem, len(req.Items))
+	for i, it := range req.Items {
+		// Match single-tx semantics: precise_amount wins; else apply precision
+		// via the same DB-lookup helper used by UpdateInflightStatus.
+		var amount *big.Int
+		if it.PreciseAmount != nil {
+			amount = it.PreciseAmount
+		} else {
+			amount = model.ApplyPrecisionWithDBLookup(&model.Transaction{Amount: it.Amount, TransactionID: it.TransactionID}, ds.Conn)
+		}
+		items[i] = blnk.BulkInflightItem{TransactionID: it.TransactionID, Amount: amount}
+	}
+
+	outcomes, err := a.blnk.BulkInflightUpdate(c.Request.Context(), blnk.BulkInflightCommit, items, bulkInflightMaxWorkers)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	resp, _ := toAPIResults(outcomes)
+	c.JSON(http.StatusOK, resp)
 }

--- a/api/transactions.go
+++ b/api/transactions.go
@@ -642,13 +642,13 @@ func (a Api) BulkCommitInflight(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	if len(req.Items) == 0 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "items cannot be empty"})
+	if len(req.Transactions) == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "transactions cannot be empty"})
 		return
 	}
-	if len(req.Items) > model2.MaxBulkInflightItems {
+	if len(req.Transactions) > model2.MaxBulkInflightItems {
 		c.JSON(http.StatusBadRequest, gin.H{
-			"error": "too many items; max is " + strconv.Itoa(model2.MaxBulkInflightItems),
+			"error": "too many transactions; max is " + strconv.Itoa(model2.MaxBulkInflightItems),
 		})
 		return
 	}
@@ -664,8 +664,8 @@ func (a Api) BulkCommitInflight(c *gin.Context) {
 		return
 	}
 
-	items := make([]blnk.BulkInflightItem, len(req.Items))
-	for i, it := range req.Items {
+	items := make([]blnk.BulkInflightItem, len(req.Transactions))
+	for i, it := range req.Transactions {
 		// Match single-tx semantics: precise_amount wins; else apply precision
 		// via the same DB-lookup helper used by UpdateInflightStatus.
 		var amount *big.Int

--- a/inflight_transaction.go
+++ b/inflight_transaction.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"strings"
 	"sync"
 	"time"
 
@@ -586,4 +587,133 @@ func (l *Blnk) finalizeVoidTransaction(ctx context.Context, transaction *model.T
 
 	span.AddEvent("Void transaction finalized", trace.WithAttributes(attribute.String("transaction.id", transaction.TransactionID)))
 	return transaction, nil
+}
+
+// BulkInflightAction discriminates between the two operations supported by
+// BulkInflightUpdate.
+type BulkInflightAction int
+
+const (
+	BulkInflightVoid BulkInflightAction = iota
+	BulkInflightCommit
+)
+
+// BulkInflightItem is the internal per-item shape consumed by
+// BulkInflightUpdate. For void calls only TransactionID is used.
+type BulkInflightItem struct {
+	TransactionID string
+	Amount        *big.Int
+}
+
+// BulkInflightOutcome is the per-item outcome from BulkInflightUpdate.
+// On success Err is nil; on failure Code carries a stable classification
+// (see classifyInflightError) and Err preserves the original message.
+type BulkInflightOutcome struct {
+	TransactionID string
+	Txn           *model.Transaction
+	Err           error
+	Code          string
+}
+
+// classifyInflightError maps the unstructured errors emitted by
+// CommitInflightTransaction / VoidInflightTransaction to stable codes so
+// bulk callers can branch on them programmatically instead of regex-matching
+// human-readable messages.
+//
+// Codes are intentionally action-agnostic where possible. ALREADY_VOIDED and
+// ALREADY_COMMITTED are reported as observed — a void on an already-committed
+// txn surfaces ALREADY_COMMITTED, and vice versa.
+func classifyInflightError(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "transaction not found"),
+		strings.Contains(msg, "no rows in result set"),
+		strings.Contains(msg, "not found"):
+		return "NOT_FOUND"
+	case strings.Contains(msg, "has already been voided"):
+		return "ALREADY_VOIDED"
+	case strings.Contains(msg, "Transaction already committed"),
+		strings.Contains(msg, "cannot void. Transaction already committed"):
+		return "ALREADY_COMMITTED"
+	case strings.Contains(msg, "not in inflight status"):
+		return "NOT_INFLIGHT"
+	case strings.Contains(msg, "cannot commit more than"):
+		return "INVALID_AMOUNT"
+	case strings.Contains(msg, "failed to acquire lock"):
+		return "LOCKED"
+	default:
+		return "INTERNAL_ERROR"
+	}
+}
+
+// BulkInflightUpdate voids or commits a list of independently-created
+// inflight transactions in parallel.
+//
+// Each id is processed in its own goroutine via a worker pool of size
+// `maxWorkers` (clamped to [1, 16]). Per-item failures are reported in the
+// returned result slice and do not abort the rest of the batch; the returned
+// error is non-nil only for input validation failures (empty list, too many
+// items).
+//
+// Idempotency: bulk has no batch-wide idempotency key. Retries that include
+// already-processed ids will see those ids surface as ALREADY_VOIDED /
+// ALREADY_COMMITTED, which callers should treat as success-equivalent for
+// retry semantics.
+//
+// Results are returned in the same order as the input.
+func (l *Blnk) BulkInflightUpdate(ctx context.Context, action BulkInflightAction, items []BulkInflightItem, maxWorkers int) ([]BulkInflightOutcome, error) {
+	if len(items) == 0 {
+		return nil, errors.New("transaction_ids cannot be empty")
+	}
+	if maxWorkers < 1 {
+		maxWorkers = 4
+	}
+	if maxWorkers > 16 {
+		maxWorkers = 16
+	}
+	if maxWorkers > len(items) {
+		maxWorkers = len(items)
+	}
+
+	results := make([]BulkInflightOutcome, len(items))
+	type job struct {
+		idx  int
+		item BulkInflightItem
+	}
+	jobs := make(chan job, len(items))
+	for i, it := range items {
+		jobs <- job{idx: i, item: it}
+	}
+	close(jobs)
+
+	var wg sync.WaitGroup
+	for w := 0; w < maxWorkers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := range jobs {
+				var txn *model.Transaction
+				var err error
+				switch action {
+				case BulkInflightCommit:
+					txn, err = l.CommitInflightTransaction(ctx, j.item.TransactionID, j.item.Amount)
+				case BulkInflightVoid:
+					txn, err = l.VoidInflightTransaction(ctx, j.item.TransactionID)
+				default:
+					err = fmt.Errorf("unknown bulk inflight action: %d", action)
+				}
+				results[j.idx] = BulkInflightOutcome{
+					TransactionID: j.item.TransactionID,
+					Txn:           txn,
+					Err:           err,
+					Code:          classifyInflightError(err),
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	return results, nil
 }

--- a/inflight_transaction_bulk_test.go
+++ b/inflight_transaction_bulk_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2024 Blnk Finance Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package blnk
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// classifyInflightError is a pure function: a focused unit test verifies
+// that each known error string from CommitInflightTransaction /
+// VoidInflightTransaction maps to its stable public code. This is what
+// callers branch on, so drift here is a silent API break.
+func TestClassifyInflightError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"nil", nil, ""},
+		{"not found", fmt.Errorf("transaction not found"), "NOT_FOUND"},
+		{"sql no rows is treated as not found", fmt.Errorf("sql: no rows in result set"), "NOT_FOUND"},
+		{"apierror wrapped not found", fmt.Errorf("Transaction with ID 'txn_xyz' not found"), "NOT_FOUND"},
+		{"already voided", fmt.Errorf("transaction has already been voided"), "ALREADY_VOIDED"},
+		{"already committed (commit path)", errors.New("cannot commit. Transaction already committed"), "ALREADY_COMMITTED"},
+		{"already committed (void path)", errors.New("cannot void. Transaction already committed"), "ALREADY_COMMITTED"},
+		{"not inflight", fmt.Errorf("transaction is not in inflight status"), "NOT_INFLIGHT"},
+		{"over original amount", fmt.Errorf("cannot commit more than the original transaction amount. Original: USD500.00, Requested: USD600.00"), "INVALID_AMOUNT"},
+		{"over remaining amount", fmt.Errorf("cannot commit more than the remaining amount. Available: USD100.00, Requested: USD200.00"), "INVALID_AMOUNT"},
+		{"lock contention", fmt.Errorf("failed to acquire lock for inflight commit: timeout"), "LOCKED"},
+		{"unknown error falls back to internal", errors.New("unexpected database failure"), "INTERNAL_ERROR"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyInflightError(tc.err)
+			if got != tc.want {
+				t.Errorf("classifyInflightError(%q) = %q, want %q", errString(tc.err), got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBulkInflightUpdate_InputValidation exercises the input-validation
+// guards on BulkInflightUpdate. These run without any infra because they
+// return before touching the DB / lock service.
+func TestBulkInflightUpdate_InputValidation(t *testing.T) {
+	l := &Blnk{}
+
+	t.Run("empty items returns error", func(t *testing.T) {
+		_, err := l.BulkInflightUpdate(context.TODO(), BulkInflightVoid, nil, 4)
+		if err == nil {
+			t.Fatal("expected error for empty items, got nil")
+		}
+	})
+}
+
+func errString(err error) string {
+	if err == nil {
+		return "<nil>"
+	}
+	return err.Error()
+}


### PR DESCRIPTION
## Summary

Closes #245.

Adds two new endpoints for voiding/committing N independently-created inflight transactions in a single call:

```
POST /transactions/inflight/bulk-void
POST /transactions/inflight/bulk-commit
```

Today the only path is N separate `PUT /transactions/inflight/:txID` calls. The existing bulk-transaction + batch_id flow doesn't fit my use case (cron-driven expiry of holds created individually over days/weeks — no shared parent).

## Design notes

- **Split by verb, not a `status` discriminator.** Void and commit have different payload shapes — commit takes a per-item `amount` for partial commits; void doesn't. Two routes read better than one with a mode flag.
- **Structured per-item results.** Each item reports `{ transaction_id, status, code, message }` with a stable `code` value (`NOT_FOUND`, `ALREADY_VOIDED`, `ALREADY_COMMITTED`, `NOT_INFLIGHT`, `INVALID_AMOUNT`, `LOCKED`, `INTERNAL_ERROR`) so callers can retry by code instead of regex-matching messages.
- **Synchronous, capped at 100 ids per call.** Bounded request latency, bounded lock-holding. Async/persistent-batch can come later if needed.
- **Per-item idempotency.** Retries that include already-processed ids surface as `ALREADY_VOIDED` / `ALREADY_COMMITTED` rather than double-processing — falls out of the existing `CommitInflightTransaction` / `VoidInflightTransaction` guards.
- **Worker pool** (size 8) over the existing single-tx service methods. `ProcessTransactionInBatches` is built around a single parent id and doesn't fit the N-independent-parents shape directly.

## Request / response shape

```
POST /transactions/inflight/bulk-void
{ "transaction_ids": ["txn_001", "txn_002", ...] }
```
```
POST /transactions/inflight/bulk-commit
{
  "items": [
    { "transaction_id": "txn_001" },
    { "transaction_id": "txn_002", "amount": 50 }
  ]
}
```
Both return:
```
{
  "succeeded": 98,
  "failed": 2,
  "results": [
    { "transaction_id": "txn_001", "status": "succeeded" },
    { "transaction_id": "txn_099", "status": "failed", "code": "ALREADY_VOIDED", "message": "transaction has already been voided" }
  ]
}
```

## Test plan

- [x] `TestClassifyInflightError` — pin every known inflight error string to its stable public code
- [x] `TestBulkInflightUpdate_InputValidation` — empty-list guard
- [x] Handler validation tests via httptest (no infra): empty list / oversized list / malformed JSON for both endpoints
- [x] `TestBulkVoidInflight_Integration` — bulk-void 3 independent inflight txns, retry shows `ALREADY_VOIDED` per id, balances reset to zero
- [x] `TestBulkCommitInflight_Integration` — bulk-commit 2 valid txns + 1 unknown id, asserts partial-failure with `NOT_FOUND`
- [x] `go build ./...` clean
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)