### PR TITLE
Restrict hook management to the master key

### DIFF
--- a/api/hooks.go
+++ b/api/hooks.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/blnkfinance/blnk/internal/apierror"
@@ -8,8 +9,29 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+var errHooksRequireMasterKey = errors.New("hook management requires master key")
+
+func isHookMasterKeyRequest(c *gin.Context) bool {
+	isMasterKey, _ := c.Get("isMasterKey")
+	isMaster, _ := isMasterKey.(bool)
+	return isMaster
+}
+
+func ensureHookManagementAuthorized(c *gin.Context) bool {
+	if isHookMasterKeyRequest(c) {
+		return true
+	}
+
+	c.JSON(http.StatusForbidden, gin.H{"error": errHooksRequireMasterKey.Error()})
+	return false
+}
+
 // RegisterHook handles the registration of a new webhook.
 func (a *Api) RegisterHook(c *gin.Context) {
+	if !ensureHookManagementAuthorized(c) {
+		return
+	}
+
 	var hook hooks.Hook
 	if err := c.ShouldBindJSON(&hook); err != nil {
 		c.JSON(http.StatusBadRequest, apierror.NewAPIError(apierror.ErrInvalidInput, "invalid hook data", err))
@@ -26,6 +48,10 @@ func (a *Api) RegisterHook(c *gin.Context) {
 
 // UpdateHook handles updating an existing webhook.
 func (a *Api) UpdateHook(c *gin.Context) {
+	if !ensureHookManagementAuthorized(c) {
+		return
+	}
+
 	hookID := c.Param("id")
 	var hook hooks.Hook
 	if err := c.ShouldBindJSON(&hook); err != nil {
@@ -43,6 +69,10 @@ func (a *Api) UpdateHook(c *gin.Context) {
 
 // GetHook retrieves a specific webhook by ID.
 func (a *Api) GetHook(c *gin.Context) {
+	if !ensureHookManagementAuthorized(c) {
+		return
+	}
+
 	hookID := c.Param("id")
 	hook, err := a.blnk.Hooks.GetHook(c.Request.Context(), hookID)
 	if err != nil {
@@ -55,6 +85,10 @@ func (a *Api) GetHook(c *gin.Context) {
 
 // ListHooks retrieves all hooks of a specific type.
 func (a *Api) ListHooks(c *gin.Context) {
+	if !ensureHookManagementAuthorized(c) {
+		return
+	}
+
 	hookType := hooks.HookType(c.Query("type"))
 	hooks, err := a.blnk.Hooks.ListHooks(c.Request.Context(), hookType)
 	if err != nil {
@@ -67,6 +101,10 @@ func (a *Api) ListHooks(c *gin.Context) {
 
 // DeleteHook removes a webhook by ID.
 func (a *Api) DeleteHook(c *gin.Context) {
+	if !ensureHookManagementAuthorized(c) {
+		return
+	}
+
 	hookID := c.Param("id")
 	if err := a.blnk.Hooks.DeleteHook(c.Request.Context(), hookID); err != nil {
 		c.JSON(http.StatusBadRequest, apierror.NewAPIError(apierror.ErrInvalidInput, "failed to delete hook", err))

--- a/api/hooks_test.go
+++ b/api/hooks_test.go
@@ -24,14 +24,48 @@ import (
 
 	"github.com/blnkfinance/blnk/internal/hooks"
 	"github.com/blnkfinance/blnk/internal/request"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestRegisterHook(t *testing.T) {
+func setupHookRouter(t *testing.T, isMaster bool) *gin.Engine {
+	t.Helper()
+
 	router, _, err := setupRouter()
 	if err != nil {
 		t.Fatalf("Failed to setup router: %v", err)
 	}
+
+	router.Use(func(c *gin.Context) {
+		c.Set("isMasterKey", isMaster)
+		c.Next()
+	})
+
+	return router
+}
+
+func TestEnsureHookManagementAuthorized(t *testing.T) {
+	t.Run("Master key is allowed", func(t *testing.T) {
+		resp := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(resp)
+		c.Set("isMasterKey", true)
+
+		assert.True(t, ensureHookManagementAuthorized(c))
+		assert.Equal(t, http.StatusOK, resp.Code)
+	})
+
+	t.Run("API key is denied", func(t *testing.T) {
+		resp := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(resp)
+
+		assert.False(t, ensureHookManagementAuthorized(c))
+		assert.Equal(t, http.StatusForbidden, resp.Code)
+		assert.Contains(t, resp.Body.String(), errHooksRequireMasterKey.Error())
+	})
+}
+
+func TestRegisterHook(t *testing.T) {
+	router := setupHookRouter(t, true)
 
 	t.Run("Invalid JSON", func(t *testing.T) {
 		req := httptest.NewRequest("POST", "/hooks", bytes.NewReader([]byte("invalid json")))
@@ -59,10 +93,7 @@ func TestRegisterHook(t *testing.T) {
 }
 
 func TestUpdateHook(t *testing.T) {
-	router, _, err := setupRouter()
-	if err != nil {
-		t.Fatalf("Failed to setup router: %v", err)
-	}
+	router := setupHookRouter(t, true)
 
 	t.Run("Invalid JSON", func(t *testing.T) {
 		req := httptest.NewRequest("PUT", "/hooks/hk_test123", bytes.NewReader([]byte("invalid json")))
@@ -74,10 +105,7 @@ func TestUpdateHook(t *testing.T) {
 }
 
 func TestGetHook(t *testing.T) {
-	router, _, err := setupRouter()
-	if err != nil {
-		t.Fatalf("Failed to setup router: %v", err)
-	}
+	router := setupHookRouter(t, true)
 
 	t.Run("Hook not found", func(t *testing.T) {
 		req := httptest.NewRequest("GET", "/hooks/hk_nonexistent", nil)
@@ -88,10 +116,7 @@ func TestGetHook(t *testing.T) {
 }
 
 func TestListHooks(t *testing.T) {
-	router, _, err := setupRouter()
-	if err != nil {
-		t.Fatalf("Failed to setup router: %v", err)
-	}
+	router := setupHookRouter(t, true)
 
 	t.Run("List all hooks", func(t *testing.T) {
 		req := httptest.NewRequest("GET", "/hooks", nil)
@@ -109,10 +134,7 @@ func TestListHooks(t *testing.T) {
 }
 
 func TestDeleteHook(t *testing.T) {
-	router, _, err := setupRouter()
-	if err != nil {
-		t.Fatalf("Failed to setup router: %v", err)
-	}
+	router := setupHookRouter(t, true)
 
 	t.Run("Delete non-existent hook", func(t *testing.T) {
 		req := httptest.NewRequest("DELETE", "/hooks/hk_nonexistent", nil)

--- a/api/hooks_test.go
+++ b/api/hooks_test.go
@@ -22,6 +22,9 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/blnkfinance/blnk"
+	"github.com/blnkfinance/blnk/config"
+	"github.com/blnkfinance/blnk/database"
 	"github.com/blnkfinance/blnk/internal/hooks"
 	"github.com/blnkfinance/blnk/internal/request"
 	"github.com/gin-gonic/gin"
@@ -31,17 +34,36 @@ import (
 func setupHookRouter(t *testing.T, isMaster bool) *gin.Engine {
 	t.Helper()
 
-	router, _, err := setupRouter()
+	config.MockConfig(&config.Configuration{
+		Queue: config.QueueConfig{
+			TransactionQueue: "transaction_queue_test_api_md_async",
+			NumberOfQueues:   1,
+		},
+		Redis:      config.RedisConfig{Dns: "localhost:6379"},
+		DataSource: config.DataSourceConfig{Dns: "postgres://postgres:@localhost:5432/blnk?sslmode=disable"},
+	})
+	cnf, err := config.Fetch()
 	if err != nil {
 		t.Fatalf("Failed to setup router: %v", err)
 	}
 
-	router.Use(func(c *gin.Context) {
+	db, err := database.NewDataSource(cnf)
+	if err != nil {
+		t.Fatalf("Failed to setup router: %v", err)
+	}
+
+	newBlnk, err := blnk.NewBlnk(db)
+	if err != nil {
+		t.Fatalf("Failed to setup router: %v", err)
+	}
+
+	apiInstance := NewAPI(newBlnk)
+	apiInstance.router.Use(func(c *gin.Context) {
 		c.Set("isMasterKey", isMaster)
 		c.Next()
 	})
 
-	return router
+	return apiInstance.Router()
 }
 
 func TestEnsureHookManagementAuthorized(t *testing.T) {


### PR DESCRIPTION
## Summary

This PR locks hook management down to the master key.

After this change, ordinary API keys can no longer create, list, read, update, or delete hooks.

## What was wrong before

Hooks are currently global. They are not scoped to an owner or tenant.

That meant an API key with hook permissions could register an attacker-controlled webhook and then receive transaction payloads triggered by other tenants. In practice, this creates:

- cross-tenant data exfiltration
- an SSRF primitive through attacker-controlled hook URLs

## What this PR changes

- all hook management endpoints now require the master key
- non-master callers get `403` before any hook operation runs

## Why this fix

This is an intentional containment fix.

The deeper problem is that hooks need proper owner or tenant scoping across storage, lookup, and execution. That is a broader follow-up change. Until that exists, allowing API keys to manage global hooks is unsafe.

So this PR takes the safest short-term step: remove delegated hook management entirely and close the verified exploit path now.

## Follow-up

A future PR can safely restore delegated hook access only after hooks are scoped end to end.

## Validation

- `go test ./api -run 'TestEnsureHookManagementAuthorized'`