### PR TITLE
fix(workers): wire inflight commit queue consumer (fixes #300)

### DIFF
--- a/cmd/workers.go
+++ b/cmd/workers.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"math/big"
 	"fmt"
 	"net/http"
 	"os/signal"
@@ -257,6 +258,22 @@ func (b *blnkInstance) indexBatchData(ctx context.Context, t *asynq.Task) error 
 	return nil
 }
 
+func (b *blnkInstance) processInflightCommit(ctx context.Context, t *asynq.Task) error {
+	var txnID string
+	if err := json.Unmarshal(t.Payload(), &txnID); err != nil {
+		logrus.Error(err)
+		return err
+	}
+
+	_, err := b.blnk.CommitInflightTransaction(ctx, txnID, big.NewInt(0))
+	if err != nil {
+		return err
+	}
+
+	logrus.Printf(" [*] Inflight Transaction Committed %s", txnID)
+	return nil
+}
+
 // processInflightExpiry handles the expiry of inflight transactions.
 // It voids the transaction by its ID and logs the action.
 func (b *blnkInstance) processInflightExpiry(cxt context.Context, t *asynq.Task) error {
@@ -286,6 +303,7 @@ func initializeQueues() map[string]int {
 
 	queues := make(map[string]int)
 	queues[cfg.Queue.InflightExpiryQueue] = 1
+	queues[cfg.Queue.InflightCommitQueue] = 1
 
 	for i := 1; i <= cfg.Queue.NumberOfQueues; i++ {
 		queueName := fmt.Sprintf("%s_%d", cfg.Queue.TransactionQueue, i)
@@ -404,6 +422,7 @@ func initializeTaskHandlers(b *blnkInstance, mux *asynq.ServeMux) {
 		mux.HandleFunc(cfg.Queue.HotQueueName, b.processTransaction)
 	}
 	mux.HandleFunc(cfg.Queue.InflightExpiryQueue, b.processInflightExpiry)
+	mux.HandleFunc(cfg.Queue.InflightCommitQueue, b.processInflightCommit)
 }
 
 func initializeWebhookTaskHandlers(b *blnkInstance, mux *asynq.ServeMux) {

--- a/cmd/workers_test.go
+++ b/cmd/workers_test.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 
 	"github.com/blnkfinance/blnk/config"
+	"github.com/hibiken/asynq"
 )
 
 func TestHasReachedMaxRetryAttempt(t *testing.T) {
@@ -52,4 +55,56 @@ func TestShouldRejectLockContentionImmediately(t *testing.T) {
 	if shouldRejectLockContentionImmediately(cfg, fmt.Errorf("failed to acquire lock: already held")) {
 		t.Fatal("expected lock contention not to reject immediately when disabled")
 	}
+}
+
+func mockConfig(t *testing.T) *config.Configuration {
+	t.Helper()
+	config.MockConfig(&config.Configuration{
+		DataSource: config.DataSourceConfig{Dns: "postgres://x:x@localhost/x"},
+		Redis:      config.RedisConfig{Dns: "redis://localhost:6379"},
+	})
+	cfg, err := config.Fetch()
+	if err != nil {
+		t.Fatalf("config.Fetch: %v", err)
+	}
+	return cfg
+}
+
+// Fix 1: InflightCommitQueue must have a non-empty default so the producer
+// doesn't silently enqueue to a "" queue name when the env var is unset.
+func TestInflightCommitQueueDefault(t *testing.T) {
+	cfg := mockConfig(t)
+	if cfg.Queue.InflightCommitQueue == "" {
+		t.Fatal("InflightCommitQueue has no default — producer will enqueue to empty queue name and jobs are lost")
+	}
+}
+
+// Fix 2: initializeQueues must include InflightCommitQueue so the asynq server
+// polls it. Without this, tasks move from scheduled→pending and sit there forever.
+func TestInflightCommitQueuePolled(t *testing.T) {
+	cfg := mockConfig(t)
+	queues := initializeQueues()
+	if _, ok := queues[cfg.Queue.InflightCommitQueue]; !ok {
+		t.Fatalf("initializeQueues() missing %q — asynq server will never dequeue inflight commit jobs", cfg.Queue.InflightCommitQueue)
+	}
+}
+
+// Fix 3: initializeTaskHandlers must register a handler for InflightCommitQueue.
+// Without this, asynq archives every task with "handler not found".
+func TestInflightCommitHandlerRegistered(t *testing.T) {
+	cfg := mockConfig(t)
+	b := &blnkInstance{cnf: cfg}
+	mux := asynq.NewServeMux()
+	initializeTaskHandlers(b, mux)
+
+	payload, _ := json.Marshal("dummy-txn-id")
+	task := asynq.NewTask(cfg.Queue.InflightCommitQueue, payload)
+	noHandlerErr := fmt.Sprintf("asynq: no handler found for task %q", cfg.Queue.InflightCommitQueue)
+
+	func() {
+		defer func() { _ = recover() }() // nil blnk panics inside handler body — that's fine, it means handler was found
+		if err := mux.ProcessTask(context.Background(), task); err != nil && err.Error() == noHandlerErr {
+			t.Fatalf("no handler registered for %q — tasks will be archived unprocessed", cfg.Queue.InflightCommitQueue)
+		}
+	}()
 }

--- a/config/config.go
+++ b/config/config.go
@@ -62,6 +62,7 @@ var (
 		WebhookQueue:                    "new:webhook",
 		IndexQueue:                      "new:index",
 		InflightExpiryQueue:             "new:inflight-expiry",
+		InflightCommitQueue:             "new:inflight-commit",
 		NumberOfQueues:                  20,
 		EnableHotLane:                   false,
 		HotQueueName:                    "hot_transactions",
@@ -382,6 +383,9 @@ func (cnf *Configuration) setQueueDefaults() {
 	}
 	if cnf.Queue.InflightExpiryQueue == "" {
 		cnf.Queue.InflightExpiryQueue = defaultQueue.InflightExpiryQueue
+	}
+	if cnf.Queue.InflightCommitQueue == "" {
+		cnf.Queue.InflightCommitQueue = defaultQueue.InflightCommitQueue
 	}
 	if cnf.Queue.NumberOfQueues == 0 {
 		cnf.Queue.NumberOfQueues = defaultQueue.NumberOfQueues


### PR DESCRIPTION
## Summary

Commit `9bc2d24` added the full producer path for `inflight_commit_date` (model field, `queue.go` enqueue functions, `transaction.go` call site) but left the consumer side completely unwired in `cmd/workers.go`, causing scheduled commit jobs to sit in Redis in the `scheduled` state indefinitely.

## Changes

### `config/config.go`
- Add `InflightCommitQueue: "new:inflight-commit"` to `defaultQueue`
- Add empty-string fallback in `setQueueDefaults()`

Without this, when `BLNK_QUEUE_INFLIGHT_COMMIT` is unset the field stays `""` and the producer silently enqueues to a nameless queue no server watches.

### `cmd/workers.go`
- Add `queues[cfg.Queue.InflightCommitQueue] = 1` in `initializeQueues()`
- Add `processInflightCommit` handler + `mux.HandleFunc` registration in `initializeTaskHandlers()`

Without the queue map entry the asynq server never polls the queue. Without the handler registration asynq archives every task with `"handler not found"`.

`processInflightCommit` calls `CommitInflightTransaction(ctx, txnID, big.NewInt(0))` — the zero-amount convention already used by `updateTransactionAmount` to commit the full remaining inflight balance.

## Test plan

```
go test ./cmd/ -run TestInflightCommit -v
```

- `TestInflightCommitQueueDefault` — field has a non-empty default after `setQueueDefaults()`
- `TestInflightCommitQueuePolled` — `initializeQueues()` includes the commit queue so the server polls it
- `TestInflightCommitHandlerRegistered` — mux has a handler registered (not "handler not found")

All three fail on `main` before this patch and pass after.

## Related

Closes #300
Producer added in: `9bc2d24` — `feat(transaction): add inflight_commit_date for time-based auto-commit`