### PR TITLE
feat(observability): add remote monitoring exporter

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -18,6 +18,7 @@ package api
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/typesense/typesense-go/typesense/api"
 	"go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin"
@@ -26,6 +27,7 @@ import (
 	"github.com/blnkfinance/blnk/api/middleware"
 	"github.com/blnkfinance/blnk/config"
 	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
 )
 
 // Api represents the API structure for handling requests.
@@ -158,7 +160,9 @@ func NewAPI(b *blnk.Blnk) *Api {
 	if err != nil {
 		return nil
 	}
-	r := gin.Default()
+	r := gin.New()
+	r.Use(logrusAccessLogger())
+	r.Use(logrusRecovery())
 	auth := middleware.NewAuthMiddleware(b)
 	r.Use(middleware.RateLimitMiddleware(conf))
 	r.Use(middleware.SecurityHeaders())
@@ -175,6 +179,39 @@ func NewAPI(b *blnk.Blnk) *Api {
 	})
 
 	return &Api{blnk: b, router: r, auth: auth}
+}
+
+func logrusAccessLogger() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		start := time.Now()
+		path := c.Request.URL.Path
+		method := c.Request.Method
+		clientIP := c.ClientIP()
+
+		c.Next()
+
+		logrus.WithFields(logrus.Fields{
+			"method":       method,
+			"path":         path,
+			"status":       c.Writer.Status(),
+			"latency_ms":   time.Since(start).Milliseconds(),
+			"client_ip":    clientIP,
+			"error_count":  len(c.Errors),
+			"response_len": c.Writer.Size(),
+		}).Info("http request")
+	}
+}
+
+func logrusRecovery() gin.HandlerFunc {
+	return gin.CustomRecovery(func(c *gin.Context, recovered interface{}) {
+		logrus.WithFields(logrus.Fields{
+			"method":    c.Request.Method,
+			"path":      c.Request.URL.Path,
+			"client_ip": c.ClientIP(),
+			"panic":     recovered,
+		}).Error("panic recovered")
+		c.AbortWithStatus(http.StatusInternalServerError)
+	})
 }
 
 // Search performs a search query on a specified collection.

--- a/api/api_logging_test.go
+++ b/api/api_logging_test.go
@@ -1,0 +1,47 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+)
+
+func TestLogrusAccessLoggerDropsQueryString(t *testing.T) {
+	var buf bytes.Buffer
+	logger := logrus.StandardLogger()
+	previousOutput := logger.Out
+	previousFormatter := logger.Formatter
+	defer func() {
+		logger.SetOutput(previousOutput)
+		logger.SetFormatter(previousFormatter)
+	}()
+
+	logger.SetOutput(&buf)
+	logger.SetFormatter(&logrus.JSONFormatter{})
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(logrusAccessLogger())
+	router.GET("/transactions", func(c *gin.Context) {
+		c.Status(http.StatusNoContent)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/transactions?token=secret&limit=20", nil)
+	router.ServeHTTP(httptest.NewRecorder(), req)
+
+	var entry map[string]interface{}
+	if err := json.NewDecoder(&buf).Decode(&entry); err != nil {
+		t.Fatalf("failed to decode log entry: %v", err)
+	}
+	if entry["path"] != "/transactions" {
+		t.Fatalf("expected query-free path, got %+v", entry["path"])
+	}
+	if bytes.Contains(buf.Bytes(), []byte("token=secret")) {
+		t.Fatalf("access log leaked query string: %s", buf.String())
+	}
+}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -195,8 +195,8 @@ func initializeRouter(b *blnkInstance) *gin.Engine {
 	return router
 }
 
-func initializeOpenTelemetry(ctx context.Context) (func(context.Context) error, error) {
-	shutdown, err := trace.SetupOTelSDK(ctx, "BLNK")
+func initializeOpenTelemetry(ctx context.Context, monitoringDSN string) (func(context.Context) error, error) {
+	shutdown, err := trace.SetupOTelSDK(ctx, "BLNK", monitoringDSN)
 	if err != nil {
 		return nil, fmt.Errorf("error setting up OTel SDK: %w", err)
 	}
@@ -285,7 +285,7 @@ func initializeTelemetryAndObservability(ctx context.Context, cfg *config.Config
 
 	// Initialize tracing if observability is enabled
 	if cfg.EnableObservability {
-		tracingShutdown, err = initializeOpenTelemetry(ctx)
+		tracingShutdown, err = initializeOpenTelemetry(ctx, cfg.RemoteMonitoringDSN())
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to initialize tracing: %w", err)
 		}

--- a/cmd/workers.go
+++ b/cmd/workers.go
@@ -19,8 +19,8 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"math/big"
 	"fmt"
+	"math/big"
 	"net/http"
 	"os/signal"
 	"strings"
@@ -74,6 +74,7 @@ func (b *blnkInstance) processTransaction(ctx context.Context, t *asynq.Task) er
 	if err != nil {
 		logrus.WithError(err).Warnf("failed pre-checking transaction reference %s", txn.Reference)
 	} else if exists {
+		notification.NotifyError(fmt.Errorf("reference %s has already been used", txn.Reference))
 		return nil
 	}
 
@@ -93,7 +94,7 @@ func (b *blnkInstance) processTransaction(ctx context.Context, t *asynq.Task) er
 	_, err = b.blnk.ProcessQueuedTransaction(ctx, &txn, b.cnf.Queue.EnableHotLane && t.Type() == b.cnf.Queue.HotQueueName)
 	if err != nil {
 		// Handle reference already used error
-		if strings.Contains(strings.ToLower(err.Error()), "reference") && strings.Contains(strings.ToLower(err.Error()), "already been used") {
+		if blnk.IsDuplicateReferenceError(err) {
 			notification.NotifyError(err)
 			return nil
 		}
@@ -497,7 +498,7 @@ func workerCommands(b *blnkInstance) *cobra.Command {
 			// Wait for SIGINT/SIGTERM.
 			<-ctx.Done()
 
-			logrus.Errorf("Shutdown signal received. Shutting down...")
+			logrus.Info("Shutdown signal received. Shutting down...")
 
 			recoveryProcessor.Stop()
 
@@ -515,7 +516,7 @@ func workerCommands(b *blnkInstance) *cobra.Command {
 			}
 			srv.Shutdown()
 
-			logrus.Errorf("Shutdown complete.")
+			logrus.Info("Shutdown complete.")
 		},
 	}
 
@@ -587,7 +588,7 @@ func startMonitoringServer(conf *config.Configuration) *http.Server {
 	}
 
 	go func() {
-		logrus.Errorf("Worker monitoring server listening on %s (health: /health, dashboard: /monitoring)", monitoringAddr)
+		logrus.Infof("Worker monitoring server listening on %s (health: /health, dashboard: /monitoring)", monitoringAddr)
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			logrus.Fatalf("could not start monitoring server: %v", err)
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -211,9 +211,17 @@ type Configuration struct {
 	RateLimit               RateLimitConfig               `json:"rate_limit"`
 	EnableTelemetry         bool                          `json:"enable_telemetry" envconfig:"BLNK_ENABLE_TELEMETRY"`
 	EnableObservability     bool                          `json:"enable_observability" envconfig:"BLNK_ENABLE_OBSERVABILITY"`
+	MonitoringDSN           string                        `json:"monitoring_dsn" envconfig:"BLNK_MONITORING_DSN"`
 	Transaction             TransactionConfig             `json:"transaction"`
 	Reconciliation          ReconciliationConfig          `json:"reconciliation"`
 	Queue                   QueueConfig                   `json:"queue"`
+}
+
+func (cnf *Configuration) RemoteMonitoringDSN() string {
+	if strings.TrimSpace(cnf.MonitoringDSN) != "" {
+		return cnf.MonitoringDSN
+	}
+	return ""
 }
 
 func loadConfigFromFile(file string) error {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -188,6 +188,45 @@ func TestLoadConfigFromFile(t *testing.T) {
 	}
 }
 
+func TestLoadConfigFromFileMonitoringDSN(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "blnk.json")
+	if err != nil {
+		t.Fatalf("Unable to create temporary file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	sampleConfig := Configuration{
+		ProjectName:         "Monitoring DSN Test",
+		MonitoringDSN:       "https://blnk_obs_test@observe.blnk.cloud/monproj_test",
+		EnableObservability: true,
+		DataSource: DataSourceConfig{
+			Dns: "temp-dns",
+		},
+		Redis: RedisConfig{
+			Dns: "temp-redis",
+		},
+	}
+	if err := json.NewEncoder(tmpFile).Encode(sampleConfig); err != nil {
+		t.Fatalf("Unable to write to temporary file: %v", err)
+	}
+	tmpFile.Close()
+
+	if err := loadConfigFromFile(tmpFile.Name()); err != nil {
+		t.Fatalf("loadConfigFromFile failed: %v", err)
+	}
+
+	loadedConfig, err := Fetch()
+	if err != nil {
+		t.Fatalf("Fetch failed: %v", err)
+	}
+	if loadedConfig.MonitoringDSN != "https://blnk_obs_test@observe.blnk.cloud/monproj_test" {
+		t.Fatalf("Expected MonitoringDSN from config file, got %q", loadedConfig.MonitoringDSN)
+	}
+	if loadedConfig.RemoteMonitoringDSN() != "https://blnk_obs_test@observe.blnk.cloud/monproj_test" {
+		t.Fatalf("Expected remote monitoring DSN from config file, got %q", loadedConfig.RemoteMonitoringDSN())
+	}
+}
+
 func TestInitConfig(t *testing.T) {
 	// Create a temporary file
 	tmpFile, err := os.CreateTemp("", "blnk.json")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -193,7 +193,7 @@ func TestLoadConfigFromFileMonitoringDSN(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create temporary file: %v", err)
 	}
-	defer os.Remove(tmpFile.Name())
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
 
 	sampleConfig := Configuration{
 		ProjectName:         "Monitoring DSN Test",
@@ -209,7 +209,9 @@ func TestLoadConfigFromFileMonitoringDSN(t *testing.T) {
 	if err := json.NewEncoder(tmpFile).Encode(sampleConfig); err != nil {
 		t.Fatalf("Unable to write to temporary file: %v", err)
 	}
-	tmpFile.Close()
+	if err := tmpFile.Close(); err != nil {
+		t.Fatalf("Unable to close temporary file: %v", err)
+	}
 
 	if err := loadConfigFromFile(tmpFile.Name()); err != nil {
 		t.Fatalf("loadConfigFromFile failed: %v", err)

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -48,7 +48,7 @@ import (
 // - The recorded transaction if successful, or an error if the recording fails.
 func (d Datasource) RecordTransaction(ctx context.Context, txn *model.Transaction) (*model.Transaction, error) {
 	// Start a new tracing span for the database operation
-	ctx, span := otel.Tracer("transaction.database").Start(ctx, "RecordTransaction")
+	ctx, span := otel.Tracer("transaction.database").Start(ctx, "PersistTransaction")
 	defer span.End()
 
 	// Marshal transaction metadata into JSON format

--- a/internal/monitoringexporter/config.go
+++ b/internal/monitoringexporter/config.go
@@ -1,0 +1,112 @@
+package monitoringexporter
+
+import (
+	"errors"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	envDSN       = "BLNK_MONITORING_DSN"
+	envLegacyDSN = "BLNK_CLOUD_DSN"
+
+	defaultTimeout = 5 * time.Second
+)
+
+// Config describes the optional remote monitoring telemetry sink.
+type Config struct {
+	DSN       string
+	PublicKey string
+	ProjectID string
+	Endpoint  string
+	Timeout   time.Duration
+}
+
+// FromEnv returns the monitoring exporter config from environment variables.
+// Missing DSN is not an error; it means remote export is disabled.
+func FromEnv() (Config, bool, error) {
+	dsn := os.Getenv(envDSN)
+	if strings.TrimSpace(dsn) == "" {
+		dsn = os.Getenv(envLegacyDSN)
+	}
+	return FromDSN(dsn)
+}
+
+func FromDSN(dsn string) (Config, bool, error) {
+	dsn = strings.TrimSpace(dsn)
+	if dsn == "" {
+		return Config{}, false, nil
+	}
+
+	cfg, err := ParseDSN(dsn)
+	if err != nil {
+		return Config{}, false, err
+	}
+
+	cfg.Timeout = defaultTimeout
+	return cfg, true, nil
+}
+
+// ParseDSN parses a remote monitoring DSN:
+// https://<write-key>@<host>/<project-id>
+func ParseDSN(raw string) (Config, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return Config{}, errors.New("monitoring exporter DSN is empty")
+	}
+
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return Config{}, errors.New("monitoring exporter DSN is invalid")
+	}
+	if parsed.Scheme != "https" {
+		return Config{}, errors.New("monitoring exporter DSN must use https")
+	}
+	if parsed.Host == "" {
+		return Config{}, errors.New("monitoring exporter DSN host is required")
+	}
+	if parsed.User == nil || parsed.User.Username() == "" {
+		return Config{}, errors.New("monitoring exporter DSN write key is required")
+	}
+
+	projectID := strings.Trim(strings.TrimSpace(parsed.Path), "/")
+	if projectID == "" {
+		return Config{}, errors.New("monitoring exporter DSN project id is required")
+	}
+	if strings.Contains(projectID, "/") {
+		return Config{}, errors.New("monitoring exporter DSN project id must be a single path segment")
+	}
+
+	endpoint := (&url.URL{
+		Scheme: parsed.Scheme,
+		Host:   parsed.Host,
+	}).String()
+
+	return Config{
+		DSN:       raw,
+		PublicKey: parsed.User.Username(),
+		ProjectID: projectID,
+		Endpoint:  endpoint,
+		Timeout:   defaultTimeout,
+	}, nil
+}
+
+func (c Config) Headers() map[string]string {
+	headers := map[string]string{}
+	if c.PublicKey != "" {
+		headers["Authorization"] = "Bearer " + c.PublicKey
+	}
+	return headers
+}
+
+func (c Config) SignalURL(signal string) string {
+	endpoint := strings.TrimRight(c.Endpoint, "/")
+	return endpoint + "/monitoring/ingest/v1/" + strings.TrimLeft(signal, "/")
+}
+
+func (c Config) OTLPSignalURL(signal string) string {
+	endpoint := strings.TrimRight(c.Endpoint, "/")
+	return endpoint + "/monitoring/ingest/v1/otlp/" + strings.TrimLeft(signal, "/")
+}

--- a/internal/monitoringexporter/config_test.go
+++ b/internal/monitoringexporter/config_test.go
@@ -1,0 +1,140 @@
+package monitoringexporter
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseDSN(t *testing.T) {
+	cfg, err := ParseDSN("https://blnk_obs_abc123@observe.blnk.cloud/monproj_123")
+	if err != nil {
+		t.Fatalf("ParseDSN returned error: %v", err)
+	}
+
+	if cfg.PublicKey != "blnk_obs_abc123" {
+		t.Fatalf("expected write key blnk_obs_abc123, got %s", cfg.PublicKey)
+	}
+	if cfg.ProjectID != "monproj_123" {
+		t.Fatalf("expected project id monproj_123, got %s", cfg.ProjectID)
+	}
+	if cfg.Endpoint != "https://observe.blnk.cloud" {
+		t.Fatalf("expected endpoint https://observe.blnk.cloud, got %s", cfg.Endpoint)
+	}
+	if cfg.Timeout != 5*time.Second {
+		t.Fatalf("expected default timeout 5s, got %s", cfg.Timeout)
+	}
+}
+
+func TestParseDSNAllowsCustomHostWithSameShape(t *testing.T) {
+	cfg, err := ParseDSN("https://write_key_123@telemetry.example.com/project_123")
+	if err != nil {
+		t.Fatalf("ParseDSN returned error: %v", err)
+	}
+
+	if cfg.PublicKey != "write_key_123" {
+		t.Fatalf("expected write key write_key_123, got %s", cfg.PublicKey)
+	}
+	if cfg.ProjectID != "project_123" {
+		t.Fatalf("expected project id project_123, got %s", cfg.ProjectID)
+	}
+	if cfg.Endpoint != "https://telemetry.example.com" {
+		t.Fatalf("expected endpoint https://telemetry.example.com, got %s", cfg.Endpoint)
+	}
+	if cfg.SignalURL("logs") != "https://telemetry.example.com/monitoring/ingest/v1/logs" {
+		t.Fatalf("unexpected logs URL: %s", cfg.SignalURL("logs"))
+	}
+	if cfg.OTLPSignalURL("metrics") != "https://telemetry.example.com/monitoring/ingest/v1/otlp/metrics" {
+		t.Fatalf("unexpected OTLP metrics URL: %s", cfg.OTLPSignalURL("metrics"))
+	}
+}
+
+func TestParseDSNRejectsInvalidInputs(t *testing.T) {
+	tests := []string{
+		"",
+		"http://pk_test@observe.blnk.cloud/project_123",
+		"https://observe.blnk.cloud/project_123",
+		"https://example.com/in/e_test",
+		"https://pk_test@observe.blnk.cloud",
+		"https://pk_test@observe.blnk.cloud/project/extra",
+	}
+
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			if _, err := ParseDSN(input); err == nil {
+				t.Fatalf("expected error for %q", input)
+			}
+		})
+	}
+}
+
+func TestFromEnv(t *testing.T) {
+	t.Setenv(envDSN, "")
+	t.Setenv(envLegacyDSN, "")
+	cfg, enabled, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv returned error without DSN: %v", err)
+	}
+	if enabled {
+		t.Fatalf("expected monitoring exporter to be disabled without DSN")
+	}
+	if cfg.ProjectID != "" {
+		t.Fatalf("expected empty config without DSN")
+	}
+
+	t.Setenv(envDSN, "https://blnk_obs_live@observe.blnk.cloud/monproj_live")
+
+	cfg, enabled, err = FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv returned error: %v", err)
+	}
+	if !enabled {
+		t.Fatalf("expected monitoring exporter to be enabled")
+	}
+	if cfg.ProjectID != "monproj_live" {
+		t.Fatalf("expected project id to be copied, got %q", cfg.ProjectID)
+	}
+}
+
+func TestFromEnvFallsBackToLegacyCloudDSN(t *testing.T) {
+	t.Setenv(envDSN, "")
+	t.Setenv(envLegacyDSN, "https://legacy_key@observe.blnk.cloud/legacy_project")
+
+	cfg, enabled, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv returned error: %v", err)
+	}
+	if !enabled {
+		t.Fatalf("expected monitoring exporter to be enabled")
+	}
+	if cfg.ProjectID != "legacy_project" {
+		t.Fatalf("expected legacy project id, got %q", cfg.ProjectID)
+	}
+}
+
+func TestHeadersAndSignalURL(t *testing.T) {
+	cfg := Config{
+		PublicKey: "blnk_obs_abc123",
+		ProjectID: "monproj_123",
+		Endpoint:  "https://observe.blnk.cloud/",
+	}
+
+	headers := cfg.Headers()
+	if headers["Authorization"] != "Bearer blnk_obs_abc123" {
+		t.Fatalf("unexpected auth header: %s", headers["Authorization"])
+	}
+	if _, ok := headers["X-Blnk-Project-ID"]; ok {
+		t.Fatalf("did not expect project header")
+	}
+	if _, ok := headers["X-Blnk-Environment"]; ok {
+		t.Fatalf("did not expect environment header")
+	}
+	if _, ok := headers["X-Blnk-Instance-ID"]; ok {
+		t.Fatalf("did not expect instance id header")
+	}
+	if cfg.SignalURL("logs") != "https://observe.blnk.cloud/monitoring/ingest/v1/logs" {
+		t.Fatalf("unexpected logs URL: %s", cfg.SignalURL("logs"))
+	}
+	if cfg.OTLPSignalURL("traces") != "https://observe.blnk.cloud/monitoring/ingest/v1/otlp/traces" {
+		t.Fatalf("unexpected OTLP traces URL: %s", cfg.OTLPSignalURL("traces"))
+	}
+}

--- a/internal/monitoringexporter/exporters.go
+++ b/internal/monitoringexporter/exporters.go
@@ -1,0 +1,37 @@
+package monitoringexporter
+
+import (
+	"context"
+	"time"
+
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+// NewTraceExporter creates an OTLP/HTTP trace exporter for remote monitoring.
+func NewTraceExporter(ctx context.Context, cfg Config) (sdktrace.SpanExporter, error) {
+	return otlptracehttp.New(ctx,
+		otlptracehttp.WithEndpointURL(cfg.OTLPSignalURL("traces")),
+		otlptracehttp.WithHeaders(cfg.Headers()),
+		otlptracehttp.WithTimeout(cfg.Timeout),
+	)
+}
+
+// NewMetricReader creates an OTLP/HTTP metric reader for remote monitoring.
+func NewMetricReader(ctx context.Context, cfg Config) (sdkmetric.Reader, error) {
+	exporter, err := otlpmetrichttp.New(ctx,
+		otlpmetrichttp.WithEndpointURL(cfg.OTLPSignalURL("metrics")),
+		otlpmetrichttp.WithHeaders(cfg.Headers()),
+		otlpmetrichttp.WithTimeout(cfg.Timeout),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return sdkmetric.NewPeriodicReader(exporter,
+		sdkmetric.WithInterval(60*time.Second),
+		sdkmetric.WithTimeout(cfg.Timeout),
+	), nil
+}

--- a/internal/monitoringexporter/logs.go
+++ b/internal/monitoringexporter/logs.go
@@ -1,0 +1,138 @@
+package monitoringexporter
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const logQueueSize = 1024
+
+// LogHook asynchronously forwards sanitized logrus entries to remote monitoring.
+type LogHook struct {
+	cfg    Config
+	client *http.Client
+	queue  chan logPayload
+	closed atomic.Bool
+	wg     sync.WaitGroup
+	levels []logrus.Level
+}
+
+type logPayload struct {
+	Time    time.Time              `json:"time"`
+	Level   string                 `json:"level"`
+	Message string                 `json:"message"`
+	TraceID string                 `json:"trace_id,omitempty"`
+	SpanID  string                 `json:"span_id,omitempty"`
+	Fields  map[string]interface{} `json:"fields,omitempty"`
+}
+
+func NewLogHook(cfg Config) *LogHook {
+	h := &LogHook{
+		cfg: cfg,
+		client: &http.Client{
+			Timeout: cfg.Timeout,
+		},
+		queue:  make(chan logPayload, logQueueSize),
+		levels: logrus.AllLevels,
+	}
+	h.wg.Add(1)
+	go h.run()
+	return h
+}
+
+func InstallLogHook(cfg Config) *LogHook {
+	h := NewLogHook(cfg)
+	logrus.AddHook(h)
+	return h
+}
+
+func (h *LogHook) Levels() []logrus.Level {
+	return h.levels
+}
+
+func (h *LogHook) Fire(entry *logrus.Entry) error {
+	if h.closed.Load() {
+		return nil
+	}
+
+	payload := logPayload{
+		Time:    entry.Time.UTC(),
+		Level:   entry.Level.String(),
+		Message: RedactString(entry.Message),
+		Fields:  RedactFields(entry.Data),
+	}
+
+	if entry.Context != nil {
+		spanContext := trace.SpanContextFromContext(entry.Context)
+		if spanContext.IsValid() {
+			payload.TraceID = spanContext.TraceID().String()
+			payload.SpanID = spanContext.SpanID().String()
+		}
+	}
+
+	select {
+	case h.queue <- payload:
+	default:
+	}
+	return nil
+}
+
+func (h *LogHook) Shutdown(ctx context.Context) error {
+	if h.closed.Swap(true) {
+		return nil
+	}
+	close(h.queue)
+
+	done := make(chan struct{})
+	go func() {
+		h.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-done:
+		return nil
+	}
+}
+
+func (h *LogHook) run() {
+	defer h.wg.Done()
+	for payload := range h.queue {
+		h.send(payload)
+	}
+}
+
+func (h *LogHook) send(payload logPayload) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), h.cfg.Timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, h.cfg.SignalURL("logs"), bytes.NewReader(body))
+	if err != nil {
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	for key, value := range h.cfg.Headers() {
+		req.Header.Set(key, value)
+	}
+
+	resp, err := h.client.Do(req)
+	if err != nil {
+		return
+	}
+	_ = resp.Body.Close()
+}

--- a/internal/monitoringexporter/logs_test.go
+++ b/internal/monitoringexporter/logs_test.go
@@ -1,0 +1,78 @@
+package monitoringexporter
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestLogHookPostsSanitizedPayload(t *testing.T) {
+	received := make(chan logPayload, 1)
+	var authHeader string
+	var projectHeader string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/monitoring/ingest/v1/logs" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		authHeader = r.Header.Get("Authorization")
+		projectHeader = r.Header.Get("X-Blnk-Project-ID")
+
+		var payload logPayload
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Errorf("failed to decode payload: %v", err)
+		}
+		received <- payload
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer server.Close()
+
+	hook := NewLogHook(Config{
+		PublicKey: "blnk_obs_test",
+		ProjectID: "monproj_test",
+		Endpoint:  server.URL,
+		Timeout:   time.Second,
+	})
+
+	err := hook.Fire(&logrus.Entry{
+		Time:    time.Now(),
+		Level:   logrus.ErrorLevel,
+		Message: "failed request",
+		Data: logrus.Fields{
+			"Authorization": "Bearer secret",
+			"status":        "failed",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Fire returned error: %v", err)
+	}
+
+	select {
+	case payload := <-received:
+		if authHeader != "Bearer blnk_obs_test" {
+			t.Fatalf("unexpected auth header: %s", authHeader)
+		}
+		if projectHeader != "" {
+			t.Fatalf("did not expect project header: %s", projectHeader)
+		}
+		if payload.Fields["Authorization"] != redacted {
+			t.Fatalf("expected Authorization field to be redacted: %+v", payload.Fields)
+		}
+		if payload.Fields["status"] != "failed" {
+			t.Fatalf("expected safe status field to remain: %+v", payload.Fields)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for log payload")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := hook.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown returned error: %v", err)
+	}
+}

--- a/internal/monitoringexporter/redact.go
+++ b/internal/monitoringexporter/redact.go
@@ -1,0 +1,167 @@
+package monitoringexporter
+
+import (
+	"fmt"
+	"net/url"
+	"reflect"
+	"regexp"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+const redacted = "[REDACTED]"
+
+var sensitiveKeyParts = []string{
+	"authorization",
+	"token",
+	"secret",
+	"password",
+	"api_key",
+	"apikey",
+	"credential",
+	"dsn",
+	"url",
+	"uri",
+	"endpoint",
+	"callback",
+	"metadata",
+	"webhook",
+}
+
+var (
+	absoluteURLPattern = regexp.MustCompile(`https?://[^\s"'<>]+`)
+	queryValuePattern  = regexp.MustCompile(`([?&][^=\s&]+)=([^&\s]+)`)
+	bearerPattern      = regexp.MustCompile(`(?i)\bBearer\s+[A-Za-z0-9._~+/=-]+`)
+)
+
+func RedactFields(fields logrus.Fields) map[string]interface{} {
+	if len(fields) == 0 {
+		return nil
+	}
+
+	out := make(map[string]interface{}, len(fields))
+	for key, value := range fields {
+		if IsSensitiveKey(key) {
+			out[key] = redacted
+			continue
+		}
+		out[key] = RedactValue(value)
+	}
+	return out
+}
+
+func RedactValue(value interface{}) interface{} {
+	if value == nil {
+		return nil
+	}
+
+	switch v := value.(type) {
+	case error:
+		return RedactString(v.Error())
+	case string:
+		return RedactString(v)
+	case fmt.Stringer:
+		return RedactString(v.String())
+	case map[string]interface{}:
+		out := make(map[string]interface{}, len(v))
+		for key, nested := range v {
+			if IsSensitiveKey(key) {
+				out[key] = redacted
+				continue
+			}
+			out[key] = RedactValue(nested)
+		}
+		return out
+	case map[string]string:
+		out := make(map[string]interface{}, len(v))
+		for key, nested := range v {
+			if IsSensitiveKey(key) {
+				out[key] = redacted
+				continue
+			}
+			out[key] = RedactString(nested)
+		}
+		return out
+	case []interface{}:
+		out := make([]interface{}, len(v))
+		for i, nested := range v {
+			out[i] = RedactValue(nested)
+		}
+		return out
+	case []string:
+		out := make([]interface{}, len(v))
+		for i, nested := range v {
+			out[i] = RedactString(nested)
+		}
+		return out
+	default:
+		return redactReflectValue(value)
+	}
+}
+
+func RedactString(value string) string {
+	value = bearerPattern.ReplaceAllString(value, "Bearer "+redacted)
+	value = absoluteURLPattern.ReplaceAllStringFunc(value, redactURL)
+	value = queryValuePattern.ReplaceAllString(value, "$1"+redacted)
+	if len(value) <= 512 {
+		return value
+	}
+	return value[:512] + "...[truncated]"
+}
+
+func redactURL(raw string) string {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return redacted
+	}
+	if parsed.User != nil {
+		parsed.User = url.User(redacted)
+	}
+	if parsed.RawQuery != "" {
+		query := parsed.Query()
+		for key := range query {
+			query.Set(key, redacted)
+		}
+		parsed.RawQuery = query.Encode()
+	}
+	return parsed.String()
+}
+
+func IsSensitiveKey(key string) bool {
+	normalized := strings.ToLower(strings.ReplaceAll(strings.TrimSpace(key), "-", "_"))
+	for _, part := range sensitiveKeyParts {
+		if strings.Contains(normalized, part) {
+			return true
+		}
+	}
+	return false
+}
+
+func redactReflectValue(value interface{}) interface{} {
+	rv := reflect.ValueOf(value)
+	switch rv.Kind() {
+	case reflect.Map:
+		if rv.Type().Key().Kind() != reflect.String {
+			return value
+		}
+		out := make(map[string]interface{}, rv.Len())
+		for _, key := range rv.MapKeys() {
+			keyString := key.String()
+			if IsSensitiveKey(keyString) {
+				out[keyString] = redacted
+				continue
+			}
+			out[keyString] = RedactValue(rv.MapIndex(key).Interface())
+		}
+		return out
+	case reflect.Slice, reflect.Array:
+		out := make([]interface{}, rv.Len())
+		for i := 0; i < rv.Len(); i++ {
+			out[i] = RedactValue(rv.Index(i).Interface())
+		}
+		return out
+	default:
+		return value
+	}
+}

--- a/internal/monitoringexporter/redact_test.go
+++ b/internal/monitoringexporter/redact_test.go
@@ -1,0 +1,110 @@
+package monitoringexporter
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestRedactFields(t *testing.T) {
+	fields := logrus.Fields{
+		"Authorization": "Bearer secret",
+		"api_key":       "key",
+		"hook_url":      "https://secret@example.com/hook?token=abc",
+		"endpoint":      "https://observe.blnk.cloud/path?write_key=abc",
+		"metadata": map[string]interface{}{
+			"customer": "Jane",
+		},
+		"safe": "value",
+		"nested": map[string]interface{}{
+			"password": "pass",
+			"status":   "ok",
+		},
+	}
+
+	out := RedactFields(fields)
+	if out["Authorization"] != redacted {
+		t.Fatalf("expected Authorization to be redacted")
+	}
+	if out["api_key"] != redacted {
+		t.Fatalf("expected api_key to be redacted")
+	}
+	if out["hook_url"] != redacted {
+		t.Fatalf("expected hook_url to be redacted")
+	}
+	if out["endpoint"] != redacted {
+		t.Fatalf("expected endpoint to be redacted")
+	}
+	if out["metadata"] != redacted {
+		t.Fatalf("expected metadata to be redacted")
+	}
+	if out["safe"] != "value" {
+		t.Fatalf("expected safe field to remain")
+	}
+
+	nested := out["nested"].(map[string]interface{})
+	if nested["password"] != redacted {
+		t.Fatalf("expected nested password to be redacted")
+	}
+	if nested["status"] != "ok" {
+		t.Fatalf("expected nested status to remain")
+	}
+}
+
+func TestRedactStringTruncatesLongValues(t *testing.T) {
+	long := strings.Repeat("a", 600)
+	got := RedactString(long)
+	if len(got) >= len(long) {
+		t.Fatalf("expected long string to be truncated")
+	}
+	if !strings.Contains(got, "[truncated]") {
+		t.Fatalf("expected truncation marker")
+	}
+}
+
+func TestRedactStringSanitizesSecretsInMessages(t *testing.T) {
+	input := `GET /transactions?token=abc&safe=ok https://user:pass@example.com/cb?signature=secret Authorization: Bearer live_token`
+	got := RedactString(input)
+
+	for _, leaked := range []string{"token=abc", "safe=ok", "user:pass", "signature=secret", "live_token"} {
+		if strings.Contains(got, leaked) {
+			t.Fatalf("expected %q to be redacted from %q", leaked, got)
+		}
+	}
+	if !strings.Contains(got, "[REDACTED]") {
+		t.Fatalf("expected redaction marker in %q", got)
+	}
+}
+
+func TestRedactValueHandlesStringMapsAndSlices(t *testing.T) {
+	input := logrus.Fields{
+		"headers": map[string]string{
+			"Authorization": "Bearer secret",
+			"X-Request-ID":  "req_123",
+		},
+		"items": []interface{}{
+			map[string]string{"callback_url": "https://example.com/cb?token=abc"},
+			"https://example.com/path?token=abc",
+		},
+	}
+
+	out := RedactFields(input)
+
+	headers := out["headers"].(map[string]interface{})
+	if headers["Authorization"] != redacted {
+		t.Fatalf("expected nested Authorization to be redacted: %+v", headers)
+	}
+	if headers["X-Request-ID"] != "req_123" {
+		t.Fatalf("expected safe string map value to remain: %+v", headers)
+	}
+
+	items := out["items"].([]interface{})
+	first := items[0].(map[string]interface{})
+	if first["callback_url"] != redacted {
+		t.Fatalf("expected nested callback_url to be redacted: %+v", first)
+	}
+	if strings.Contains(items[1].(string), "token=abc") {
+		t.Fatalf("expected URL query value in slice to be redacted: %s", items[1].(string))
+	}
+}

--- a/internal/traces/otel.go
+++ b/internal/traces/otel.go
@@ -24,6 +24,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/blnkfinance/blnk/internal/monitoringexporter"
+	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
@@ -52,7 +54,7 @@ func MetricsHandler() http.Handler {
 
 // SetupOTelSDK bootstraps the OpenTelemetry pipeline.
 // If it does not return an error, make sure to call shutdown for proper cleanup.
-func SetupOTelSDK(ctx context.Context, serviceName string) (shutdown func(context.Context) error, err error) {
+func SetupOTelSDK(ctx context.Context, serviceName, monitoringDSN string) (shutdown func(context.Context) error, err error) {
 	var shutdownFuncs []func(context.Context) error
 
 	// shutdown calls cleanup functions registered via shutdownFuncs.
@@ -78,12 +80,14 @@ func SetupOTelSDK(ctx context.Context, serviceName string) (shutdown func(contex
 		return shutdown, err
 	}
 
+	exporterCfg, exporterEnabled := monitoringExporterConfigFromDSN(monitoringDSN)
+
 	// Set up propagator.
 	prop := newPropagator()
 	otel.SetTextMapPropagator(prop)
 
 	// Set up trace provider.
-	tracerProvider, err := newTraceProvider(ctx, res)
+	tracerProvider, err := newTraceProvider(ctx, res, exporterCfg, exporterEnabled)
 	if err != nil {
 		handleErr(err)
 		return
@@ -92,7 +96,7 @@ func SetupOTelSDK(ctx context.Context, serviceName string) (shutdown func(contex
 	otel.SetTracerProvider(tracerProvider)
 
 	// Set up meter provider (dual-mode: Prometheus pull + OTLP push).
-	meterProvider, err := newMeterProvider(ctx, res)
+	meterProvider, err := newMeterProvider(ctx, res, exporterCfg, exporterEnabled)
 	if err != nil {
 		handleErr(err)
 		return
@@ -108,6 +112,12 @@ func SetupOTelSDK(ctx context.Context, serviceName string) (shutdown func(contex
 	}
 	shutdownFuncs = append(shutdownFuncs, loggerProvider.Shutdown)
 	global.SetLoggerProvider(loggerProvider)
+
+	if exporterEnabled {
+		exporterLogs := monitoringexporter.InstallLogHook(exporterCfg)
+		shutdownFuncs = append(shutdownFuncs, exporterLogs.Shutdown)
+		logrus.Info("monitoring exporter enabled")
+	}
 
 	return
 }
@@ -128,17 +138,28 @@ func newPropagator() propagation.TextMapPropagator {
 	)
 }
 
-func newTraceProvider(ctx context.Context, res *resource.Resource) (*sdktrace.TracerProvider, error) {
+func newTraceProvider(ctx context.Context, res *resource.Resource, exporterCfg monitoringexporter.Config, exporterEnabled bool) (*sdktrace.TracerProvider, error) {
 	exporter, err := newTraceExporter(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	traceProvider := sdktrace.NewTracerProvider(
+	opts := []sdktrace.TracerProviderOption{
 		sdktrace.WithBatcher(exporter,
 			sdktrace.WithBatchTimeout(5*time.Second)),
 		sdktrace.WithResource(res),
-	)
+	}
+	if exporterEnabled {
+		exporter, err := monitoringexporter.NewTraceExporter(ctx, exporterCfg)
+		if err != nil {
+			logrus.WithError(err).Warn("monitoring trace exporter unavailable")
+		} else {
+			opts = append(opts, sdktrace.WithBatcher(exporter,
+				sdktrace.WithBatchTimeout(5*time.Second)))
+		}
+	}
+
+	traceProvider := sdktrace.NewTracerProvider(opts...)
 	return traceProvider, nil
 }
 
@@ -146,7 +167,7 @@ func newTraceProvider(ctx context.Context, res *resource.Resource) (*sdktrace.Tr
 //   - Pull (Prometheus): always active — exposes metrics via /metrics endpoint for scraping.
 //   - Push (OTLP HTTP): opt-in — enabled when OTEL_EXPORTER_OTLP_ENDPOINT is set.
 //     Uses the standard OTel env var, so it works automatically with any OTel Collector.
-func newMeterProvider(ctx context.Context, res *resource.Resource) (*sdkmetric.MeterProvider, error) {
+func newMeterProvider(ctx context.Context, res *resource.Resource, exporterCfg monitoringexporter.Config, exporterEnabled bool) (*sdkmetric.MeterProvider, error) {
 	// Pull exporter: Prometheus scrape endpoint (always active).
 	promExp, err := promexporter.New()
 	if err != nil {
@@ -173,6 +194,15 @@ func newMeterProvider(ctx context.Context, res *resource.Resource) (*sdkmetric.M
 		opts = append(opts, sdkmetric.WithReader(sdkmetric.NewPeriodicReader(otlpExp,
 			sdkmetric.WithInterval(60*time.Second),
 		)))
+	}
+
+	if exporterEnabled {
+		exporterReader, err := monitoringexporter.NewMetricReader(ctx, exporterCfg)
+		if err != nil {
+			logrus.WithError(err).Warn("monitoring metric exporter unavailable")
+		} else {
+			opts = append(opts, sdkmetric.WithReader(exporterReader))
+		}
 	}
 
 	meterProvider := sdkmetric.NewMeterProvider(opts...)
@@ -223,4 +253,13 @@ func parseOTLPEndpoint(endpoint string) (hostPort string, insecure bool) {
 		return endpoint, true
 	}
 	return parsed.Host, parsed.Scheme != "https"
+}
+
+func monitoringExporterConfigFromDSN(dsn string) (monitoringexporter.Config, bool) {
+	cfg, enabled, err := monitoringexporter.FromDSN(dsn)
+	if err != nil {
+		logrus.WithError(err).Warn("monitoring exporter disabled")
+		return monitoringexporter.Config{}, false
+	}
+	return cfg, enabled
 }

--- a/internal/traces/otel_test.go
+++ b/internal/traces/otel_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/blnkfinance/blnk/internal/monitoringexporter"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/sdk/resource"
@@ -26,7 +27,7 @@ func TestNewMeterProvider_PrometheusOnlyWhenNoOTLPEndpoint(t *testing.T) {
 	))
 	require.NoError(t, err)
 
-	mp, err := newMeterProvider(ctx, res)
+	mp, err := newMeterProvider(ctx, res, monitoringExporterConfigForTest(), false)
 	require.NoError(t, err)
 	require.NotNil(t, mp)
 	t.Cleanup(func() { _ = mp.Shutdown(ctx) })
@@ -48,7 +49,7 @@ func TestMetricsHandler_ServesPrometheusFormat(t *testing.T) {
 	))
 	require.NoError(t, err)
 
-	mp, err := newMeterProvider(ctx, res)
+	mp, err := newMeterProvider(ctx, res, monitoringExporterConfigForTest(), false)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = mp.Shutdown(ctx) })
 
@@ -109,4 +110,34 @@ func TestParseOTLPEndpoint(t *testing.T) {
 			assert.Equal(t, tt.wantInsecure, insecure)
 		})
 	}
+}
+
+func TestCloudConfigFromDSN(t *testing.T) {
+	cfg, enabled := monitoringExporterConfigFromDSN("")
+	if enabled {
+		t.Fatalf("expected cloud config to be disabled without DSN")
+	}
+	if cfg.ProjectID != "" {
+		t.Fatalf("expected empty cloud config without DSN")
+	}
+
+	cfg, enabled = monitoringExporterConfigFromDSN("not-a-dsn")
+	if enabled {
+		t.Fatalf("expected invalid cloud config to be disabled")
+	}
+	if cfg.ProjectID != "" {
+		t.Fatalf("expected empty cloud config for invalid DSN")
+	}
+
+	cfg, enabled = monitoringExporterConfigFromDSN("https://pk_test@observe.blnk.cloud/project_123")
+	if !enabled {
+		t.Fatalf("expected valid cloud config to be enabled")
+	}
+	if cfg.ProjectID != "project_123" {
+		t.Fatalf("expected project_123, got %s", cfg.ProjectID)
+	}
+}
+
+func monitoringExporterConfigForTest() monitoringexporter.Config {
+	return monitoringexporter.Config{}
 }

--- a/queue_recovery.go
+++ b/queue_recovery.go
@@ -48,7 +48,7 @@ func NewQueuedTransactionRecoveryProcessor(blnk *Blnk) *QueuedTransactionRecover
 		blnk:                     blnk,
 		batchSize:                100,
 		maxWorkers:               1,
-		pollInterval:             30 * time.Second,
+		pollInterval:             30 * time.Minute,
 		stuckThreshold:           2 * time.Hour,
 		maxRecoveryAttempts:      3,
 		stopCh:                   make(chan struct{}),

--- a/transaction.go
+++ b/transaction.go
@@ -391,11 +391,20 @@ func (l *Blnk) validateTxn(ctx context.Context, transaction *model.Transaction) 
 	if txn {
 		err := fmt.Errorf("reference %s has already been used", transaction.Reference)
 		span.RecordError(err)
+		notification.NotifyError(err)
 		return err
 	}
 
 	span.AddEvent("Transaction validated")
 	return nil
+}
+
+func IsDuplicateReferenceError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "reference") && strings.Contains(msg, "already been used")
 }
 
 // applyTransactionToBalances applies a transaction to the provided balances.
@@ -1562,11 +1571,15 @@ func (l *Blnk) validateQueuedBatchTransactionReference(ctx context.Context, tran
 	}
 
 	if _, ok := batchReferences[transaction.Reference]; ok {
-		return fmt.Errorf("reference %s has already been used", transaction.Reference)
+		err := fmt.Errorf("reference %s has already been used", transaction.Reference)
+		notification.NotifyError(err)
+		return err
 	}
 
 	if _, ok := existingReferences[transaction.Reference]; ok {
-		return fmt.Errorf("reference %s has already been used", transaction.Reference)
+		err := fmt.Errorf("reference %s has already been used", transaction.Reference)
+		notification.NotifyError(err)
+		return err
 	}
 
 	if len(prefetchedReferences) == 0 {

--- a/transaction_batch_test.go
+++ b/transaction_batch_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/blnkfinance/blnk/config"
 	"github.com/blnkfinance/blnk/database/mocks"
+	"github.com/blnkfinance/blnk/internal/notification"
 	"github.com/blnkfinance/blnk/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -272,6 +273,41 @@ func TestValidateQueuedBatchTransactionReferenceUsesPrefetchedSet(t *testing.T) 
 	}, prefetched, existing, batch)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "already been used")
+}
+
+func TestValidateQueuedBatchTransactionReferenceNotifiesDuplicateReference(t *testing.T) {
+	if currentConfig, err := config.Fetch(); err == nil {
+		t.Cleanup(func() { config.MockConfig(currentConfig) })
+	}
+	config.MockConfig(&config.Configuration{
+		DataSource: config.DataSourceConfig{Dns: "postgres://test"},
+		Redis:      config.RedisConfig{Dns: "redis://test"},
+		Notification: config.Notification{
+			Webhook: config.WebhookConfig{Url: "http://example.com/system-error"},
+		},
+	})
+
+	events := make(chan string, 1)
+	notification.RegisterWebhookSender(func(event string, payload interface{}) error {
+		events <- event
+		return nil
+	})
+	t.Cleanup(func() { notification.RegisterWebhookSender(nil) })
+
+	blnkInstance := &Blnk{}
+	err := blnkInstance.validateQueuedBatchTransactionReference(context.Background(), &model.Transaction{
+		Reference: "duplicate_ref_q",
+	}, map[string]struct{}{"duplicate_ref_q": {}}, map[string]struct{}{"duplicate_ref_q": {}}, map[string]struct{}{})
+
+	assert.Error(t, err)
+	assert.True(t, IsDuplicateReferenceError(err))
+
+	select {
+	case event := <-events:
+		assert.Equal(t, "system.error", event)
+	case <-time.After(time.Second):
+		t.Fatal("expected system.error webhook event for duplicate reference")
+	}
 }
 
 func TestBatchReferenceCheckEnabled(t *testing.T) {


### PR DESCRIPTION
## Summary
  - Add `internal/monitoringexporter` for optional remote logs, traces, and metrics export via monitoring DSN.
  - Support `BLNK_MONITORING_DSN`.
  - Forward logrus entries asynchronously with bounded queue behavior.
  - Harden exported log payloads by redacting sensitive fields, bearer tokens, DSNs, URLs, userinfo, and query values.
  - Replace raw Gin access/recovery logging with structured query-free logs.

Fix #305.