### PR TITLE
fix(search): use balances.id instead of balances.balance_id in transactions Typesense join

### DIFF
--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -576,8 +576,8 @@ func getTransactionSchema() *api.CollectionSchema {
 	facet := true
 	sortBy := "created_at"
 	enableNested := true
-	sourceId := "balances.balance_id"
-	destinationId := "balances.balance_id"
+	sourceId := "balances.id"
+	destinationId := "balances.id"
 	return &api.CollectionSchema{
 		Name: "transactions",
 		Fields: []api.Field{


### PR DESCRIPTION
## Problem

The `transactions` Typesense collection declares its `source` and `destination`
fields as reference joins to **`balances.balance_id`** (`internal/search/search.go`,
`getTransactionSchema`):

```go
sourceId := "balances.balance_id"
destinationId := "balances.balance_id"
```

But a Typesense reference join must target the referenced collection's document
**`id`**, not an arbitrary field. The `balances` collection is indexed with
`IDField: "balance_id"`, so each balance document's `id` already holds the
balance_id value — the correct join target is `balances.id`.

As shipped, **every** transaction upsert into Typesense fails with:

```
Referenced field `balance_id` not found in the collection `balances`
```

so transaction search indexing is completely broken.

## Steps to reproduce

Run Blnk with Typesense enabled and the worker running (e.g. `docker compose up`),
then create a ledger, two balances, and a transaction:

```bash
# 1) a ledger
LEDGER=$(curl -s -X POST http://localhost:5001/ledgers \
  -H 'Content-Type: application/json' -d '{"name":"repro"}' | jq -r .ledger_id)

# 2) two balances in that ledger
A=$(curl -s -X POST http://localhost:5001/balances -H 'Content-Type: application/json' \
  -d "{\"ledger_id\":\"$LEDGER\",\"currency\":\"USD\"}" | jq -r .balance_id)
B=$(curl -s -X POST http://localhost:5001/balances -H 'Content-Type: application/json' \
  -d "{\"ledger_id\":\"$LEDGER\",\"currency\":\"USD\"}" | jq -r .balance_id)

# 3) a transaction A -> B (allow_overdraft so the empty source can fund it)
curl -s -X POST http://localhost:5001/transactions -H 'Content-Type: application/json' \
  -d "{\"amount\":100,\"precision\":100,\"reference\":\"repro_1\",\"description\":\"repro\",
       \"currency\":\"USD\",\"source\":\"$A\",\"destination\":\"$B\",
       \"allow_overdraft\":true,\"skip_queue\":true}"
```

**Observed** — the worker (which indexes into Typesense asynchronously) fails to
index the transaction:

```
ERROR ... failed to upsert document in Typesense: status: 400 response:
{"message":"Referenced field `balance_id` not found in the collection `balances`."}
```

And the collection schema confirms the wrong join target:

```bash
curl -s http://localhost:8108/collections/transactions \
  -H 'X-TYPESENSE-API-KEY: <typesense-key>' \
  | jq '.fields[] | select(.name=="source" or .name=="destination") | {name, reference}'
# => {"name":"source","reference":"balances.balance_id"}
#    {"name":"destination","reference":"balances.balance_id"}
```

(On v0.14.2 a real workload logged 1,200+ of these errors in 30 minutes; no
transaction ever lands in the search index.)

**Confirming the fix** — recreate the `transactions` collection with the
reference set to `balances.id` (or run this patched build), then post another
transaction: the worker indexes it cleanly (`num_documents` increments, no
`balance_id` error) and it becomes searchable.

## Why a reindex doesn't resolve this (re: #281)

#281 was closed with the suggestion to run a Typesense reindex
(`POST /search/reindex`) rather than changing the code. That does not fix it:
the `transactions` collection schema is defined in code (`getTransactionSchema`),
so reindex recreates the collection with the **same** `balances.balance_id`
reference before re-indexing. Verified on v0.14.2 — after a reindex:

```bash
curl -s -X POST http://localhost:5001/search/reindex >/dev/null

curl -s http://localhost:8108/collections/transactions -H 'X-TYPESENSE-API-KEY: <key>' \
  | jq '.fields[] | select(.name=="source") | .reference'
# => "balances.balance_id"   # still wrong; upserts keep failing
```

A manually-recreated collection with `balances.id` works, but the next reindex
(or a fresh instance) reverts it, because the schema comes from the code. The
reference therefore has to be corrected at the source — which is what this PR does.

## Fix

Point both references at `balances.id`. The sibling references
(`balances.ledger_id -> ledgers.ledger_id`, `balances.identity_id ->
identities.identity_id`) use the same pattern but do **not** error in practice,
so they are left unchanged to keep the fix minimal.

Fixes #280. (Supersedes #281, which was closed without merging.)
