### PR TITLE
Harden API key authorization

### DIFF
--- a/api/apikeys.go
+++ b/api/apikeys.go
@@ -1,12 +1,90 @@
 package api
 
 import (
+	"errors"
 	"net/http"
 
+	authz "github.com/blnkfinance/blnk/api/middleware"
 	"github.com/blnkfinance/blnk/api/model"
 	"github.com/blnkfinance/blnk/database"
+	coremodel "github.com/blnkfinance/blnk/model"
 	"github.com/gin-gonic/gin"
 )
+
+var (
+	errAPIKeyOwnerRequired    = errors.New("owner is required")
+	errAPIKeyCrossOwnerAccess = errors.New("cannot manage API keys for another owner")
+	errAPIKeyScopeEscalation  = errors.New("cannot grant scopes broader than caller")
+	errMissingAPIKeyPrincipal = errors.New("authenticated API key principal missing")
+)
+
+func isMasterKeyRequest(c *gin.Context) bool {
+	isMasterKey, _ := c.Get("isMasterKey")
+	isMaster, _ := isMasterKey.(bool)
+	return isMaster
+}
+
+func currentAPIKeyPrincipal(c *gin.Context) (*coremodel.APIKey, bool) {
+	apiKeyValue, exists := c.Get("apiKey")
+	if !exists {
+		return nil, false
+	}
+
+	apiKey, ok := apiKeyValue.(*coremodel.APIKey)
+	return apiKey, ok
+}
+
+func resolveAPIKeyOwner(isMaster bool, principal *coremodel.APIKey, requestedOwner string, ownerRequired bool) (string, error) {
+	if isMaster {
+		if ownerRequired && requestedOwner == "" {
+			return "", errAPIKeyOwnerRequired
+		}
+		return requestedOwner, nil
+	}
+
+	if principal == nil {
+		return "", errMissingAPIKeyPrincipal
+	}
+
+	if requestedOwner != "" && requestedOwner != principal.OwnerID {
+		return "", errAPIKeyCrossOwnerAccess
+	}
+
+	return principal.OwnerID, nil
+}
+
+func validateGrantedScopes(isMaster bool, principal *coremodel.APIKey, requestedScopes []string) error {
+	if isMaster {
+		return nil
+	}
+
+	if principal == nil {
+		return errMissingAPIKeyPrincipal
+	}
+
+	if !authz.CanGrantScopes(principal.Scopes, requestedScopes) {
+		return errAPIKeyScopeEscalation
+	}
+
+	return nil
+}
+
+func writeAPIKeyAuthorizationError(c *gin.Context, err error) bool {
+	if err == nil {
+		return false
+	}
+
+	switch err {
+	case errAPIKeyOwnerRequired, errMissingAPIKeyPrincipal:
+		c.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
+	case errAPIKeyCrossOwnerAccess, errAPIKeyScopeEscalation:
+		c.JSON(http.StatusForbidden, gin.H{"error": err.Error()})
+	default:
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+	}
+
+	return true
+}
 
 // CreateAPIKey creates a new API key for the authenticated user
 //
@@ -23,7 +101,19 @@ func (a Api) CreateAPIKey(c *gin.Context) {
 		return
 	}
 
-	apiKey, err := a.blnk.CreateAPIKey(c.Request.Context(), req.Name, req.Owner, req.Scopes, req.ExpiresAt)
+	isMaster := isMasterKeyRequest(c)
+	principal, _ := currentAPIKeyPrincipal(c)
+
+	ownerID, err := resolveAPIKeyOwner(isMaster, principal, req.Owner, true)
+	if writeAPIKeyAuthorizationError(c, err) {
+		return
+	}
+
+	if err := validateGrantedScopes(isMaster, principal, req.Scopes); writeAPIKeyAuthorizationError(c, err) {
+		return
+	}
+
+	apiKey, err := a.blnk.CreateAPIKey(c.Request.Context(), req.Name, ownerID, req.Scopes, req.ExpiresAt)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -41,13 +131,15 @@ func (a Api) CreateAPIKey(c *gin.Context) {
 // - 200 OK: Returns the list of API keys
 // - 500 Internal Server Error: If there's an error retrieving the keys
 func (a Api) ListAPIKeys(c *gin.Context) {
-	owner := c.Query("owner")
-	if owner == "" {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+	isMaster := isMasterKeyRequest(c)
+	principal, _ := currentAPIKeyPrincipal(c)
+
+	ownerID, err := resolveAPIKeyOwner(isMaster, principal, c.Query("owner"), isMaster)
+	if writeAPIKeyAuthorizationError(c, err) {
 		return
 	}
 
-	keys, err := a.blnk.ListAPIKeys(c.Request.Context(), owner)
+	keys, err := a.blnk.ListAPIKeys(c.Request.Context(), ownerID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -67,13 +159,15 @@ func (a Api) ListAPIKeys(c *gin.Context) {
 // - 403 Forbidden: If the user doesn't own the API key
 func (a Api) RevokeAPIKey(c *gin.Context) {
 	id := c.Param("id")
-	owner := c.Query("owner")
-	if owner == "" {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+	isMaster := isMasterKeyRequest(c)
+	principal, _ := currentAPIKeyPrincipal(c)
+
+	ownerID, err := resolveAPIKeyOwner(isMaster, principal, c.Query("owner"), isMaster)
+	if writeAPIKeyAuthorizationError(c, err) {
 		return
 	}
 
-	if err := a.blnk.RevokeAPIKey(c.Request.Context(), id, owner); err != nil {
+	if err := a.blnk.RevokeAPIKey(c.Request.Context(), id, ownerID); err != nil {
 		switch err {
 		case database.ErrAPIKeyNotFound:
 			c.JSON(http.StatusNotFound, gin.H{"error": "API key not found"})

--- a/api/apikeys_test.go
+++ b/api/apikeys_test.go
@@ -1,0 +1,126 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/blnkfinance/blnk/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveAPIKeyOwner(t *testing.T) {
+	principal := &model.APIKey{OwnerID: "owner_a"}
+
+	tests := []struct {
+		name           string
+		isMaster       bool
+		principal      *model.APIKey
+		requestedOwner string
+		ownerRequired  bool
+		expectedOwner  string
+		expectedErr    error
+	}{
+		{
+			name:           "Master key can manage requested owner",
+			isMaster:       true,
+			requestedOwner: "owner_b",
+			ownerRequired:  true,
+			expectedOwner:  "owner_b",
+		},
+		{
+			name:          "Master key requires owner when route depends on it",
+			isMaster:      true,
+			ownerRequired: true,
+			expectedErr:   errAPIKeyOwnerRequired,
+		},
+		{
+			name:          "API key uses its own owner when query owner omitted",
+			principal:     principal,
+			expectedOwner: "owner_a",
+		},
+		{
+			name:           "API key can manage matching owner",
+			principal:      principal,
+			requestedOwner: "owner_a",
+			expectedOwner:  "owner_a",
+		},
+		{
+			name:           "API key cannot manage another owner",
+			principal:      principal,
+			requestedOwner: "owner_b",
+			expectedErr:    errAPIKeyCrossOwnerAccess,
+		},
+		{
+			name:        "API key principal is required",
+			expectedErr: errMissingAPIKeyPrincipal,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ownerID, err := resolveAPIKeyOwner(tt.isMaster, tt.principal, tt.requestedOwner, tt.ownerRequired)
+			assert.ErrorIs(t, err, tt.expectedErr)
+			assert.Equal(t, tt.expectedOwner, ownerID)
+		})
+	}
+}
+
+func TestValidateGrantedScopes(t *testing.T) {
+	principal := &model.APIKey{
+		OwnerID: "owner_a",
+		Scopes:  []string{"api-keys:write", "api-keys:read", "ledgers:*"},
+	}
+
+	tests := []struct {
+		name            string
+		isMaster        bool
+		principal       *model.APIKey
+		requestedScopes []string
+		expectedErr     error
+	}{
+		{
+			name:            "Master key can grant any scope",
+			isMaster:        true,
+			requestedScopes: []string{"*:*"},
+		},
+		{
+			name:            "API key can grant exact owned scopes",
+			principal:       principal,
+			requestedScopes: []string{"api-keys:read"},
+		},
+		{
+			name:            "API key can grant scopes covered by wildcard action",
+			principal:       principal,
+			requestedScopes: []string{"ledgers:delete"},
+		},
+		{
+			name:            "API key cannot grant broader scopes",
+			principal:       principal,
+			requestedScopes: []string{"*:*"},
+			expectedErr:     errAPIKeyScopeEscalation,
+		},
+		{
+			name:            "API key cannot grant other resource scopes",
+			principal:       principal,
+			requestedScopes: []string{"accounts:write"},
+			expectedErr:     errAPIKeyScopeEscalation,
+		},
+		{
+			name:            "API key cannot grant invalid scopes",
+			principal:       principal,
+			requestedScopes: []string{"not-a-scope"},
+			expectedErr:     errAPIKeyScopeEscalation,
+		},
+		{
+			name:            "API key principal is required",
+			requestedScopes: []string{"ledgers:read"},
+			expectedErr:     errMissingAPIKeyPrincipal,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateGrantedScopes(tt.isMaster, tt.principal, tt.requestedScopes)
+			assert.ErrorIs(t, err, tt.expectedErr)
+		})
+	}
+}

--- a/api/middleware/auth_test.go
+++ b/api/middleware/auth_test.go
@@ -887,6 +887,106 @@ func TestParseScope(t *testing.T) {
 	}
 }
 
+func TestScopeCovers(t *testing.T) {
+	tests := []struct {
+		name           string
+		grantedScope   string
+		requestedScope string
+		expected       bool
+	}{
+		{
+			name:           "Exact scope match",
+			grantedScope:   "ledgers:read",
+			requestedScope: "ledgers:read",
+			expected:       true,
+		},
+		{
+			name:           "Resource wildcard covers exact scope",
+			grantedScope:   "*:write",
+			requestedScope: "accounts:write",
+			expected:       true,
+		},
+		{
+			name:           "Action wildcard covers resource action",
+			grantedScope:   "ledgers:*",
+			requestedScope: "ledgers:delete",
+			expected:       true,
+		},
+		{
+			name:           "Exact resource scope does not cover wildcard request",
+			grantedScope:   "ledgers:read",
+			requestedScope: "ledgers:*",
+			expected:       false,
+		},
+		{
+			name:           "Different action is denied",
+			grantedScope:   "ledgers:read",
+			requestedScope: "ledgers:write",
+			expected:       false,
+		},
+		{
+			name:           "Invalid requested scope is denied",
+			grantedScope:   "ledgers:*",
+			requestedScope: "not-a-scope",
+			expected:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ScopeCovers(tt.grantedScope, tt.requestedScope)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestCanGrantScopes(t *testing.T) {
+	tests := []struct {
+		name            string
+		callerScopes    []string
+		requestedScopes []string
+		expected        bool
+	}{
+		{
+			name:            "All requested scopes are covered",
+			callerScopes:    []string{"api-keys:read", "api-keys:write", "ledgers:*"},
+			requestedScopes: []string{"api-keys:read", "ledgers:delete"},
+			expected:        true,
+		},
+		{
+			name:            "Wildcard caller can grant wildcard request",
+			callerScopes:    []string{"*:*"},
+			requestedScopes: []string{"accounts:delete"},
+			expected:        true,
+		},
+		{
+			name:            "Broader requested scope is denied",
+			callerScopes:    []string{"api-keys:write"},
+			requestedScopes: []string{"*:*"},
+			expected:        false,
+		},
+		{
+			name:            "Different resource is denied",
+			callerScopes:    []string{"ledgers:*"},
+			requestedScopes: []string{"accounts:read"},
+			expected:        false,
+		},
+		{
+			name:            "Invalid requested scope is denied",
+			callerScopes:    []string{"ledgers:*"},
+			requestedScopes: []string{"invalid"},
+			expected:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CanGrantScopes(tt.callerScopes, tt.requestedScopes)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 func TestRateLimitMiddleware(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/api/middleware/scope.go
+++ b/api/middleware/scope.go
@@ -100,3 +100,43 @@ func HasPermission(scopes []string, resource Resource, method string) bool {
 	}
 	return false
 }
+
+// ScopeCovers reports whether a granted scope is broad enough to authorize a requested scope.
+func ScopeCovers(grantedScope, requestedScope string) bool {
+	grantedResource, grantedAction := ParseScope(grantedScope)
+	requestedResource, requestedAction := ParseScope(requestedScope)
+
+	if grantedResource == "" || grantedAction == "" || requestedResource == "" || requestedAction == "" {
+		return false
+	}
+
+	if grantedResource == ResourceAll {
+		return grantedAction == ActionAll || grantedAction == requestedAction
+	}
+
+	if grantedResource != requestedResource {
+		return false
+	}
+
+	return grantedAction == ActionAll || grantedAction == requestedAction
+}
+
+// CanGrantScopes reports whether all requested scopes are covered by the caller's scopes.
+func CanGrantScopes(callerScopes, requestedScopes []string) bool {
+	for _, requestedScope := range requestedScopes {
+		covered := false
+
+		for _, callerScope := range callerScopes {
+			if ScopeCovers(callerScope, requestedScope) {
+				covered = true
+				break
+			}
+		}
+
+		if !covered {
+			return false
+		}
+	}
+
+	return true
+}


### PR DESCRIPTION
## Summary

This PR fixes two API key authorization issues:

- an API key could manage keys for a different owner by passing another `owner` value in the request
- an API key could create a stronger key than itself by requesting broader scopes

After this change, non-master API keys are limited to managing their own keys and can only grant scopes they already have.

## What was wrong before

The API key endpoints were trusting request data from the caller instead of the authenticated API key.

That meant a caller could:

- create a key for some other owner
- list another owner's keys
- revoke another owner's keys
- mint a more privileged key and escalate access

## What this PR changes

For non-master API keys:

- the effective owner now comes from the authenticated API key, not the `owner` sent by the caller
- cross-owner key operations are rejected with `403`
- requested scopes must be covered by the caller's existing scopes

Master-key behavior is unchanged.

## Why this fix

This is a direct root-cause fix for the API key authz bug. It preserves the current API shape but removes the trust in caller-controlled owner and scope values.

## Validation

- `go test ./api/middleware -run 'TestScopeCovers|TestCanGrantScopes'`
- `go test ./api -run 'TestResolveAPIKeyOwner|TestValidateGrantedScopes'`
