### PR TITLE
feat(transaction): allow skip_queue on the refund endpoint

### DIFF
--- a/api/transaction_api_test.go
+++ b/api/transaction_api_test.go
@@ -834,3 +834,102 @@ func TestInflightTransaction_Commit_WithAmount_API(t *testing.T) {
 	assert.Equal(t, originalPreciseAmount.Neg(originalPreciseAmount).String(), dbAfterFullCommit.Balance.String(), "Destination balance incorrect after full commit")
 	assert.Equal(t, int64(0), dbAfterFullCommit.InflightBalance.Int64(), "Destination inflight balance should be 0 after full commit")
 }
+
+// TestRefundTransaction_API exercises the POST /refund-transaction/:id
+// handler — specifically the optional skip_queue body added so callers
+// can request a synchronous refund.
+//
+// Three cases:
+//   - no body  → backward-compatible, refund is queued (default).
+//   - {"skip_queue": true} → refund is processed synchronously (APPLIED).
+//   - malformed body → 400, not a panic or a silent default.
+func TestRefundTransaction_API(t *testing.T) {
+	router, b, err := setupRouter()
+	if err != nil {
+		t.Fatalf("Failed to setup router: %v", err)
+	}
+	ctx := context.Background()
+
+	ledger, err := b.CreateLedger(model.Ledger{Name: gofakeit.Name()})
+	require.NoError(t, err)
+
+	// applyTxn records a fresh, immediately-applied transaction and
+	// returns its id — the thing a refund operates on.
+	applyTxn := func(t *testing.T) string {
+		t.Helper()
+		src, err := b.CreateBalance(ctx, model.Balance{LedgerID: ledger.LedgerID, Currency: "EUR"})
+		require.NoError(t, err)
+		dst, err := b.CreateBalance(ctx, model.Balance{LedgerID: ledger.LedgerID, Currency: "EUR"})
+		require.NoError(t, err)
+
+		payload := model2.RecordTransaction{
+			Amount:         100,
+			Precision:      100,
+			Reference:      "refund_api_" + gofakeit.UUID(),
+			Description:    "refund API test",
+			Currency:       "EUR",
+			Source:         src.BalanceID,
+			Destination:    dst.BalanceID,
+			AllowOverDraft: true,
+			SkipQueue:      true,
+		}
+		body, _ := request.ToJsonReq(&payload)
+		var txn model.Transaction
+		resp, err := SetUpTestRequest(TestRequest{
+			Payload: body, Response: &txn, Method: "POST", Route: "/transactions", Router: router,
+		})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusCreated, resp.Code)
+		require.Equal(t, "APPLIED", txn.Status)
+		return txn.TransactionID
+	}
+
+	t.Run("no body keeps the default (queued) behavior", func(t *testing.T) {
+		id := applyTxn(t)
+		var refund model.Transaction
+		resp, err := SetUpTestRequest(TestRequest{
+			Payload:  nil, // bodiless — the historical call shape
+			Response: &refund, Method: "POST",
+			Route: "/refund-transaction/" + id, Router: router,
+		})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusCreated, resp.Code,
+			"a bodiless refund must still succeed")
+		require.Equal(t, id, refund.ParentTransaction,
+			"refund must reference the original as parent")
+	})
+
+	t.Run("skip_queue true processes synchronously", func(t *testing.T) {
+		id := applyTxn(t)
+		body, _ := request.ToJsonReq(&refundBody{SkipQueue: true})
+		var refund model.Transaction
+		resp, err := SetUpTestRequest(TestRequest{
+			Payload: body, Response: &refund, Method: "POST",
+			Route: "/refund-transaction/" + id, Router: router,
+		})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusCreated, resp.Code)
+		require.Equal(t, "APPLIED", refund.Status,
+			"skip_queue=true must apply the refund synchronously")
+		require.Equal(t, id, refund.ParentTransaction)
+	})
+
+	t.Run("malformed body is rejected with 400", func(t *testing.T) {
+		id := applyTxn(t)
+		var out map[string]interface{}
+		resp, err := SetUpTestRequest(TestRequest{
+			Payload:  strings.NewReader(`{"skip_queue": not-json`),
+			Response: &out, Method: "POST",
+			Route: "/refund-transaction/" + id, Router: router,
+		})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusBadRequest, resp.Code,
+			"a malformed body must be rejected, not silently defaulted")
+	})
+}
+
+// refundBody mirrors the handler's optional request shape so the test
+// does not depend on the unexported refundTransactionRequest type.
+type refundBody struct {
+	SkipQueue bool `json:"skip_queue"`
+}

--- a/api/transactions.go
+++ b/api/transactions.go
@@ -17,6 +17,7 @@ package api
 
 import (
 	"errors"
+	"io"
 	"math/big"
 	"net/http"
 	"strconv"
@@ -206,15 +207,16 @@ func (a Api) RefundTransaction(c *gin.Context) {
 		return
 	}
 
-	// The body is optional. Bind it only when one was actually sent so
-	// the long-standing bodiless `POST /refund-transaction/:id` keeps
-	// working unchanged.
+	// The body is optional — the long-standing bodiless
+	// `POST /refund-transaction/:id` must keep working unchanged. An
+	// empty body makes encoding/json (via ShouldBindJSON) return io.EOF;
+	// treat ONLY that as "no options supplied" and reject any other
+	// bind error. Detecting emptiness via io.EOF is reliable regardless
+	// of Content-Length / chunked transfer encoding.
 	var req refundTransactionRequest
-	if c.Request.ContentLength != 0 {
-		if err := c.ShouldBindJSON(&req); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-			return
-		}
+	if err := c.ShouldBindJSON(&req); err != nil && !errors.Is(err, io.EOF) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
 	}
 
 	transaction, err := a.blnk.ProcessTransactionInBatches(c.Request.Context(), id, big.NewInt(0), 1, false, a.blnk.GetRefundableTransactionsByParentID, a.blnk.RefundWorkerWithOptions(req.SkipQueue))

--- a/api/transactions.go
+++ b/api/transactions.go
@@ -175,9 +175,23 @@ func (a Api) QueueTransaction(c *gin.Context) {
 	c.JSON(http.StatusCreated, transformTransaction(resp))
 }
 
+// refundTransactionRequest is the optional JSON body of a refund
+// request. It is OPTIONAL: an empty body keeps the default behavior
+// (the refund is queued for asynchronous processing).
+type refundTransactionRequest struct {
+	// SkipQueue, when true, processes the refund synchronously instead
+	// of placing it on the transaction queue — useful for time-sensitive
+	// refunds where the caller needs immediate confirmation. Mirrors the
+	// skip_queue flag on Create Transaction.
+	SkipQueue bool `json:"skip_queue"`
+}
+
 // RefundTransaction processes a refund for a transaction based on the given ID.
 // It retrieves the transaction to be refunded and processes it in batches. If any errors
 // occur during retrieval or processing, it responds with an appropriate error message.
+//
+// An optional JSON body {"skip_queue": true} processes the refund
+// synchronously; an absent or empty body queues it (the default).
 //
 // Parameters:
 // - c: The Gin context containing the request and response.
@@ -191,7 +205,19 @@ func (a Api) RefundTransaction(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "id is required. pass id in the route /:id"})
 		return
 	}
-	transaction, err := a.blnk.ProcessTransactionInBatches(c.Request.Context(), id, big.NewInt(0), 1, false, a.blnk.GetRefundableTransactionsByParentID, a.blnk.RefundWorker)
+
+	// The body is optional. Bind it only when one was actually sent so
+	// the long-standing bodiless `POST /refund-transaction/:id` keeps
+	// working unchanged.
+	var req refundTransactionRequest
+	if c.Request.ContentLength != 0 {
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+	}
+
+	transaction, err := a.blnk.ProcessTransactionInBatches(c.Request.Context(), id, big.NewInt(0), 1, false, a.blnk.GetRefundableTransactionsByParentID, a.blnk.RefundWorkerWithOptions(req.SkipQueue))
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return

--- a/transaction.go
+++ b/transaction.go
@@ -749,6 +749,40 @@ func (l *Blnk) RefundWorker(ctx context.Context, jobs <-chan *model.Transaction,
 	}
 }
 
+// RefundWorkerWithOptions returns a transactionWorker that refunds each
+// job with an explicit skipQueue decision, rather than inheriting it
+// from the original transaction.
+//
+// This exists because skip_queue is a request-time routing flag and is
+// deliberately NOT persisted (see Transaction Lifecycle docs). The
+// original transaction fetched from storage for a refund therefore
+// always deserializes SkipQueue=false, so the plain RefundWorker can
+// never produce a synchronous refund. RefundWorkerWithOptions lets the
+// caller — e.g. the /refund-transaction API handler honoring a
+// "skip_queue" field in the request body — choose synchronous
+// processing for time-sensitive refunds.
+//
+// RefundWorker is left unchanged; this is purely additive.
+func (l *Blnk) RefundWorkerWithOptions(skipQueue bool) transactionWorker {
+	return func(ctx context.Context, jobs <-chan *model.Transaction, results chan<- BatchJobResult, wg *sync.WaitGroup, amount *big.Int) {
+		ctx, span := tracer.Start(ctx, "RefundWorkerWithOptions")
+		defer span.End()
+		span.SetAttributes(attribute.Bool("refund.skip_queue", skipQueue))
+
+		defer wg.Done()
+		for originalTxn := range jobs {
+			queuedRefundTxn, err := l.RefundTransaction(ctx, originalTxn.TransactionID, skipQueue)
+			if err != nil {
+				results <- BatchJobResult{Error: err}
+				span.RecordError(err)
+				continue
+			}
+			results <- BatchJobResult{Txn: queuedRefundTxn}
+			span.AddEvent("Refund processed", trace.WithAttributes(attribute.String("transaction.id", queuedRefundTxn.TransactionID)))
+		}
+	}
+}
+
 // ProcessQueuedTransaction preserves the existing queued-worker behavior while routing the
 // decision through the shared internal transaction executor.
 func (l *Blnk) ProcessQueuedTransaction(ctx context.Context, transaction *model.Transaction, hotLane bool) (*model.Transaction, error) {

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -6949,3 +6949,125 @@ func TestGetBalanceAtTime_Mock(t *testing.T) {
 		mockDS.AssertExpectations(t)
 	})
 }
+
+// TestRefundWorkerWithOptions verifies that RefundWorkerWithOptions
+// honors an explicit skipQueue decision regardless of the SkipQueue
+// value on the queued job.
+//
+// This is the regression guard for the /refund-transaction API gap:
+// skip_queue is a request-time routing flag and is not persisted, so a
+// transaction fetched from storage for a refund always has
+// SkipQueue=false. The plain RefundWorker therefore can never produce a
+// synchronous refund. RefundWorkerWithOptions(true) must apply the
+// refund immediately (APPLIED) even though the job's own SkipQueue is
+// false.
+func TestRefundWorkerWithOptions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping refund worker test in short mode")
+	}
+
+	ctx := context.Background()
+	cnf := &config.Configuration{
+		Redis: config.RedisConfig{
+			Dns: "localhost:6379",
+		},
+		DataSource: config.DataSourceConfig{
+			Dns: "postgres://postgres:password@localhost:5432/blnk?sslmode=disable",
+		},
+		Queue: config.QueueConfig{
+			WebhookQueue:     "webhook_queue_test",
+			IndexQueue:       "index_queue_test",
+			TransactionQueue: "transaction_queue_test",
+			NumberOfQueues:   1,
+		},
+		Server: config.ServerConfig{
+			SecretKey: "test-secret",
+		},
+		Transaction: config.TransactionConfig{
+			BatchSize:        100,
+			MaxQueueSize:     1000,
+			LockDuration:     time.Second * 30,
+			IndexQueuePrefix: "test_index",
+		},
+	}
+	config.ConfigStore.Store(cnf)
+
+	ds, err := database.NewDataSource(cnf)
+	require.NoError(t, err, "Failed to create datasource")
+
+	blnk, err := NewBlnk(ds)
+	require.NoError(t, err, "Failed to create Blnk instance")
+
+	source, err := ds.CreateBalance(model.Balance{Currency: "USD", LedgerID: "general_ledger_id"})
+	require.NoError(t, err, "Failed to create source balance")
+	dest, err := ds.CreateBalance(model.Balance{Currency: "USD", LedgerID: "general_ledger_id"})
+	require.NoError(t, err, "Failed to create destination balance")
+
+	// Apply an original transaction synchronously.
+	txnRef := "txn_" + model.GenerateUUIDWithSuffix("refund_opts_test")
+	queuedTxn, err := blnk.QueueTransaction(ctx, &model.Transaction{
+		Reference:      txnRef,
+		Source:         source.BalanceID,
+		Destination:    dest.BalanceID,
+		Amount:         500,
+		Currency:       "USD",
+		AllowOverdraft: true,
+		Precision:      100,
+		SkipQueue:      true,
+	})
+	require.NoError(t, err, "Failed to queue transaction")
+	require.Equal(t, StatusApplied, queuedTxn.Status, "Original transaction should be APPLIED")
+
+	appliedEntry, err := ds.GetTransactionByRef(ctx, txnRef)
+	require.NoError(t, err, "Failed to get transaction by reference")
+
+	// Fetch the transaction object the way the API path does. As
+	// documented, SkipQueue is NOT persisted, so this is false here —
+	// that is precisely the condition under which the plain
+	// RefundWorker cannot produce a synchronous refund.
+	txnObj, err := ds.GetTransaction(ctx, appliedEntry.TransactionID)
+	require.NoError(t, err, "Failed to get transaction by ID")
+	require.False(t, txnObj.SkipQueue,
+		"DB-fetched transaction must have SkipQueue=false (skip_queue is not persisted)")
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	jobs := make(chan *model.Transaction, 1)
+	results := make(chan BatchJobResult, 1)
+	jobs <- txnObj
+	close(jobs)
+
+	// RefundWorkerWithOptions(true) must override the job's SkipQueue
+	// and process the refund synchronously.
+	go blnk.RefundWorkerWithOptions(true)(ctx, jobs, results, &wg, big.NewInt(0))
+	wg.Wait()
+	close(results)
+
+	var result BatchJobResult
+	select {
+	case result = <-results:
+	default:
+		t.Fatal("No results received from refund worker")
+	}
+
+	require.NoError(t, result.Error, "Refund worker should not return an error")
+	require.NotNil(t, result.Txn, "Refund worker should return a transaction")
+	require.Equal(t, StatusApplied, result.Txn.Status,
+		"RefundWorkerWithOptions(true) must apply the refund synchronously even when the job's SkipQueue is false")
+	require.Equal(t, appliedEntry.TransactionID, result.Txn.ParentTransaction,
+		"Refund transaction should reference the original as parent")
+	require.Equal(t, appliedEntry.Source, result.Txn.Destination,
+		"Refund transaction should swap source and destination")
+	require.Equal(t, appliedEntry.Destination, result.Txn.Source,
+		"Refund transaction should swap source and destination")
+
+	// Balances are back to zero — the refund settled immediately.
+	finalSource, err := ds.GetBalanceByIDLite(source.BalanceID)
+	require.NoError(t, err, "Failed to get final source balance")
+	finalDest, err := ds.GetBalanceByIDLite(dest.BalanceID)
+	require.NoError(t, err, "Failed to get final destination balance")
+	require.Equal(t, "0", finalSource.Balance.String(),
+		"Source balance should be zero after a synchronous refund")
+	require.Equal(t, "0", finalDest.Balance.String(),
+		"Destination balance should be zero after a synchronous refund")
+}


### PR DESCRIPTION
## Problem

`POST /refund-transaction/:id` always queues the refund for asynchronous processing. There is no way for an API caller to request a **synchronous** refund — even though `Create Transaction` exposes `skip_queue` for exactly this case (time-sensitive operations needing immediate confirmation).

The core `RefundTransaction` already accepts a `skipQueue bool`, but `RefundWorker` passes `originalTxn.SkipQueue`. As the [Transaction Lifecycle docs](https://docs.blnkfinance.com/transactions/transaction-lifecycle#skip-transaction-queue) state, `skip_queue` is a request-time routing flag that is **deliberately not persisted**. A transaction fetched from storage for a refund therefore always deserializes `SkipQueue=false`, so the queued path is the only one reachable from the API.

## Changes

All additive and backward-compatible:

- **`RefundWorkerWithOptions(skipQueue bool) transactionWorker`** — returns a worker that refunds each job with an *explicit* `skipQueue` decision instead of inheriting the (always-false) persisted value. `RefundWorker` is left untouched.
- **`RefundTransaction` API handler** — optionally binds `{"skip_queue": true}` from the request body. An absent or empty body preserves the existing bodiless `POST /refund-transaction/:id` behavior (queued refund).
- **`TestRefundWorkerWithOptions`** — regression guard: a synchronous refund must apply immediately (`APPLIED`) even when the queued job's `SkipQueue` is `false`.

## Backward compatibility

The request body is optional. Existing callers that send no body get the unchanged queued-refund behavior. Only a caller that explicitly sends `{"skip_queue": true}` opts into synchronous processing.

## Testing

- `go build ./...` — clean
- `go vet ./...` — clean
- `gofmt` — clean
- New test compiles and skips correctly under `-short` (it is a DB+Redis integration test, consistent with the existing `TestRefundWorkerFullFlow`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)