### PR TITLE
fix: clear inflight flag on terminal transactions

### DIFF
--- a/inflight_transaction.go
+++ b/inflight_transaction.go
@@ -350,6 +350,17 @@ func (l *Blnk) updateTransactionAmount(transaction *model.Transaction, amount *b
 	}
 }
 
+func clearTerminalInflightFlag(transaction *model.Transaction) {
+	if transaction == nil {
+		return
+	}
+
+	transaction.Inflight = false
+	if transaction.MetaData != nil {
+		delete(transaction.MetaData, "inflight")
+	}
+}
+
 // convertPreciseToFloat converts a precise amount (big.Int) to a floating-point representation.
 //
 // Parameters:
@@ -387,6 +398,7 @@ func (l *Blnk) finalizeCommitment(ctx context.Context, transaction *model.Transa
 	}
 	transaction.TransactionID = model.GenerateUUIDWithSuffix("txn")
 	transaction.Reference = model.GenerateUUIDWithSuffix("ref")
+	clearTerminalInflightFlag(transaction)
 	transaction.Hash = transaction.HashTxn()
 
 	if withQueue {
@@ -576,6 +588,7 @@ func (l *Blnk) finalizeVoidTransaction(ctx context.Context, transaction *model.T
 	transaction.ParentTransaction = transaction.TransactionID
 	transaction.TransactionID = model.GenerateUUIDWithSuffix("txn")
 	transaction.Reference = model.GenerateUUIDWithSuffix("ref")
+	clearTerminalInflightFlag(transaction)
 	transaction.Hash = transaction.HashTxn()
 	model.ApplyPrecision(transaction)
 

--- a/inflight_transaction_test.go
+++ b/inflight_transaction_test.go
@@ -1,0 +1,106 @@
+package blnk
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/blnkfinance/blnk/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newInflightFinalizationBalances() (*model.Balance, *model.Balance) {
+	source := &model.Balance{
+		BalanceID:             "bln_source",
+		Currency:              "USD",
+		InflightDebitBalance:  big.NewInt(1000),
+		InflightCreditBalance: big.NewInt(0),
+		InflightBalance:       big.NewInt(-1000),
+		DebitBalance:          big.NewInt(0),
+		CreditBalance:         big.NewInt(0),
+		Balance:               big.NewInt(0),
+		TrackFundLineage:      false,
+	}
+	destination := &model.Balance{
+		BalanceID:             "bln_destination",
+		Currency:              "USD",
+		InflightDebitBalance:  big.NewInt(0),
+		InflightCreditBalance: big.NewInt(1000),
+		InflightBalance:       big.NewInt(1000),
+		DebitBalance:          big.NewInt(0),
+		CreditBalance:         big.NewInt(0),
+		Balance:               big.NewInt(0),
+		TrackFundLineage:      false,
+	}
+	return source, destination
+}
+
+func newInflightFinalizationTransaction() *model.Transaction {
+	return &model.Transaction{
+		TransactionID:  "txn_parent",
+		Reference:      "ref_parent",
+		Source:         "bln_source",
+		Destination:    "bln_destination",
+		Amount:         10,
+		PreciseAmount:  big.NewInt(1000),
+		Precision:      100,
+		Rate:           1,
+		Currency:       "USD",
+		Status:         StatusInflight,
+		Inflight:       true,
+		AllowOverdraft: true,
+		MetaData: map[string]interface{}{
+			"inflight":        true,
+			"allow_overdraft": true,
+			"caller":          "kept",
+		},
+	}
+}
+
+func assertTerminalInflightCleared(t *testing.T, txn *model.Transaction) {
+	t.Helper()
+
+	require.NotNil(t, txn)
+	assert.False(t, txn.Inflight)
+	assert.NotContains(t, txn.MetaData, "inflight")
+	assert.Equal(t, true, txn.MetaData["allow_overdraft"])
+	assert.Equal(t, "kept", txn.MetaData["caller"])
+
+	rehydrated := *txn
+	rehydrated.Inflight = false
+	restoreTransactionFlagsFromMetadata(&rehydrated)
+	assert.False(t, rehydrated.Inflight)
+
+	setTransactionMetadata(&rehydrated)
+	assert.False(t, rehydrated.Inflight)
+	assert.NotContains(t, rehydrated.MetaData, "inflight")
+}
+
+func TestClearTerminalInflightFlagRemovesPersistedMetadata(t *testing.T) {
+	txn := newInflightFinalizationTransaction()
+
+	clearTerminalInflightFlag(txn)
+
+	assertTerminalInflightCleared(t, txn)
+}
+
+func TestBuildTransactionExecutionWorkSkipsLineageForInflightCommitAfterMetadataIsCleared(t *testing.T) {
+	source, destination := newInflightFinalizationBalances()
+	source.TrackFundLineage = true
+	destination.TrackFundLineage = true
+
+	txn := newInflightFinalizationTransaction()
+	txn.Status = StatusCommit
+	txn.ParentTransaction = "txn_parent"
+	txn.TransactionID = "txn_commit"
+	clearTerminalInflightFlag(txn)
+
+	blnk := &Blnk{}
+	work, skipPersist := blnk.buildTransactionExecutionWork(context.Background(), txn, source, destination)
+
+	assert.False(t, skipPersist)
+	assert.Nil(t, work.outbox)
+	assert.Equal(t, StatusApplied, work.transaction.Status)
+	assertTerminalInflightCleared(t, work.transaction)
+}

--- a/transaction.go
+++ b/transaction.go
@@ -1290,6 +1290,8 @@ func (l *Blnk) processBalances(ctx context.Context, transaction *model.Transacti
 // buildTransactionExecutionWork converts an in-memory-applied transaction into the shared
 // persistence and post-commit work shape used by both single and batched execution paths.
 func (l *Blnk) buildTransactionExecutionWork(ctx context.Context, transaction *model.Transaction, sourceBalance, destinationBalance *model.Balance) (queuedBatchPostCommitWork, bool) {
+	// StatusCommit is normalized to APPLIED below; capture it first for lineage handling.
+	isInflightCommit := transaction.Status == StatusCommit && transaction.ParentTransaction != ""
 	transaction = l.updateTransactionDetails(ctx, transaction, sourceBalance, destinationBalance)
 	if transaction.PreciseAmount != nil && transaction.PreciseAmount.Cmp(big.NewInt(0)) == 0 {
 		return queuedBatchPostCommitWork{
@@ -1299,11 +1301,16 @@ func (l *Blnk) buildTransactionExecutionWork(ctx context.Context, transaction *m
 		}, true
 	}
 
+	var outbox *model.LineageOutbox
+	if !isInflightCommit {
+		outbox = l.prepareTransactionOutbox(ctx, transaction, sourceBalance, destinationBalance)
+	}
+
 	return queuedBatchPostCommitWork{
 		transaction:        transaction,
 		sourceBalance:      sourceBalance,
 		destinationBalance: destinationBalance,
-		outbox:             l.prepareTransactionOutbox(ctx, transaction, sourceBalance, destinationBalance),
+		outbox:             outbox,
 	}, false
 }
 


### PR DESCRIPTION
## Summary

Closes #293.

Terminal commit/void transactions inherited `meta_data["inflight"] = true` from the original inflight transaction, so later reads restored `Inflight=true` even after the transaction reached `APPLIED` or `VOID`.

This clears the in-memory flag and removes the persisted metadata flag in `finalizeCommitment` and `finalizeVoidTransaction` before hashing/persistence. Since existing lineage handling used that metadata key to identify inflight commits, `buildTransactionExecutionWork` now captures `StatusCommit` before it is normalized to `APPLIED`, preserving the existing “do not create duplicate lineage outbox for inflight commit” behavior after the metadata cleanup.

## Tests

- `GOTOOLCHAIN=go1.25.0 go test . -run 'TestClearTerminalInflightFlagRemovesPersistedMetadata|TestBuildTransactionExecutionWorkSkipsLineageForInflightCommitAfterMetadataIsCleared' -count=1`
- `GOTOOLCHAIN=go1.25.0 go test ./model -count=1`
- `git diff --cached --check`

A full `GOTOOLCHAIN=go1.25.0 go test . -count=1` currently fails locally before reaching the new tests because existing account tests expect Redis at `127.0.0.1:6379`.