### PR TITLE
Clear inflight flag when committing or voiding inflight transactions

### DIFF
--- a/inflight_transaction.go
+++ b/inflight_transaction.go
@@ -380,6 +380,7 @@ func (l *Blnk) finalizeCommitment(ctx context.Context, transaction *model.Transa
 	defer span.End()
 
 	transaction.Status = StatusCommit
+	clearTerminalInflightFlag(transaction)
 	transaction.ParentTransaction = transaction.TransactionID
 	transaction.CreatedAt = time.Now()
 	if transaction.EffectiveDate == nil {
@@ -568,6 +569,7 @@ func (l *Blnk) finalizeVoidTransaction(ctx context.Context, transaction *model.T
 	defer span.End()
 
 	transaction.Status = StatusVoid
+	clearTerminalInflightFlag(transaction)
 	transaction.PreciseAmount = amountLeft
 	transaction.CreatedAt = time.Now()
 	if transaction.EffectiveDate == nil {
@@ -587,6 +589,13 @@ func (l *Blnk) finalizeVoidTransaction(ctx context.Context, transaction *model.T
 
 	span.AddEvent("Void transaction finalized", trace.WithAttributes(attribute.String("transaction.id", transaction.TransactionID)))
 	return transaction, nil
+}
+
+func clearTerminalInflightFlag(transaction *model.Transaction) {
+	transaction.Inflight = false
+	if transaction.MetaData != nil {
+		delete(transaction.MetaData, "inflight")
+	}
 }
 
 // BulkInflightAction discriminates between the two operations supported by

--- a/inflight_transaction_bulk_test.go
+++ b/inflight_transaction_bulk_test.go
@@ -15,6 +15,8 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+
+	"github.com/blnkfinance/blnk/model"
 )
 
 // classifyInflightError is a pure function: a focused unit test verifies
@@ -48,6 +50,34 @@ func TestClassifyInflightError(t *testing.T) {
 				t.Errorf("classifyInflightError(%q) = %q, want %q", errString(tc.err), got, tc.want)
 			}
 		})
+	}
+}
+
+func TestClearTerminalInflightFlagPreventsMetadataRestore(t *testing.T) {
+	txn := &model.Transaction{
+		Inflight:       true,
+		AllowOverdraft: true,
+		MetaData: map[string]interface{}{
+			"inflight":        true,
+			"allow_overdraft": true,
+			"source":          "test",
+		},
+	}
+
+	clearTerminalInflightFlag(txn)
+	setTransactionMetadata(txn)
+
+	if txn.Inflight {
+		t.Fatal("terminal transaction should not keep Inflight=true")
+	}
+	if _, ok := txn.MetaData["inflight"]; ok {
+		t.Fatal("terminal transaction metadata should not keep inherited inflight flag")
+	}
+	if txn.MetaData["allow_overdraft"] != true {
+		t.Fatal("terminal transaction metadata should keep unrelated flags")
+	}
+	if txn.MetaData["source"] != "test" {
+		t.Fatal("terminal transaction metadata should keep caller metadata")
 	}
 }
 


### PR DESCRIPTION
Fixes #293.

## What changed
- Clears the terminal transaction's `Inflight` field before commit/void persistence.
- Removes the inherited `meta_data.inflight` key so reads do not restore `inflight: true` for `APPLIED` or `VOID` transactions.
- Keeps unrelated metadata such as `allow_overdraft` and caller metadata intact.

## Why
`setTransactionMetadata` re-adds `meta_data.inflight` whenever `Transaction.Inflight` is true, so both the struct field and metadata source of truth need to be cleared before the terminal transaction is recorded.

## Tests
- `go test ./... -run 'TestClearTerminalInflightFlagPreventsMetadataRestore|TestClassifyInflightError|TestBulkInflightUpdate_InputValidation'`\n\n`go test -short ./...` was attempted locally, but existing tests require local Postgres/Redis and failed with connection refused on `127.0.0.1:5432` / `127.0.0.1:6379` in this environment.