### PR TITLE
Every API error response now carries a structured `error_detail` object

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -86,6 +86,6 @@ jobs:
           BLNK_REDIS_DNS: localhost:6379
 
       - name: Test
-        run: go test -v ./...
+        run: go test -v -p 1 ./...
         env:
           BLNK_TYPESENSE_DNS: http://localhost:8108

--- a/api/accounts.go
+++ b/api/accounts.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 
 	model2 "github.com/blnkfinance/blnk/api/model"
+	"github.com/blnkfinance/blnk/internal/apierror"
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/gin-gonic/gin"
@@ -39,19 +40,19 @@ import (
 func (a Api) CreateAccount(c *gin.Context) {
 	var newAccount model2.CreateAccount
 	if err := c.ShouldBindJSON(&newAccount); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondCode(c, apierror.ErrGenMalformedRequest, err.Error(), nil)
 		return
 	}
 
 	err := newAccount.ValidateCreateAccount()
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"errors": err.Error()})
+		respondCode(c, apierror.ErrGenValidation, err.Error(), nil, withLegacyKey("errors"))
 		return
 	}
 
 	resp, err := a.blnk.CreateAccount(newAccount.ToAccount())
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondError(c, err, withUpgrade(apierror.ErrGenConflict, apierror.ErrAccDuplicate))
 		return
 	}
 	c.JSON(http.StatusCreated, resp)
@@ -75,7 +76,7 @@ func (a Api) GetAccount(c *gin.Context) {
 
 	account, err := a.blnk.GetAccount(id, includes)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondError(c, err, withUpgrade(apierror.ErrGenNotFound, apierror.ErrAccNotFound))
 		return
 	}
 	c.JSON(http.StatusOK, account)
@@ -114,14 +115,15 @@ func (a Api) GetAllAccounts(c *gin.Context) {
 	if HasFilters(c) {
 		filters, parseErrors := ParseFiltersFromContext(c, nil)
 		if len(parseErrors) > 0 {
-			c.JSON(http.StatusBadRequest, gin.H{"errors": parseErrors})
+			respondCode(c, apierror.ErrGenValidation, "invalid filter parameters", parseErrors,
+				withLegacyKey("errors"), withLegacyValue(parseErrors))
 			return
 		}
 
 		// Use the new filter method
 		resp, err := a.blnk.GetAllAccountsWithFilter(c.Request.Context(), filters, limitInt, offsetInt)
 		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			respondError(c, err)
 			return
 		}
 
@@ -132,7 +134,7 @@ func (a Api) GetAllAccounts(c *gin.Context) {
 	// Fall back to the legacy method when no filters are present
 	accounts, err := a.blnk.GetAllAccounts()
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, accounts)
@@ -161,13 +163,13 @@ func (a Api) GetAllAccounts(c *gin.Context) {
 func (a Api) FilterAccounts(c *gin.Context) {
 	filters, opts, limit, offset, err := ParseFiltersFromBody(c, "accounts")
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondCode(c, apierror.ErrGenValidation, err.Error(), nil)
 		return
 	}
 
 	resp, count, err := a.blnk.GetAllAccountsWithFilterAndOptions(c.Request.Context(), filters, opts, limit, offset)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
 

--- a/api/admin.go
+++ b/api/admin.go
@@ -31,17 +31,17 @@ import (
 // - c: The Gin context containing the request and response.
 //
 // Responses:
-// - 400 Bad Request: If there's an error in creating the backup or initializing the BackupManager.
+// - 500 Internal Server Error: If there's an error in creating the backup or initializing the BackupManager.
 // - 200 OK: If the backup is successfully created and stored on disk.
 func (a Api) BackupDB(c *gin.Context) {
 	backupManager, err := backups.NewBackupManager()
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": apierror.NewAPIError(apierror.ErrInternalServer, "error creating backup", err)})
+		respondNestedAPIError(c, apierror.NewAPIError(apierror.ErrInternalServer, "error creating backup", err), apierror.ErrAdminBackupFailed)
 		return
 	}
 	_, err = backupManager.BackupToDisk(c.Request.Context())
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": apierror.NewAPIError(apierror.ErrInternalServer, "error creating backup", err)})
+		respondNestedAPIError(c, apierror.NewAPIError(apierror.ErrInternalServer, "error creating backup", err), apierror.ErrAdminBackupFailed)
 		return
 	}
 	c.JSON(http.StatusOK, "backup successful")
@@ -55,17 +55,17 @@ func (a Api) BackupDB(c *gin.Context) {
 // - c: The Gin context containing the request and response.
 //
 // Responses:
-// - 400 Bad Request: If there's an error in creating the backup or initializing the BackupManager.
+// - 500 Internal Server Error: If there's an error in creating the backup or initializing the BackupManager.
 // - 200 OK: If the backup is successfully created and stored in S3.
 func (a Api) BackupDBS3(c *gin.Context) {
 	backupManager, err := backups.NewBackupManager()
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": apierror.NewAPIError(apierror.ErrInternalServer, "error creating backup", err)})
+		respondNestedAPIError(c, apierror.NewAPIError(apierror.ErrInternalServer, "error creating backup", err), apierror.ErrAdminBackupFailed)
 		return
 	}
 	err = backupManager.BackupToS3(c.Request.Context())
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": apierror.NewAPIError(apierror.ErrInternalServer, "error creating backup", err)})
+		respondNestedAPIError(c, apierror.NewAPIError(apierror.ErrInternalServer, "error creating backup", err), apierror.ErrAdminBackupFailed)
 		return
 	}
 	c.JSON(http.StatusOK, "backup successful")

--- a/api/admin_api_test.go
+++ b/api/admin_api_test.go
@@ -39,7 +39,7 @@ func TestBackupDB(t *testing.T) {
 		req := httptest.NewRequest("GET", "/backup", nil)
 		resp := httptest.NewRecorder()
 		router.ServeHTTP(resp, req)
-		assert.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.Equal(t, http.StatusInternalServerError, resp.Code)
 		assert.Contains(t, resp.Body.String(), "error creating backup")
 	})
 
@@ -67,7 +67,7 @@ func TestBackupDBS3(t *testing.T) {
 		req := httptest.NewRequest("GET", "/backup-s3", nil)
 		resp := httptest.NewRecorder()
 		router.ServeHTTP(resp, req)
-		assert.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.Equal(t, http.StatusInternalServerError, resp.Code)
 		assert.Contains(t, resp.Body.String(), "error creating backup")
 	})
 }

--- a/api/api.go
+++ b/api/api.go
@@ -26,6 +26,7 @@ import (
 	"github.com/blnkfinance/blnk"
 	"github.com/blnkfinance/blnk/api/middleware"
 	"github.com/blnkfinance/blnk/config"
+	"github.com/blnkfinance/blnk/internal/apierror"
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 )
@@ -229,20 +230,20 @@ func logrusRecovery() gin.HandlerFunc {
 func (a Api) Search(c *gin.Context) {
 	collection, passed := c.Params.Get("collection")
 	if !passed {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "collection is required. pass id in the route /:collection"})
+		respondCode(c, apierror.ErrGenMissingParameter, "collection is required. pass id in the route /:collection", nil)
 		return
 	}
 
 	var query api.SearchCollectionParams
 	err := c.BindJSON(&query)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondCode(c, apierror.ErrGenMalformedRequest, err.Error(), nil)
 		return
 	}
 
 	resp, err := a.blnk.Search(collection, &query)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondError(c, err, withDefault(apierror.ErrSrchQueryInvalid))
 		return
 	}
 
@@ -262,13 +263,13 @@ func (a Api) Search(c *gin.Context) {
 func (a Api) MultiSearch(c *gin.Context) {
 	var searchRequests api.MultiSearchSearchesParameter
 	if err := c.BindJSON(&searchRequests); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondCode(c, apierror.ErrGenMalformedRequest, err.Error(), nil)
 		return
 	}
 
 	resp, err := a.blnk.MultiSearch(&searchRequests)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondError(c, err, withDefault(apierror.ErrSrchQueryInvalid))
 		return
 	}
 

--- a/api/api_coverage_test.go
+++ b/api/api_coverage_test.go
@@ -45,7 +45,7 @@ func TestDeleteIdentityAPI(t *testing.T) {
 
 	t.Run("Delete nonexistent identity", func(t *testing.T) {
 		resp := doJSONRequest(router, "DELETE", "/identities/idt_nonexistent", nil)
-		assert.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.Equal(t, http.StatusNotFound, resp.Code)
 	})
 }
 

--- a/api/apikeys.go
+++ b/api/apikeys.go
@@ -7,6 +7,7 @@ import (
 	authz "github.com/blnkfinance/blnk/api/middleware"
 	"github.com/blnkfinance/blnk/api/model"
 	"github.com/blnkfinance/blnk/database"
+	"github.com/blnkfinance/blnk/internal/apierror"
 	coremodel "github.com/blnkfinance/blnk/model"
 	"github.com/gin-gonic/gin"
 )
@@ -75,12 +76,16 @@ func writeAPIKeyAuthorizationError(c *gin.Context, err error) bool {
 	}
 
 	switch err {
-	case errAPIKeyOwnerRequired, errMissingAPIKeyPrincipal:
-		c.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
-	case errAPIKeyCrossOwnerAccess, errAPIKeyScopeEscalation:
-		c.JSON(http.StatusForbidden, gin.H{"error": err.Error()})
+	case errAPIKeyOwnerRequired:
+		respondCode(c, apierror.ErrAPIKeyOwnerRequired, err.Error(), nil)
+	case errMissingAPIKeyPrincipal:
+		respondCode(c, apierror.ErrAuthMissingPrincipal, err.Error(), nil)
+	case errAPIKeyCrossOwnerAccess:
+		respondCode(c, apierror.ErrAuthCrossOwnerAccess, err.Error(), nil)
+	case errAPIKeyScopeEscalation:
+		respondCode(c, apierror.ErrAuthScopeEscalation, err.Error(), nil)
 	default:
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 	}
 
 	return true
@@ -97,7 +102,7 @@ func writeAPIKeyAuthorizationError(c *gin.Context, err error) bool {
 func (a Api) CreateAPIKey(c *gin.Context) {
 	var req model.CreateAPIKeyRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondCode(c, apierror.ErrGenMalformedRequest, err.Error(), nil)
 		return
 	}
 
@@ -115,7 +120,7 @@ func (a Api) CreateAPIKey(c *gin.Context) {
 
 	apiKey, err := a.blnk.CreateAPIKey(c.Request.Context(), req.Name, ownerID, req.Scopes, req.ExpiresAt)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
 
@@ -141,7 +146,7 @@ func (a Api) ListAPIKeys(c *gin.Context) {
 
 	keys, err := a.blnk.ListAPIKeys(c.Request.Context(), ownerID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
 
@@ -170,11 +175,13 @@ func (a Api) RevokeAPIKey(c *gin.Context) {
 	if err := a.blnk.RevokeAPIKey(c.Request.Context(), id, ownerID); err != nil {
 		switch err {
 		case database.ErrAPIKeyNotFound:
-			c.JSON(http.StatusNotFound, gin.H{"error": "API key not found"})
+			respondCode(c, apierror.ErrAPIKeyNotFound, "API key not found", nil)
 		case database.ErrInvalidAPIKey:
-			c.JSON(http.StatusForbidden, gin.H{"error": "unauthorized"})
+			// In the revoke flow this means the key belongs to another owner —
+			// an authorization failure, so 403 (not 401) stays correct.
+			respondCode(c, apierror.ErrAuthCrossOwnerAccess, "unauthorized", nil)
 		default:
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			respondError(c, err)
 		}
 		return
 	}

--- a/api/apikeys_http_test.go
+++ b/api/apikeys_http_test.go
@@ -126,7 +126,8 @@ func TestListAPIKeysHTTP(t *testing.T) {
 	t.Run("Master without owner is rejected", func(t *testing.T) {
 		router, _ := setupAuthedRouter(t, true, nil)
 		resp := doJSONRequest(router, "GET", "/api-keys", nil)
-		assert.Equal(t, http.StatusUnauthorized, resp.Code)
+		// Owner-required is payload validation, not authentication: 400.
+		assert.Equal(t, http.StatusBadRequest, resp.Code)
 	})
 
 	t.Run("Non-master lists own keys", func(t *testing.T) {

--- a/api/balance.go
+++ b/api/balance.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	model2 "github.com/blnkfinance/blnk/api/model"
+	"github.com/blnkfinance/blnk/internal/apierror"
 
 	"github.com/blnkfinance/blnk/model"
 	"github.com/gin-gonic/gin"
@@ -40,19 +41,19 @@ import (
 func (a Api) CreateBalance(c *gin.Context) {
 	var newBalance model2.CreateBalance
 	if err := c.ShouldBindJSON(&newBalance); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondCode(c, apierror.ErrGenMalformedRequest, err.Error(), nil)
 		return
 	}
 
 	err := newBalance.ValidateCreateBalance()
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"errors": err.Error()})
+		respondCode(c, apierror.ErrGenValidation, err.Error(), nil, withLegacyKey("errors"))
 		return
 	}
 
 	resp, err := a.blnk.CreateBalance(c.Request.Context(), newBalance.ToBalance())
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondError(c, err, withUpgrade(apierror.ErrGenValidation, apierror.ErrBalValidation))
 		return
 	}
 
@@ -73,7 +74,7 @@ func (a Api) CreateBalance(c *gin.Context) {
 func (a Api) GetBalance(c *gin.Context) {
 	id, passed := c.Params.Get("id")
 	if !passed {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "id is required. pass id in the route /:id"})
+		respondCode(c, apierror.ErrGenMissingParameter, "id is required. pass id in the route /:id", nil)
 		return
 	}
 
@@ -85,7 +86,7 @@ func (a Api) GetBalance(c *gin.Context) {
 
 	resp, err := a.blnk.GetBalanceByID(c.Request.Context(), id, includes, withQueued)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondError(c, err, withUpgrade(apierror.ErrGenNotFound, apierror.ErrBalNotFound))
 		return
 	}
 
@@ -111,13 +112,13 @@ func (a Api) GetBalances(c *gin.Context) {
 	// Extract pagination parameters (limit and offset)
 	limit, err := strconv.Atoi(c.DefaultQuery("limit", "10")) // Default to 10 if not specified
 	if err != nil || limit <= 0 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid limit value"})
+		respondCode(c, apierror.ErrGenValidation, "invalid limit value", nil)
 		return
 	}
 
 	offset, err := strconv.Atoi(c.DefaultQuery("offset", "0")) // Default to 0 if not specified
 	if err != nil || offset < 0 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid offset value"})
+		respondCode(c, apierror.ErrGenValidation, "invalid offset value", nil)
 		return
 	}
 
@@ -125,14 +126,15 @@ func (a Api) GetBalances(c *gin.Context) {
 	if HasFilters(c) {
 		filters, parseErrors := ParseFiltersFromContext(c, nil)
 		if len(parseErrors) > 0 {
-			c.JSON(http.StatusBadRequest, gin.H{"errors": parseErrors})
+			respondCode(c, apierror.ErrGenValidation, "invalid filter parameters", parseErrors,
+				withLegacyKey("errors"), withLegacyValue(parseErrors))
 			return
 		}
 
 		// Use the new filter method
 		resp, err := a.blnk.GetAllBalancesWithFilter(c.Request.Context(), filters, limit, offset)
 		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			respondError(c, err)
 			return
 		}
 
@@ -143,7 +145,7 @@ func (a Api) GetBalances(c *gin.Context) {
 	// Fetch balances with pagination
 	resp, err := a.blnk.GetAllBalances(c.Request.Context(), limit, offset)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
 
@@ -173,13 +175,13 @@ func (a Api) GetBalances(c *gin.Context) {
 func (a Api) FilterBalances(c *gin.Context) {
 	filters, opts, limit, offset, err := ParseFiltersFromBody(c, "balances")
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondCode(c, apierror.ErrGenValidation, err.Error(), nil)
 		return
 	}
 
 	resp, count, err := a.blnk.GetAllBalancesWithFilterAndOptions(c.Request.Context(), filters, opts, limit, offset)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
 
@@ -204,19 +206,19 @@ func (a Api) FilterBalances(c *gin.Context) {
 func (a Api) CreateBalanceMonitor(c *gin.Context) {
 	var newMonitor model2.CreateBalanceMonitor
 	if err := c.ShouldBindJSON(&newMonitor); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondCode(c, apierror.ErrGenMalformedRequest, err.Error(), nil)
 		return
 	}
 
 	err := newMonitor.ValidateCreateBalanceMonitor()
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"errors": err.Error()})
+		respondCode(c, apierror.ErrGenValidation, err.Error(), nil, withLegacyKey("errors"))
 		return
 	}
 
 	resp, err := a.blnk.CreateMonitor(c.Request.Context(), newMonitor.ToBalanceMonitor())
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
 
@@ -236,13 +238,13 @@ func (a Api) CreateBalanceMonitor(c *gin.Context) {
 func (a Api) GetBalanceMonitor(c *gin.Context) {
 	id, passed := c.Params.Get("id")
 	if !passed {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "id is required. pass id in the route /:id"})
+		respondCode(c, apierror.ErrGenMissingParameter, "id is required. pass id in the route /:id", nil)
 		return
 	}
 
 	resp, err := a.blnk.GetMonitorByID(c.Request.Context(), id)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondError(c, err, withUpgrade(apierror.ErrGenNotFound, apierror.ErrBalMonitorNotFound))
 		return
 	}
 
@@ -262,7 +264,7 @@ func (a Api) GetBalanceMonitor(c *gin.Context) {
 func (a Api) GetAllBalanceMonitors(c *gin.Context) {
 	monitors, err := a.blnk.GetAllMonitors(c.Request.Context())
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
 
@@ -282,13 +284,13 @@ func (a Api) GetAllBalanceMonitors(c *gin.Context) {
 func (a Api) GetBalanceMonitorsByBalanceID(c *gin.Context) {
 	balanceID, passed := c.Params.Get("balance_id")
 	if !passed {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "balance_id is required. pass balance_id in the route /:balance_id"})
+		respondCode(c, apierror.ErrGenMissingParameter, "balance_id is required. pass balance_id in the route /:balance_id", nil)
 		return
 	}
 
 	monitors, err := a.blnk.GetBalanceMonitors(c.Request.Context(), balanceID)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
 
@@ -310,19 +312,19 @@ func (a Api) UpdateBalanceMonitor(c *gin.Context) {
 	var monitor model.BalanceMonitor
 	id, passed := c.Params.Get("id")
 	if !passed {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "id is required. pass id in the route /:id"})
+		respondCode(c, apierror.ErrGenMissingParameter, "id is required. pass id in the route /:id", nil)
 		return
 	}
 
 	if err := c.ShouldBindJSON(&monitor); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondCode(c, apierror.ErrGenMalformedRequest, err.Error(), nil)
 		return
 	}
 
 	monitor.MonitorID = id
 	err := a.blnk.UpdateMonitor(c.Request.Context(), &monitor)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondError(c, err, withUpgrade(apierror.ErrGenNotFound, apierror.ErrBalMonitorNotFound))
 		return
 	}
 
@@ -342,13 +344,13 @@ func (a Api) UpdateBalanceMonitor(c *gin.Context) {
 func (a Api) DeleteBalanceMonitor(c *gin.Context) {
 	id, passed := c.Params.Get("id")
 	if !passed {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "id is required. pass id in the route /:id"})
+		respondCode(c, apierror.ErrGenMissingParameter, "id is required. pass id in the route /:id", nil)
 		return
 	}
 
 	err := a.blnk.DeleteMonitor(c.Request.Context(), id)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondError(c, err, withUpgrade(apierror.ErrGenNotFound, apierror.ErrBalMonitorNotFound))
 		return
 	}
 
@@ -368,7 +370,7 @@ func (a Api) TakeBalanceSnapshots(c *gin.Context) {
 	// Get batch size from query parameter, default to 1000 if not specified
 	batchSize, err := strconv.Atoi(c.DefaultQuery("batch_size", "1000"))
 	if err != nil || batchSize <= 0 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid batch_size value"})
+		respondCode(c, apierror.ErrGenValidation, "invalid batch_size value", nil)
 		return
 	}
 
@@ -394,7 +396,7 @@ func (a Api) TakeBalanceSnapshots(c *gin.Context) {
 func (a Api) GetBalanceAtTime(c *gin.Context) {
 	balanceID, exists := c.Params.Get("id")
 	if !exists {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "balance ID is required"})
+		respondCode(c, apierror.ErrGenMissingParameter, "balance ID is required", nil)
 		return
 	}
 
@@ -407,9 +409,7 @@ func (a Api) GetBalanceAtTime(c *gin.Context) {
 		var err error
 		timestamp, err = time.Parse(time.RFC3339, timestampStr)
 		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{
-				"error": "invalid timestamp format. Please use ISO 8601 format (e.g., 2024-01-01T15:04:05Z)",
-			})
+			respondCode(c, apierror.ErrBalInvalidTimestamp, "invalid timestamp format. Please use ISO 8601 format (e.g., 2024-01-01T15:04:05Z)", nil)
 			return
 		}
 	}
@@ -420,7 +420,7 @@ func (a Api) GetBalanceAtTime(c *gin.Context) {
 
 	balance, err := a.blnk.GetBalanceAtTime(c.Request.Context(), balanceID, timestamp, fromSource)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondError(c, err, withUpgrade(apierror.ErrGenNotFound, apierror.ErrBalNotFound))
 		return
 	}
 
@@ -453,19 +453,19 @@ func (a Api) GetBalanceAtTime(c *gin.Context) {
 func (a Api) GetBalanceByIndicator(c *gin.Context) {
 	indicator, indicatorPassed := c.Params.Get("indicator")
 	if !indicatorPassed {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "indicator is required. pass indicator in the route /indicator/:indicator"})
+		respondCode(c, apierror.ErrGenMissingParameter, "indicator is required. pass indicator in the route /indicator/:indicator", nil)
 		return
 	}
 
 	currency, currencyPassed := c.Params.Get("currency")
 	if !currencyPassed {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "currency is required. pass currency in the route /currency/:currency"})
+		respondCode(c, apierror.ErrGenMissingParameter, "currency is required. pass currency in the route /currency/:currency", nil)
 		return
 	}
 
 	resp, err := a.blnk.GetBalanceByIndicator(c.Request.Context(), indicator, currency)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondError(c, err, withUpgrade(apierror.ErrGenNotFound, apierror.ErrBalNotFound))
 		return
 	}
 
@@ -477,23 +477,23 @@ func (a Api) GetBalanceByIndicator(c *gin.Context) {
 func (a Api) UpdateBalanceIdentity(c *gin.Context) {
 	balanceID, passed := c.Params.Get("id")
 	if !passed {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "balance id is required. pass id in the route /:id"})
+		respondCode(c, apierror.ErrGenMissingParameter, "balance id is required. pass id in the route /:id", nil)
 		return
 	}
 
 	var request model2.UpdateBalanceIdentity
 	if err := c.ShouldBindJSON(&request); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondCode(c, apierror.ErrGenMalformedRequest, err.Error(), nil)
 		return
 	}
 
 	if request.IdentityId == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "identity_id is required"})
+		respondCode(c, apierror.ErrGenValidation, "identity_id is required", nil)
 		return
 	}
 
 	if err := a.blnk.UpdateBalanceIdentity(balanceID, request.IdentityId); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondError(c, err, withUpgrade(apierror.ErrGenNotFound, apierror.ErrBalNotFound))
 		return
 	}
 
@@ -503,13 +503,13 @@ func (a Api) UpdateBalanceIdentity(c *gin.Context) {
 func (a Api) GetBalanceLineage(c *gin.Context) {
 	id, passed := c.Params.Get("id")
 	if !passed {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "id is required. pass id in the route /:id"})
+		respondCode(c, apierror.ErrGenMissingParameter, "id is required. pass id in the route /:id", nil)
 		return
 	}
 
 	lineage, err := a.blnk.GetBalanceLineage(c.Request.Context(), id)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondError(c, err, withUpgrade(apierror.ErrGenNotFound, apierror.ErrBalNotFound))
 		return
 	}
 

--- a/api/balance_api_test.go
+++ b/api/balance_api_test.go
@@ -586,7 +586,7 @@ func TestGetBalanceAtTime(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		assert.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.Equal(t, http.StatusNotFound, resp.Code)
 	})
 }
 
@@ -626,7 +626,7 @@ func TestGetBalanceByIndicator(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		assert.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.Equal(t, http.StatusNotFound, resp.Code)
 	})
 }
 
@@ -735,7 +735,7 @@ func TestUpdateBalanceIdentity(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		assert.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.Equal(t, http.StatusNotFound, resp.Code)
 	})
 
 	t.Run("Nonexistent balance", func(t *testing.T) {
@@ -751,7 +751,7 @@ func TestUpdateBalanceIdentity(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		assert.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.Equal(t, http.StatusNotFound, resp.Code)
 	})
 }
 
@@ -803,7 +803,7 @@ func TestGetBalanceLineage(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		assert.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.Equal(t, http.StatusNotFound, resp.Code)
 	})
 }
 
@@ -900,6 +900,6 @@ func TestDeleteBalanceMonitor(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		assert.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.Equal(t, http.StatusNotFound, resp.Code)
 	})
 }

--- a/api/error_detail_api_test.go
+++ b/api/error_detail_api_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2024 Blnk Finance Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package api
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/blnkfinance/blnk/internal/apierror"
+)
+
+// TestErrorDetailPayloads exercises the standard dual error payload across
+// endpoint groups: each response must carry the legacy flat field plus
+// error_detail with the catalog code, at the corrected HTTP status.
+func TestErrorDetailPayloads(t *testing.T) {
+	router, _, err := setupRouter()
+	require.NoError(t, err)
+
+	tests := []struct {
+		name   string
+		method string
+		route  string
+		body   string
+		status int
+		code   apierror.ErrorCode
+	}{
+		{"transaction not found", "GET", "/transactions/txn_nonexistent", "", http.StatusNotFound, apierror.ErrTxnNotFound},
+		{"transaction reference not found", "GET", "/transactions/reference/ref_does_not_exist", "", http.StatusNotFound, apierror.ErrTxnNotFound},
+		{"ledger not found", "GET", "/ledgers/ldg_nonexistent", "", http.StatusNotFound, apierror.ErrLgrNotFound},
+		{"balance not found", "GET", "/balances/bln_nonexistent", "", http.StatusNotFound, apierror.ErrBalNotFound},
+		{"identity not found", "GET", "/identities/idt_nonexistent", "", http.StatusNotFound, apierror.ErrIdtNotFound},
+		{"malformed transaction body", "POST", "/transactions", "{bad json", http.StatusBadRequest, apierror.ErrGenMalformedRequest},
+		{"bulk void empty list", "POST", "/transactions/inflight/bulk/void", `{"transaction_ids": []}`, http.StatusBadRequest, apierror.ErrTxnBulkEmpty},
+		{"invalid inflight action", "PUT", "/transactions/inflight/txn_x", `{"status": "explode"}`, http.StatusBadRequest, apierror.ErrTxnInvalidStatusAction},
+		{"invalid balance timestamp", "GET", "/balances/bln_x/at?timestamp=not-a-time", "", http.StatusBadRequest, apierror.ErrBalInvalidTimestamp},
+		{"reconciliation not found", "GET", "/reconciliation/recon_nonexistent", "", http.StatusNotFound, apierror.ErrReconNotFound},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var body *bytes.Reader
+			if tt.body != "" {
+				body = bytes.NewReader([]byte(tt.body))
+			} else {
+				body = bytes.NewReader(nil)
+			}
+			req := httptest.NewRequest(tt.method, tt.route, body)
+			if tt.body != "" {
+				req.Header.Set("Content-Type", "application/json")
+			}
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+			assertErrorCode(t, w, tt.status, tt.code)
+		})
+	}
+}

--- a/api/errors.go
+++ b/api/errors.go
@@ -1,0 +1,272 @@
+/*
+Copyright 2024 Blnk Finance Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package api
+
+import (
+	"database/sql"
+	"errors"
+	"strings"
+
+	"github.com/blnkfinance/blnk"
+	model2 "github.com/blnkfinance/blnk/api/model"
+	"github.com/blnkfinance/blnk/database"
+	"github.com/blnkfinance/blnk/internal/apierror"
+	redlock "github.com/blnkfinance/blnk/internal/lock"
+	"github.com/blnkfinance/blnk/internal/tokenization"
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+)
+
+// Every error response carries two payloads during the transition period:
+// the legacy field clients depend on today (flat "error"/"errors" string,
+// preserved verbatim) and the structured "error_detail" object with the
+// canonical error code. The legacy field is removed — and error_detail
+// renamed to error — at the next major release. See docs/errors.md.
+
+const errorDetailKey = "error_detail"
+
+// sanitizedInternalMessage replaces raw internal error text on unclassified
+// 5xx responses so database/driver details never leak to clients.
+const sanitizedInternalMessage = "internal server error"
+
+type respondOptions struct {
+	defaultCode     apierror.ErrorCode
+	fallbackMessage string
+	upgrades        map[apierror.ErrorCode]apierror.ErrorCode
+	legacyKey       string
+	legacyValue     interface{}
+}
+
+type respondOpt func(*respondOptions)
+
+// withDefault sets the fallback code used when respondError cannot classify
+// the error, instead of GEN_INTERNAL.
+func withDefault(code apierror.ErrorCode) respondOpt {
+	return func(o *respondOptions) { o.defaultCode = code }
+}
+
+// withFallbackMessage overrides the client-facing message when respondError
+// falls back to the default code, for handlers that historically returned a
+// fixed generic message instead of the raw error text.
+func withFallbackMessage(msg string) respondOpt {
+	return func(o *respondOptions) { o.fallbackMessage = msg }
+}
+
+// withUpgrade replaces a resolved generic code with a domain-specific one,
+// e.g. withUpgrade(apierror.ErrGenNotFound, apierror.ErrLgrNotFound) in the
+// ledger handlers.
+func withUpgrade(from, to apierror.ErrorCode) respondOpt {
+	return func(o *respondOptions) {
+		if o.upgrades == nil {
+			o.upgrades = map[apierror.ErrorCode]apierror.ErrorCode{}
+		}
+		o.upgrades[from] = to
+	}
+}
+
+// withLegacyKey overrides the legacy field name; endpoints that historically
+// responded with a plural "errors" key use this to stay byte-compatible.
+func withLegacyKey(key string) respondOpt {
+	return func(o *respondOptions) { o.legacyKey = key }
+}
+
+// withLegacyValue overrides the legacy field value when it was not a plain
+// message string historically (e.g. filter parse-error slices).
+func withLegacyValue(v interface{}) respondOpt {
+	return func(o *respondOptions) { o.legacyValue = v }
+}
+
+func buildOptions(opts []respondOpt) *respondOptions {
+	o := &respondOptions{legacyKey: "error"}
+	for _, opt := range opts {
+		opt(o)
+	}
+	return o
+}
+
+// respondCode writes the dual error payload for a known error condition.
+func respondCode(c *gin.Context, code apierror.ErrorCode, message string, details interface{}, opts ...respondOpt) {
+	writeError(c, code, message, details, buildOptions(opts))
+}
+
+// respondError resolves err to a catalog code and writes the dual payload.
+// Resolution order: typed APIError → known sentinels → message patterns →
+// fallback (withDefault or GEN_INTERNAL with a sanitized message).
+func respondError(c *gin.Context, err error, opts ...respondOpt) {
+	o := buildOptions(opts)
+	if err == nil {
+		writeError(c, apierror.ErrGenInternal, sanitizedInternalMessage, nil, o)
+		return
+	}
+
+	var apiErr apierror.APIError
+	if errors.As(err, &apiErr) {
+		writeError(c, apiErr.Code, apiErr.Message, apiErr.Details, o)
+		return
+	}
+
+	if code, ok := classifySentinel(err); ok {
+		writeError(c, code, err.Error(), nil, o)
+		return
+	}
+
+	if code, ok := classifyMessage(err.Error()); ok {
+		writeError(c, code, err.Error(), nil, o)
+		return
+	}
+
+	if o.defaultCode != "" {
+		msg := err.Error()
+		if o.fallbackMessage != "" {
+			msg = o.fallbackMessage
+			logrus.WithError(err).Error("API error masked by fallback message")
+		}
+		writeError(c, o.defaultCode, msg, nil, o)
+		return
+	}
+
+	logrus.WithError(err).Error("unclassified error in API response")
+	writeError(c, apierror.ErrGenInternal, sanitizedInternalMessage, nil, o)
+}
+
+func writeError(c *gin.Context, code apierror.ErrorCode, message string, details interface{}, o *respondOptions) {
+	code = apierror.Normalize(code)
+	if to, ok := o.upgrades[code]; ok {
+		code = to
+	}
+	legacyValue := o.legacyValue
+	if legacyValue == nil {
+		legacyValue = message
+	}
+	c.JSON(apierror.StatusForCode(code), gin.H{
+		o.legacyKey:    legacyValue,
+		errorDetailKey: apierror.APIError{Code: code, Message: message, Details: details},
+	})
+}
+
+// classifySentinel maps known typed sentinel errors to catalog codes.
+func classifySentinel(err error) (apierror.ErrorCode, bool) {
+	switch {
+	case errors.Is(err, database.ErrAPIKeyNotFound):
+		return apierror.ErrAPIKeyNotFound, true
+	case errors.Is(err, database.ErrInvalidAPIKey):
+		return apierror.ErrAuthInvalidAPIKey, true
+	case errors.Is(err, tokenization.ErrTokenizationDisabled):
+		return apierror.ErrIdtTokenizationDisabled, true
+	case errors.Is(err, redlock.ErrLockHeld), errors.Is(err, redlock.ErrLockWaitTimeout):
+		return apierror.ErrGenResourceLocked, true
+	case errors.Is(err, model2.ErrPrecisionMustBeInteger):
+		return apierror.ErrTxnPrecisionNotInteger, true
+	case errors.Is(err, blnk.ErrEntityNotFound):
+		return apierror.ErrMetaEntityNotFound, true
+	case errors.Is(err, sql.ErrNoRows):
+		return apierror.ErrGenNotFound, true
+	}
+	return "", false
+}
+
+// messagePattern entries are evaluated in order; more specific patterns must
+// precede broader ones (e.g. "field ... not found" before bare "not found").
+// This table bridges the core packages' unstructured fmt.Errorf messages to
+// catalog codes without editing ~280 core call sites. Any core error later
+// converted to a typed APIError bypasses this table entirely (it resolves in
+// respondError's errors.As step), so entries here can be retired
+// incrementally as core adopts typed errors.
+type messagePattern struct {
+	contains []string // all substrings must match
+	code     apierror.ErrorCode
+}
+
+var messagePatterns = []messagePattern{
+	// Transactions
+	{[]string{"transaction", "not found"}, apierror.ErrTxnNotFound},
+	{[]string{"not in inflight status"}, apierror.ErrTxnNotInflight},
+	{[]string{"Transaction already committed"}, apierror.ErrTxnAlreadyCommitted},
+	{[]string{"has already been voided"}, apierror.ErrTxnAlreadyVoided},
+	{[]string{"has already been refunded"}, apierror.ErrGenConflict},
+	{[]string{"has already been used"}, apierror.ErrTxnDuplicateReference},
+	{[]string{"cannot commit more than"}, apierror.ErrTxnCommitAmountExceeded},
+	{[]string{"insufficient funds"}, apierror.ErrTxnInsufficientFunds},
+	{[]string{"transaction amount must be positive"}, apierror.ErrTxnInvalidAmount},
+	{[]string{"transaction validation failed"}, apierror.ErrTxnValidation},
+	{[]string{"reference is required"}, apierror.ErrTxnValidation},
+	// Balances
+	{[]string{"no balance data found for time"}, apierror.ErrBalHistoryNotFound},
+	{[]string{"invalid timestamp format"}, apierror.ErrBalInvalidTimestamp},
+	{[]string{"balance validation failed"}, apierror.ErrBalValidation},
+	{[]string{"identity validation failed"}, apierror.ErrBalValidation},
+	// Identity tokenization
+	{[]string{"is not tokenizable"}, apierror.ErrIdtFieldNotTokenizable},
+	{[]string{"is already tokenized"}, apierror.ErrIdtFieldAlreadyTokenized},
+	{[]string{"is not tokenized"}, apierror.ErrIdtFieldNotTokenized},
+	{[]string{"field", "not found"}, apierror.ErrIdtFieldNotFound},
+	// Reconciliation rules
+	{[]string{"rule name is required"}, apierror.ErrReconRuleInvalid},
+	{[]string{"matching criteria is required"}, apierror.ErrReconRuleInvalid},
+	{[]string{"field and operator are required"}, apierror.ErrReconRuleInvalid},
+	{[]string{"invalid operator"}, apierror.ErrReconRuleInvalid},
+	{[]string{"invalid field"}, apierror.ErrReconRuleInvalid},
+	{[]string{"drift for"}, apierror.ErrReconRuleInvalid},
+	// Metadata
+	{[]string{"entity not found"}, apierror.ErrMetaEntityNotFound},
+	{[]string{"unsupported entity type"}, apierror.ErrMetaUnsupportedEntity},
+	{[]string{"invalid entity ID"}, apierror.ErrMetaInvalidEntityID},
+	// Lineage
+	{[]string{"does not have fund lineage tracking enabled"}, apierror.ErrGenBadRequest},
+	// Infrastructure
+	{[]string{"failed to acquire lock"}, apierror.ErrGenResourceLocked},
+	{[]string{"no rows in result set"}, apierror.ErrGenNotFound},
+	// Broad catch-all; must stay last.
+	{[]string{"not found"}, apierror.ErrGenNotFound},
+}
+
+func classifyMessage(msg string) (apierror.ErrorCode, bool) {
+	for _, p := range messagePatterns {
+		matched := true
+		for _, sub := range p.contains {
+			if !strings.Contains(msg, sub) {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			return p.code, true
+		}
+	}
+	return "", false
+}
+
+// respondBareAPIError preserves the hooks endpoints' historical body shape —
+// a top-level {code, message, details} object — while adding error_detail.
+func respondBareAPIError(c *gin.Context, legacy apierror.APIError, code apierror.ErrorCode) {
+	code = apierror.Normalize(code)
+	c.JSON(apierror.StatusForCode(code), gin.H{
+		"code":         legacy.Code,
+		"message":      legacy.Message,
+		"details":      legacy.Details,
+		errorDetailKey: apierror.APIError{Code: code, Message: legacy.Message, Details: legacy.Details},
+	})
+}
+
+// respondNestedAPIError preserves the admin endpoints' historical shape —
+// the APIError object under "error" — while adding error_detail.
+func respondNestedAPIError(c *gin.Context, legacy apierror.APIError, code apierror.ErrorCode) {
+	code = apierror.Normalize(code)
+	c.JSON(apierror.StatusForCode(code), gin.H{
+		"error":        legacy,
+		errorDetailKey: apierror.APIError{Code: code, Message: legacy.Message, Details: legacy.Details},
+	})
+}

--- a/api/errors_test.go
+++ b/api/errors_test.go
@@ -1,0 +1,217 @@
+/*
+Copyright 2024 Blnk Finance Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package api
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	model2 "github.com/blnkfinance/blnk/api/model"
+	"github.com/blnkfinance/blnk/database"
+	"github.com/blnkfinance/blnk/internal/apierror"
+	redlock "github.com/blnkfinance/blnk/internal/lock"
+	"github.com/blnkfinance/blnk/internal/tokenization"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestContext() (*gin.Context, *httptest.ResponseRecorder) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	return c, w
+}
+
+type errorDetailBody struct {
+	Detail apierror.APIError `json:"error_detail"`
+}
+
+func decodeDetail(t *testing.T, w *httptest.ResponseRecorder) (map[string]interface{}, apierror.APIError) {
+	t.Helper()
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &raw))
+	var body errorDetailBody
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	return raw, body.Detail
+}
+
+func TestRespondCodeDualPayload(t *testing.T) {
+	c, w := newTestContext()
+	respondCode(c, apierror.ErrTxnNotFound, "transaction not found", nil)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	raw, detail := decodeDetail(t, w)
+	assert.Equal(t, "transaction not found", raw["error"])
+	assert.Equal(t, apierror.ErrTxnNotFound, detail.Code)
+	assert.Equal(t, "transaction not found", detail.Message)
+}
+
+func TestRespondCodeLegacyKeyAndValue(t *testing.T) {
+	c, w := newTestContext()
+	parseErrors := []string{"bad filter a", "bad filter b"}
+	respondCode(c, apierror.ErrGenValidation, "invalid filters", nil,
+		withLegacyKey("errors"), withLegacyValue(parseErrors))
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	raw, detail := decodeDetail(t, w)
+	assert.Nil(t, raw["error"])
+	assert.Len(t, raw["errors"], 2)
+	assert.Equal(t, apierror.ErrGenValidation, detail.Code)
+}
+
+func TestRespondErrorTypedAPIError(t *testing.T) {
+	c, w := newTestContext()
+	err := apierror.NewAPIError(apierror.ErrNotFound, "Ledger with ID 'x' not found", nil)
+	respondError(c, fmt.Errorf("wrapped: %w", err))
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	raw, detail := decodeDetail(t, w)
+	assert.Equal(t, "Ledger with ID 'x' not found", raw["error"])
+	assert.Equal(t, apierror.ErrGenNotFound, detail.Code) // legacy NOT_FOUND normalized
+}
+
+func TestRespondErrorUpgrade(t *testing.T) {
+	c, w := newTestContext()
+	err := apierror.NewAPIError(apierror.ErrNotFound, "Ledger not found", nil)
+	respondError(c, err, withUpgrade(apierror.ErrGenNotFound, apierror.ErrLgrNotFound))
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	_, detail := decodeDetail(t, w)
+	assert.Equal(t, apierror.ErrLgrNotFound, detail.Code)
+}
+
+func TestRespondErrorSentinels(t *testing.T) {
+	tests := []struct {
+		err    error
+		code   apierror.ErrorCode
+		status int
+	}{
+		{database.ErrAPIKeyNotFound, apierror.ErrAPIKeyNotFound, http.StatusNotFound},
+		{database.ErrInvalidAPIKey, apierror.ErrAuthInvalidAPIKey, http.StatusUnauthorized},
+		{tokenization.ErrTokenizationDisabled, apierror.ErrIdtTokenizationDisabled, http.StatusForbidden},
+		{redlock.ErrLockHeld, apierror.ErrGenResourceLocked, http.StatusLocked},
+		{redlock.ErrLockWaitTimeout, apierror.ErrGenResourceLocked, http.StatusLocked},
+		{model2.ErrPrecisionMustBeInteger, apierror.ErrTxnPrecisionNotInteger, http.StatusBadRequest},
+		{sql.ErrNoRows, apierror.ErrGenNotFound, http.StatusNotFound},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.code), func(t *testing.T) {
+			c, w := newTestContext()
+			respondError(c, fmt.Errorf("context: %w", tt.err))
+			assert.Equal(t, tt.status, w.Code)
+			_, detail := decodeDetail(t, w)
+			assert.Equal(t, tt.code, detail.Code)
+		})
+	}
+}
+
+func TestRespondErrorMessagePatterns(t *testing.T) {
+	tests := []struct {
+		msg    string
+		code   apierror.ErrorCode
+		status int
+	}{
+		{"transaction not found", apierror.ErrTxnNotFound, http.StatusNotFound},
+		{"transaction txn_123 not found in DB or queue: timeout", apierror.ErrTxnNotFound, http.StatusNotFound},
+		{"transaction is not in inflight status", apierror.ErrTxnNotInflight, http.StatusBadRequest},
+		{"cannot commit. Transaction already committed", apierror.ErrTxnAlreadyCommitted, http.StatusConflict},
+		{"transaction has already been voided", apierror.ErrTxnAlreadyVoided, http.StatusConflict},
+		{"transaction txn_1 has already been refunded", apierror.ErrGenConflict, http.StatusConflict},
+		{"reference ref_991 has already been used", apierror.ErrTxnDuplicateReference, http.StatusConflict},
+		{"cannot commit more than the remaining amount. Available: USD 5.00, Requested: USD 9.00", apierror.ErrTxnCommitAmountExceeded, http.StatusBadRequest},
+		{"insufficient funds in source balance", apierror.ErrTxnInsufficientFunds, http.StatusBadRequest},
+		{"transaction validation failed", apierror.ErrTxnValidation, http.StatusBadRequest},
+		{"no balance data found for time: 2024-01-01", apierror.ErrBalHistoryNotFound, http.StatusNotFound},
+		{"balance validation failed: bad currency", apierror.ErrBalValidation, http.StatusBadRequest},
+		{"field email_address is not tokenizable", apierror.ErrIdtFieldNotTokenizable, http.StatusBadRequest},
+		{"field email_address is already tokenized", apierror.ErrIdtFieldAlreadyTokenized, http.StatusConflict},
+		{"field email_address is not tokenized. Metadata: {}", apierror.ErrIdtFieldNotTokenized, http.StatusBadRequest},
+		{"field nickname not found", apierror.ErrIdtFieldNotFound, http.StatusBadRequest},
+		{"rule name is required", apierror.ErrReconRuleInvalid, http.StatusBadRequest},
+		{"at least one matching criteria is required", apierror.ErrReconRuleInvalid, http.StatusBadRequest},
+		{"invalid operator", apierror.ErrReconRuleInvalid, http.StatusBadRequest},
+		{"drift for amount must be between 0 and 100 (percentage)", apierror.ErrReconRuleInvalid, http.StatusBadRequest},
+		{"entity not found", apierror.ErrMetaEntityNotFound, http.StatusNotFound},
+		{"unsupported entity type: zone", apierror.ErrMetaUnsupportedEntity, http.StatusBadRequest},
+		{"invalid entity ID format: zzz", apierror.ErrMetaInvalidEntityID, http.StatusBadRequest},
+		{"failed to acquire lock: contention", apierror.ErrGenResourceLocked, http.StatusLocked},
+		{"sql: no rows in result set", apierror.ErrGenNotFound, http.StatusNotFound},
+		{"balance monitor not found", apierror.ErrGenNotFound, http.StatusNotFound},
+	}
+	for _, tt := range tests {
+		t.Run(tt.msg, func(t *testing.T) {
+			c, w := newTestContext()
+			respondError(c, errors.New(tt.msg))
+			assert.Equal(t, tt.status, w.Code)
+			raw, detail := decodeDetail(t, w)
+			assert.Equal(t, tt.code, detail.Code)
+			assert.Equal(t, tt.msg, raw["error"], "legacy message must be preserved verbatim")
+		})
+	}
+}
+
+func TestRespondErrorFallbackSanitizes(t *testing.T) {
+	c, w := newTestContext()
+	respondError(c, errors.New("pq: connection refused on 10.0.0.5"))
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	raw, detail := decodeDetail(t, w)
+	assert.Equal(t, apierror.ErrGenInternal, detail.Code)
+	assert.Equal(t, sanitizedInternalMessage, raw["error"])
+	assert.Equal(t, sanitizedInternalMessage, detail.Message)
+}
+
+func TestRespondErrorWithDefault(t *testing.T) {
+	c, w := newTestContext()
+	respondError(c, errors.New("some opaque reconciliation failure"), withDefault(apierror.ErrReconStartFailed))
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	raw, detail := decodeDetail(t, w)
+	assert.Equal(t, apierror.ErrReconStartFailed, detail.Code)
+	// 4xx/explicit-default paths keep the original message.
+	assert.Equal(t, "some opaque reconciliation failure", raw["error"])
+}
+
+func TestRespondBareAPIErrorShape(t *testing.T) {
+	c, w := newTestContext()
+	legacy := apierror.APIError{Code: apierror.ErrInvalidInput, Message: "invalid hook data", Details: nil}
+	respondBareAPIError(c, legacy, apierror.ErrHookInvalid)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	raw, detail := decodeDetail(t, w)
+	assert.Equal(t, string(apierror.ErrInvalidInput), raw["code"], "historical top-level code preserved")
+	assert.Equal(t, "invalid hook data", raw["message"])
+	assert.Equal(t, apierror.ErrHookInvalid, detail.Code)
+}
+
+func TestRespondNestedAPIErrorShape(t *testing.T) {
+	c, w := newTestContext()
+	legacy := apierror.APIError{Code: apierror.ErrInternalServer, Message: "Failed to backup database", Details: nil}
+	respondNestedAPIError(c, legacy, apierror.ErrAdminBackupFailed)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	raw, detail := decodeDetail(t, w)
+	legacyErr, ok := raw["error"].(map[string]interface{})
+	require.True(t, ok, "legacy error must remain an object on admin endpoints")
+	assert.Equal(t, string(apierror.ErrInternalServer), legacyErr["code"])
+	assert.Equal(t, apierror.ErrAdminBackupFailed, detail.Code)
+}

--- a/api/hooks.go
+++ b/api/hooks.go
@@ -11,6 +11,15 @@ import (
 
 var errHooksRequireMasterKey = errors.New("hook management requires master key")
 
+// hookFailureCode distinguishes a missing hook (the manager returns
+// "hook not found: <id>") from genuine infrastructure failures.
+func hookFailureCode(err error) apierror.ErrorCode {
+	if code, ok := classifyMessage(err.Error()); ok && apierror.StatusForCode(code) == http.StatusNotFound {
+		return apierror.ErrHookNotFound
+	}
+	return apierror.ErrHookOperationFailed
+}
+
 func isHookMasterKeyRequest(c *gin.Context) bool {
 	isMasterKey, _ := c.Get("isMasterKey")
 	isMaster, _ := isMasterKey.(bool)
@@ -22,7 +31,7 @@ func ensureHookManagementAuthorized(c *gin.Context) bool {
 		return true
 	}
 
-	c.JSON(http.StatusForbidden, gin.H{"error": errHooksRequireMasterKey.Error()})
+	respondCode(c, apierror.ErrAuthMasterKeyRequired, errHooksRequireMasterKey.Error(), nil)
 	return false
 }
 
@@ -34,12 +43,12 @@ func (a *Api) RegisterHook(c *gin.Context) {
 
 	var hook hooks.Hook
 	if err := c.ShouldBindJSON(&hook); err != nil {
-		c.JSON(http.StatusBadRequest, apierror.NewAPIError(apierror.ErrInvalidInput, "invalid hook data", err))
+		respondBareAPIError(c, apierror.NewAPIError(apierror.ErrInvalidInput, "invalid hook data", err), apierror.ErrHookInvalid)
 		return
 	}
 
 	if err := a.blnk.Hooks.RegisterHook(c.Request.Context(), &hook); err != nil {
-		c.JSON(http.StatusBadRequest, apierror.NewAPIError(apierror.ErrInvalidInput, "failed to register hook", err))
+		respondBareAPIError(c, apierror.NewAPIError(apierror.ErrInvalidInput, "failed to register hook", err), apierror.ErrHookOperationFailed)
 		return
 	}
 
@@ -55,12 +64,12 @@ func (a *Api) UpdateHook(c *gin.Context) {
 	hookID := c.Param("id")
 	var hook hooks.Hook
 	if err := c.ShouldBindJSON(&hook); err != nil {
-		c.JSON(http.StatusBadRequest, apierror.NewAPIError(apierror.ErrInvalidInput, "invalid hook data", err))
+		respondBareAPIError(c, apierror.NewAPIError(apierror.ErrInvalidInput, "invalid hook data", err), apierror.ErrHookInvalid)
 		return
 	}
 
 	if err := a.blnk.Hooks.UpdateHook(c.Request.Context(), hookID, &hook); err != nil {
-		c.JSON(http.StatusBadRequest, apierror.NewAPIError(apierror.ErrInvalidInput, "failed to update hook", err))
+		respondBareAPIError(c, apierror.NewAPIError(apierror.ErrInvalidInput, "failed to update hook", err), hookFailureCode(err))
 		return
 	}
 
@@ -76,7 +85,7 @@ func (a *Api) GetHook(c *gin.Context) {
 	hookID := c.Param("id")
 	hook, err := a.blnk.Hooks.GetHook(c.Request.Context(), hookID)
 	if err != nil {
-		c.JSON(http.StatusNotFound, apierror.NewAPIError(apierror.ErrNotFound, "hook not found", err))
+		respondBareAPIError(c, apierror.NewAPIError(apierror.ErrNotFound, "hook not found", err), apierror.ErrHookNotFound)
 		return
 	}
 
@@ -92,7 +101,7 @@ func (a *Api) ListHooks(c *gin.Context) {
 	hookType := hooks.HookType(c.Query("type"))
 	hooks, err := a.blnk.Hooks.ListHooks(c.Request.Context(), hookType)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, apierror.NewAPIError(apierror.ErrInvalidInput, "failed to list hooks", err))
+		respondBareAPIError(c, apierror.NewAPIError(apierror.ErrInvalidInput, "failed to list hooks", err), apierror.ErrHookOperationFailed)
 		return
 	}
 
@@ -107,7 +116,7 @@ func (a *Api) DeleteHook(c *gin.Context) {
 
 	hookID := c.Param("id")
 	if err := a.blnk.Hooks.DeleteHook(c.Request.Context(), hookID); err != nil {
-		c.JSON(http.StatusBadRequest, apierror.NewAPIError(apierror.ErrInvalidInput, "failed to delete hook", err))
+		respondBareAPIError(c, apierror.NewAPIError(apierror.ErrInvalidInput, "failed to delete hook", err), hookFailureCode(err))
 		return
 	}
 

--- a/api/hooks_test.go
+++ b/api/hooks_test.go
@@ -162,6 +162,6 @@ func TestDeleteHook(t *testing.T) {
 		req := httptest.NewRequest("DELETE", "/hooks/hk_nonexistent", nil)
 		resp := httptest.NewRecorder()
 		router.ServeHTTP(resp, req)
-		assert.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.Equal(t, http.StatusNotFound, resp.Code)
 	})
 }

--- a/api/identity.go
+++ b/api/identity.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 
 	apimodel "github.com/blnkfinance/blnk/api/model"
+	"github.com/blnkfinance/blnk/internal/apierror"
 	"github.com/blnkfinance/blnk/model"
 	"github.com/gin-gonic/gin"
 )
@@ -39,13 +40,13 @@ import (
 func (a Api) CreateIdentity(c *gin.Context) {
 	var identity model.Identity
 	if err := c.ShouldBindJSON(&identity); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondCode(c, apierror.ErrGenMalformedRequest, err.Error(), nil)
 		return
 	}
 
 	resp, err := a.blnk.CreateIdentity(identity)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondError(c, err, withUpgrade(apierror.ErrGenConflict, apierror.ErrIdtValidation), withUpgrade(apierror.ErrGenBadRequest, apierror.ErrIdtValidation))
 		return
 	}
 
@@ -66,13 +67,13 @@ func (a Api) CreateIdentity(c *gin.Context) {
 func (a Api) GetIdentity(c *gin.Context) {
 	id, passed := c.Params.Get("id")
 	if !passed {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "id is required. pass id in the route /:id"})
+		respondCode(c, apierror.ErrGenMissingParameter, "id is required. pass id in the route /:id", nil)
 		return
 	}
 
 	resp, err := a.blnk.GetIdentity(id)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondError(c, err, withUpgrade(apierror.ErrGenNotFound, apierror.ErrIdtNotFound))
 		return
 	}
 
@@ -94,19 +95,19 @@ func (a Api) UpdateIdentity(c *gin.Context) {
 	var identity model.Identity
 	id, passed := c.Params.Get("id")
 	if !passed {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "id is required. pass id in the route /:id"})
+		respondCode(c, apierror.ErrGenMissingParameter, "id is required. pass id in the route /:id", nil)
 		return
 	}
 
 	if err := c.ShouldBindJSON(&identity); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondCode(c, apierror.ErrGenMalformedRequest, err.Error(), nil)
 		return
 	}
 
 	identity.IdentityID = id
 	err := a.blnk.UpdateIdentity(&identity)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondError(c, err, withUpgrade(apierror.ErrGenNotFound, apierror.ErrIdtNotFound))
 		return
 	}
 
@@ -126,13 +127,13 @@ func (a Api) UpdateIdentity(c *gin.Context) {
 func (a Api) DeleteIdentity(c *gin.Context) {
 	id, passed := c.Params.Get("id")
 	if !passed {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "id is required. pass id in the route /:id"})
+		respondCode(c, apierror.ErrGenMissingParameter, "id is required. pass id in the route /:id", nil)
 		return
 	}
 
 	err := a.blnk.DeleteIdentity(id)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondError(c, err, withUpgrade(apierror.ErrGenNotFound, apierror.ErrIdtNotFound))
 		return
 	}
 
@@ -174,14 +175,15 @@ func (a Api) GetAllIdentities(c *gin.Context) {
 	if HasFilters(c) {
 		filters, parseErrors := ParseFiltersFromContext(c, nil)
 		if len(parseErrors) > 0 {
-			c.JSON(http.StatusBadRequest, gin.H{"errors": parseErrors})
+			respondCode(c, apierror.ErrGenValidation, "invalid filter parameters", parseErrors,
+				withLegacyKey("errors"), withLegacyValue(parseErrors))
 			return
 		}
 
 		// Use the new filter method
 		resp, err := a.blnk.GetAllIdentitiesWithFilter(c.Request.Context(), filters, limitInt, offsetInt)
 		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			respondError(c, err)
 			return
 		}
 
@@ -192,7 +194,7 @@ func (a Api) GetAllIdentities(c *gin.Context) {
 	// Fall back to the legacy method when no filters are present
 	identities, err := a.blnk.GetAllIdentities()
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
 
@@ -222,13 +224,13 @@ func (a Api) GetAllIdentities(c *gin.Context) {
 func (a Api) FilterIdentities(c *gin.Context) {
 	filters, opts, limit, offset, err := ParseFiltersFromBody(c, "identity")
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondCode(c, apierror.ErrGenValidation, err.Error(), nil)
 		return
 	}
 
 	resp, count, err := a.blnk.GetAllIdentitiesWithFilterAndOptions(c.Request.Context(), filters, opts, limit, offset)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
 
@@ -254,18 +256,18 @@ func (a Api) TokenizeIdentityField(c *gin.Context) {
 	field, fieldExists := c.Params.Get("field")
 
 	if !idExists {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "identity ID is required"})
+		respondCode(c, apierror.ErrGenMissingParameter, "identity ID is required", nil)
 		return
 	}
 
 	if !fieldExists {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "field name is required"})
+		respondCode(c, apierror.ErrGenMissingParameter, "field name is required", nil)
 		return
 	}
 
 	err := a.blnk.TokenizeIdentityField(id, field)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondError(c, err, withUpgrade(apierror.ErrGenNotFound, apierror.ErrIdtNotFound))
 		return
 	}
 
@@ -287,18 +289,18 @@ func (a Api) DetokenizeIdentityField(c *gin.Context) {
 	field, fieldExists := c.Params.Get("field")
 
 	if !idExists {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "identity ID is required"})
+		respondCode(c, apierror.ErrGenMissingParameter, "identity ID is required", nil)
 		return
 	}
 
 	if !fieldExists {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "field name is required"})
+		respondCode(c, apierror.ErrGenMissingParameter, "field name is required", nil)
 		return
 	}
 
 	originalValue, err := a.blnk.DetokenizeIdentityField(id, field)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondError(c, err, withUpgrade(apierror.ErrGenNotFound, apierror.ErrIdtNotFound))
 		return
 	}
 
@@ -318,24 +320,24 @@ func (a Api) DetokenizeIdentityField(c *gin.Context) {
 func (a Api) TokenizeIdentity(c *gin.Context) {
 	id, passed := c.Params.Get("id")
 	if !passed {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "identity ID is required"})
+		respondCode(c, apierror.ErrGenMissingParameter, "identity ID is required", nil)
 		return
 	}
 
 	var request apimodel.TokenizeRequest
 	if err := c.ShouldBindJSON(&request); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondCode(c, apierror.ErrGenMalformedRequest, err.Error(), nil)
 		return
 	}
 
 	if len(request.Fields) == 0 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "at least one field must be specified"})
+		respondCode(c, apierror.ErrGenValidation, "at least one field must be specified", nil)
 		return
 	}
 
 	err := a.blnk.TokenizeIdentity(id, request.Fields)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondError(c, err, withUpgrade(apierror.ErrGenNotFound, apierror.ErrIdtNotFound))
 		return
 	}
 
@@ -355,13 +357,13 @@ func (a Api) TokenizeIdentity(c *gin.Context) {
 func (a Api) DetokenizeIdentity(c *gin.Context) {
 	id, passed := c.Params.Get("id")
 	if !passed {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "identity ID is required"})
+		respondCode(c, apierror.ErrGenMissingParameter, "identity ID is required", nil)
 		return
 	}
 
 	var request apimodel.DetokenizeRequest
 	if err := c.ShouldBindJSON(&request); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondCode(c, apierror.ErrGenMalformedRequest, err.Error(), nil)
 		return
 	}
 
@@ -369,7 +371,7 @@ func (a Api) DetokenizeIdentity(c *gin.Context) {
 	if len(request.Fields) == 0 {
 		detokenizedFields, err := a.blnk.DetokenizeIdentity(id)
 		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			respondError(c, err, withUpgrade(apierror.ErrGenNotFound, apierror.ErrIdtNotFound))
 			return
 		}
 
@@ -382,7 +384,7 @@ func (a Api) DetokenizeIdentity(c *gin.Context) {
 	for _, field := range request.Fields {
 		value, err := a.blnk.DetokenizeIdentityField(id, field)
 		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			respondError(c, err, withUpgrade(apierror.ErrGenNotFound, apierror.ErrIdtNotFound))
 			return
 		}
 		result[field] = value
@@ -402,13 +404,13 @@ func (a Api) DetokenizeIdentity(c *gin.Context) {
 func (a Api) GetTokenizedFields(c *gin.Context) {
 	id, passed := c.Params.Get("id")
 	if !passed {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "identity ID is required"})
+		respondCode(c, apierror.ErrGenMissingParameter, "identity ID is required", nil)
 		return
 	}
 
 	identity, err := a.blnk.GetIdentity(id)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondError(c, err, withUpgrade(apierror.ErrGenNotFound, apierror.ErrIdtNotFound))
 		return
 	}
 

--- a/api/identity_test.go
+++ b/api/identity_test.go
@@ -127,7 +127,7 @@ func TestGetIdentity(t *testing.T) {
 		}
 
 		resp, _ := SetUpTestRequest(testRequest)
-		assert.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.Equal(t, http.StatusNotFound, resp.Code)
 	})
 }
 

--- a/api/identity_tokenization_api_test.go
+++ b/api/identity_tokenization_api_test.go
@@ -72,7 +72,7 @@ func TestTokenizeIdentityField(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		assert.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.Equal(t, http.StatusConflict, resp.Code)
 		assert.Contains(t, response["error"], "already tokenized")
 	})
 
@@ -102,7 +102,7 @@ func TestTokenizeIdentityField(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		assert.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.Equal(t, http.StatusNotFound, resp.Code)
 	})
 }
 
@@ -124,7 +124,7 @@ func TestTokenizationDisabled(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, http.StatusBadRequest, resp.Code)
+	assert.Equal(t, http.StatusForbidden, resp.Code)
 }
 
 func TestDetokenizeIdentityField(t *testing.T) {
@@ -185,7 +185,7 @@ func TestDetokenizeIdentityField(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		assert.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.Equal(t, http.StatusNotFound, resp.Code)
 	})
 }
 
@@ -388,6 +388,6 @@ func TestGetTokenizedFields(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		assert.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.Equal(t, http.StatusNotFound, resp.Code)
 	})
 }

--- a/api/ledger.go
+++ b/api/ledger.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 
 	model2 "github.com/blnkfinance/blnk/api/model"
+	"github.com/blnkfinance/blnk/internal/apierror"
 
 	"github.com/gin-gonic/gin"
 )
@@ -38,19 +39,19 @@ import (
 func (a Api) CreateLedger(c *gin.Context) {
 	var newLedger model2.CreateLedger
 	if err := c.ShouldBindJSON(&newLedger); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"errors": err.Error()})
+		respondCode(c, apierror.ErrGenMalformedRequest, err.Error(), nil, withLegacyKey("errors"))
 		return
 	}
 
 	err := newLedger.ValidateCreateLedger()
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"errors": err.Error()})
+		respondCode(c, apierror.ErrGenValidation, err.Error(), nil, withLegacyKey("errors"))
 		return
 	}
 
 	resp, err := a.blnk.CreateLedger(newLedger.ToLedger())
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondError(c, err, withUpgrade(apierror.ErrGenConflict, apierror.ErrLgrDuplicate))
 		return
 	}
 
@@ -72,13 +73,13 @@ func (a Api) GetLedger(c *gin.Context) {
 	id, passed := c.Params.Get("id")
 
 	if !passed {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "id is required. Pass id in the route /:id"})
+		respondCode(c, apierror.ErrGenMissingParameter, "id is required. Pass id in the route /:id", nil)
 		return
 	}
 
 	resp, err := a.blnk.GetLedgerByID(id)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondError(c, err, withUpgrade(apierror.ErrGenNotFound, apierror.ErrLgrNotFound))
 		return
 	}
 
@@ -109,13 +110,13 @@ func (a Api) GetAllLedgers(c *gin.Context) {
 	// Convert limit and offset to integers
 	limitInt, err := strconv.Atoi(limit)
 	if err != nil || limitInt < 1 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid limit value"})
+		respondCode(c, apierror.ErrGenValidation, "Invalid limit value", nil)
 		return
 	}
 
 	offsetInt, err := strconv.Atoi(offset)
 	if err != nil || offsetInt < 0 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid offset value"})
+		respondCode(c, apierror.ErrGenValidation, "Invalid offset value", nil)
 		return
 	}
 
@@ -123,14 +124,15 @@ func (a Api) GetAllLedgers(c *gin.Context) {
 	if HasFilters(c) {
 		filters, parseErrors := ParseFiltersFromContext(c, nil)
 		if len(parseErrors) > 0 {
-			c.JSON(http.StatusBadRequest, gin.H{"errors": parseErrors})
+			respondCode(c, apierror.ErrGenValidation, "invalid filter parameters", parseErrors,
+				withLegacyKey("errors"), withLegacyValue(parseErrors))
 			return
 		}
 
 		// Use the new filter method
 		resp, err := a.blnk.GetAllLedgersWithFilter(c.Request.Context(), filters, limitInt, offsetInt)
 		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			respondError(c, err)
 			return
 		}
 
@@ -141,7 +143,7 @@ func (a Api) GetAllLedgers(c *gin.Context) {
 	// Fall back to the legacy method when no filters are present
 	resp, err := a.blnk.GetAllLedgers(limitInt, offsetInt)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
 
@@ -170,13 +172,13 @@ func (a Api) GetAllLedgers(c *gin.Context) {
 func (a Api) FilterLedgers(c *gin.Context) {
 	filters, opts, limit, offset, err := ParseFiltersFromBody(c, "ledgers")
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondCode(c, apierror.ErrGenValidation, err.Error(), nil)
 		return
 	}
 
 	resp, count, err := a.blnk.GetAllLedgersWithFilterAndOptions(c.Request.Context(), filters, opts, limit, offset)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
 
@@ -201,25 +203,25 @@ func (a Api) FilterLedgers(c *gin.Context) {
 func (a Api) UpdateLedger(c *gin.Context) {
 	id, passed := c.Params.Get("id")
 	if !passed {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "id is required. Pass id in the route /:id"})
+		respondCode(c, apierror.ErrGenMissingParameter, "id is required. Pass id in the route /:id", nil)
 		return
 	}
 
 	var updateLedger model2.UpdateLedger
 	if err := c.ShouldBindJSON(&updateLedger); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"errors": err.Error()})
+		respondCode(c, apierror.ErrGenMalformedRequest, err.Error(), nil, withLegacyKey("errors"))
 		return
 	}
 
 	err := updateLedger.ValidateUpdateLedger()
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"errors": err.Error()})
+		respondCode(c, apierror.ErrGenValidation, err.Error(), nil, withLegacyKey("errors"))
 		return
 	}
 
 	resp, err := a.blnk.UpdateLedger(id, updateLedger.Name)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondError(c, err, withUpgrade(apierror.ErrGenNotFound, apierror.ErrLgrNotFound))
 		return
 	}
 

--- a/api/ledger_api_test.go
+++ b/api/ledger_api_test.go
@@ -340,7 +340,7 @@ func TestUpdateLedger(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		assert.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.Equal(t, http.StatusNotFound, resp.Code)
 	})
 }
 

--- a/api/metadata.go
+++ b/api/metadata.go
@@ -1,10 +1,9 @@
 package api
 
 import (
-	"errors"
 	"net/http"
 
-	"github.com/blnkfinance/blnk"
+	"github.com/blnkfinance/blnk/internal/apierror"
 	"github.com/gin-gonic/gin"
 )
 
@@ -29,23 +28,22 @@ func (a Api) UpdateMetadata(c *gin.Context) {
 	entityID := c.Param("entity-id")
 
 	if entityID == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "entity ID is required"})
+		respondCode(c, apierror.ErrMetaInvalidEntityID, "entity ID is required", nil)
 		return
 	}
 
 	var req MetadataRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondCode(c, apierror.ErrGenMalformedRequest, err.Error(), nil)
 		return
 	}
 
+	// Known conditions (entity not found, unsupported entity type, invalid
+	// entity ID) classify to META_* codes; anything else is an internal
+	// failure (e.g. database error) and falls back to a sanitized 500.
 	updatedMetadata, err := a.blnk.UpdateMetadata(c.Request.Context(), entityID, req.Metadata)
 	if err != nil {
-		if errors.Is(err, blnk.ErrEntityNotFound) {
-			c.JSON(http.StatusNotFound, gin.H{"error": "entity not found"})
-			return
-		}
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
 

--- a/api/middleware/auth.go
+++ b/api/middleware/auth.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/blnkfinance/blnk"
 	"github.com/blnkfinance/blnk/config"
+	"github.com/blnkfinance/blnk/internal/apierror"
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 )
@@ -31,6 +32,17 @@ import (
 const (
 	KeyHeader = "X-Blnk-Key"
 )
+
+// abortWithCode writes the standard dual error payload (legacy flat "error"
+// string + structured "error_detail") and aborts the request. The status is
+// resolved from the error-code catalog.
+func abortWithCode(c *gin.Context, code apierror.ErrorCode, message string) {
+	resp := apierror.NewErrorResponse(code, message, nil)
+	c.AbortWithStatusJSON(apierror.StatusForCode(resp.Error.Code), gin.H{
+		"error":        message,
+		"error_detail": resp.Error,
+	})
+}
 
 // pathToResource maps URL paths to their corresponding resource types.
 // This is used by the authentication middleware to determine the required permissions.
@@ -208,8 +220,7 @@ func (m *AuthMiddleware) Authenticate() gin.HandlerFunc {
 
 		key := extractKey(c)
 		if key == "" {
-			c.JSON(401, gin.H{"error": "Authentication required. Use X-Blnk-Key header"})
-			c.Abort()
+			abortWithCode(c, apierror.ErrAuthMissingAPIKey, "Authentication required. Use X-Blnk-Key header")
 			return
 		}
 
@@ -224,28 +235,24 @@ func (m *AuthMiddleware) Authenticate() gin.HandlerFunc {
 		// If not master key, try API key authentication
 		apiKey, err := m.service.GetAPIKeyByKey(c.Request.Context(), key)
 		if err != nil {
-			c.JSON(401, gin.H{"error": "Invalid API key"})
-			c.Abort()
+			abortWithCode(c, apierror.ErrAuthInvalidAPIKey, "Invalid API key")
 			return
 		}
 
 		if !apiKey.IsValid() {
-			c.JSON(401, gin.H{"error": "API key is expired or revoked"})
-			c.Abort()
+			abortWithCode(c, apierror.ErrAuthExpiredAPIKey, "API key is expired or revoked")
 			return
 		}
 
 		// Determine required resource from path
 		if c.Request == nil || c.Request.URL == nil {
-			c.JSON(500, gin.H{"error": "Invalid request"})
-			c.Abort()
+			abortWithCode(c, apierror.ErrGenInternal, "Invalid request")
 			return
 		}
 
 		resource := getResourceFromPath(c.Request.URL.Path)
 		if resource == "" {
-			c.JSON(403, gin.H{"error": "Unknown resource type"})
-			c.Abort()
+			abortWithCode(c, apierror.ErrAuthUnknownResource, "Unknown resource type")
 			return
 		}
 
@@ -253,8 +260,7 @@ func (m *AuthMiddleware) Authenticate() gin.HandlerFunc {
 		if !HasPermission(apiKey.Scopes, resource, c.Request.Method) {
 			// Get the required action for this method
 			action := methodToAction[c.Request.Method]
-			c.JSON(403, gin.H{"error": "Insufficient permissions for " + string(resource) + ":" + string(action)})
-			c.Abort()
+			abortWithCode(c, apierror.ErrAuthInsufficientPermissions, "Insufficient permissions for "+string(resource)+":"+string(action))
 			return
 		}
 

--- a/api/middleware/metrics_security_test.go
+++ b/api/middleware/metrics_security_test.go
@@ -402,7 +402,13 @@ func TestMetricsAuthHandler_LockdownResponseIsJSON(t *testing.T) {
 	assert.Equal(t, http.StatusForbidden, w.Code)
 	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
 	assert.JSONEq(t,
-		`{"error":"Metrics endpoint unavailable: metrics_bearer_token must be configured when secure mode is enabled"}`,
+		`{
+			"error": "Metrics endpoint unavailable: metrics_bearer_token must be configured when secure mode is enabled",
+			"error_detail": {
+				"code": "AUTH_METRICS_DISABLED",
+				"message": "Metrics endpoint unavailable: metrics_bearer_token must be configured when secure mode is enabled"
+			}
+		}`,
 		w.Body.String())
 }
 

--- a/api/middleware/middleware.go
+++ b/api/middleware/middleware.go
@@ -18,11 +18,13 @@ package middleware
 
 import (
 	"crypto/subtle"
+	"encoding/json"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/blnkfinance/blnk/config"
+	"github.com/blnkfinance/blnk/internal/apierror"
 	"github.com/didip/tollbooth/v7"
 	"github.com/didip/tollbooth/v7/limiter"
 	"github.com/gin-gonic/gin"
@@ -63,7 +65,11 @@ func RateLimitMiddleware(conf *config.Configuration) gin.HandlerFunc {
 		httpError := tollbooth.LimitByRequest(lmt, c.Writer, c.Request)
 		if httpError != nil {
 			// Respond with an error if the request exceeds the rate limit.
-			c.AbortWithStatusJSON(httpError.StatusCode, gin.H{"error": httpError.Message})
+			// Tollbooth's status code stays authoritative for the response.
+			c.AbortWithStatusJSON(httpError.StatusCode, gin.H{
+				"error":        httpError.Message,
+				"error_detail": apierror.NewErrorResponse(apierror.ErrGenRateLimited, httpError.Message, nil).Error,
+			})
 			return
 		}
 		c.Next()
@@ -84,9 +90,7 @@ func RateLimitMiddleware(conf *config.Configuration) gin.HandlerFunc {
 func MetricsAuth(secure bool, token string) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if secure && token == "" {
-			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
-				"error": "Metrics endpoint unavailable: metrics_bearer_token must be configured when secure mode is enabled",
-			})
+			abortWithCode(c, apierror.ErrAuthMetricsDisabled, "Metrics endpoint unavailable: metrics_bearer_token must be configured when secure mode is enabled")
 			return
 		}
 
@@ -97,19 +101,19 @@ func MetricsAuth(secure bool, token string) gin.HandlerFunc {
 
 		auth := c.GetHeader("Authorization")
 		if auth == "" {
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "Authorization required for metrics endpoint"})
+			abortWithCode(c, apierror.ErrAuthMetricsTokenRequired, "Authorization required for metrics endpoint")
 			return
 		}
 
 		const prefix = "Bearer "
 		if !strings.HasPrefix(auth, prefix) {
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "Authorization header must use Bearer scheme"})
+			abortWithCode(c, apierror.ErrAuthMetricsTokenRequired, "Authorization header must use Bearer scheme")
 			return
 		}
 
 		provided := auth[len(prefix):]
 		if subtle.ConstantTimeCompare([]byte(provided), []byte(token)) != 1 {
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "Invalid bearer token"})
+			abortWithCode(c, apierror.ErrAuthInvalidBearerToken, "Invalid bearer token")
 			return
 		}
 
@@ -124,9 +128,7 @@ func MetricsAuth(secure bool, token string) gin.HandlerFunc {
 func MetricsAuthHandler(secure bool, token string, next http.Handler) http.Handler {
 	if secure && token == "" {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusForbidden)
-			_, _ = w.Write([]byte(`{"error":"Metrics endpoint unavailable: metrics_bearer_token must be configured when secure mode is enabled"}`))
+			writeMetricsAuthError(w, apierror.ErrAuthMetricsDisabled, "Metrics endpoint unavailable: metrics_bearer_token must be configured when secure mode is enabled")
 		})
 	}
 
@@ -137,24 +139,37 @@ func MetricsAuthHandler(secure bool, token string, next http.Handler) http.Handl
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		auth := r.Header.Get("Authorization")
 		if auth == "" {
-			http.Error(w, `{"error":"Authorization required for metrics endpoint"}`, http.StatusUnauthorized)
+			writeMetricsAuthError(w, apierror.ErrAuthMetricsTokenRequired, "Authorization required for metrics endpoint")
 			return
 		}
 
 		const prefix = "Bearer "
 		if !strings.HasPrefix(auth, prefix) {
-			http.Error(w, `{"error":"Authorization header must use Bearer scheme"}`, http.StatusUnauthorized)
+			writeMetricsAuthError(w, apierror.ErrAuthMetricsTokenRequired, "Authorization header must use Bearer scheme")
 			return
 		}
 
 		provided := auth[len(prefix):]
 		if subtle.ConstantTimeCompare([]byte(provided), []byte(token)) != 1 {
-			http.Error(w, `{"error":"Invalid bearer token"}`, http.StatusUnauthorized)
+			writeMetricsAuthError(w, apierror.ErrAuthInvalidBearerToken, "Invalid bearer token")
 			return
 		}
 
 		next.ServeHTTP(w, r)
 	})
+}
+
+// writeMetricsAuthError is the plain net/http counterpart of abortWithCode.
+// It also fixes the previous handler, which sent JSON bodies through
+// http.Error and therefore with a text/plain content type.
+func writeMetricsAuthError(w http.ResponseWriter, code apierror.ErrorCode, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(apierror.StatusForCode(code))
+	payload := map[string]interface{}{
+		"error":        message,
+		"error_detail": apierror.NewErrorResponse(code, message, nil).Error,
+	}
+	_ = json.NewEncoder(w).Encode(payload)
 }
 
 // SecurityHeaders sets security headers to the response.

--- a/api/reconciliation_api.go
+++ b/api/reconciliation_api.go
@@ -17,8 +17,8 @@ package api
 
 import (
 	"net/http"
-	"strings"
 
+	"github.com/blnkfinance/blnk/internal/apierror"
 	"github.com/blnkfinance/blnk/model"
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
@@ -39,7 +39,7 @@ func (a Api) UploadExternalData(c *gin.Context) {
 	source := c.PostForm("source")
 	file, header, err := c.Request.FormFile("file")
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "File upload failed"})
+		respondCode(c, apierror.ErrReconUploadFailed, "File upload failed", nil)
 		return
 	}
 	defer file.Close()
@@ -49,7 +49,7 @@ func (a Api) UploadExternalData(c *gin.Context) {
 	uploadID, total, err := a.blnk.UploadExternalData(c.Request.Context(), source, file, fileName)
 	if err != nil {
 		logrus.Error(err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to process upload"})
+		respondCode(c, apierror.ErrReconUploadProcessingFailed, "Failed to process upload", nil)
 		return
 	}
 
@@ -76,18 +76,18 @@ func (a Api) StartReconciliation(c *gin.Context) {
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondCode(c, apierror.ErrGenMalformedRequest, err.Error(), nil)
 		return
 	}
 	if len(req.MatchingRuleIDs) == 0 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "matching_rule_ids is required"})
+		respondCode(c, apierror.ErrReconMatchingRulesRequired, "matching_rule_ids is required", nil)
 		return
 	}
 
 	reconciliationID, err := a.blnk.StartReconciliation(c.Request.Context(), req.UploadID, req.Strategy, req.GroupingCriteria, req.MatchingRuleIDs, req.DryRun)
 	if err != nil {
 		logrus.Error(err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to start reconciliation"})
+		respondError(c, err, withDefault(apierror.ErrReconStartFailed), withFallbackMessage("Failed to start reconciliation"))
 		return
 	}
 
@@ -115,15 +115,15 @@ func (a Api) InstantReconciliation(c *gin.Context) {
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondCode(c, apierror.ErrGenMalformedRequest, err.Error(), nil)
 		return
 	}
 	if len(req.ExternalTransactions) == 0 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "external_transactions is required"})
+		respondCode(c, apierror.ErrReconExternalTxnsRequired, "external_transactions is required", nil)
 		return
 	}
 	if len(req.MatchingRuleIDs) == 0 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "matching_rule_ids is required"})
+		respondCode(c, apierror.ErrReconMatchingRulesRequired, "matching_rule_ids is required", nil)
 		return
 	}
 
@@ -137,7 +137,7 @@ func (a Api) InstantReconciliation(c *gin.Context) {
 	)
 	if err != nil {
 		logrus.Error(err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to start instant reconciliation"})
+		respondError(c, err, withDefault(apierror.ErrReconStartFailed), withFallbackMessage("Failed to start instant reconciliation"))
 		return
 	}
 
@@ -157,21 +157,19 @@ func (a Api) InstantReconciliation(c *gin.Context) {
 func (a Api) GetReconciliation(c *gin.Context) {
 	reconciliationID := c.Param("id")
 	if reconciliationID == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Reconciliation ID is required"})
+		respondCode(c, apierror.ErrGenMissingParameter, "Reconciliation ID is required", nil)
 		return
 	}
 
 	reconciliation, err := a.blnk.GetReconciliation(c.Request.Context(), reconciliationID)
 	if err != nil {
 		logrus.Error(err)
-
-		// Check if it's a not found error and return appropriate status code
-		if strings.Contains(err.Error(), "not found") {
-			c.JSON(http.StatusNotFound, gin.H{"error": "Reconciliation not found"})
+		if code, ok := classifyMessage(err.Error()); ok && apierror.StatusForCode(code) == http.StatusNotFound {
+			// Historical fixed message preserved for the legacy field.
+			respondCode(c, apierror.ErrReconNotFound, "Reconciliation not found", nil)
 			return
 		}
-
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to retrieve reconciliation"})
+		respondCode(c, apierror.ErrGenInternal, "Failed to retrieve reconciliation", nil)
 		return
 	}
 
@@ -191,14 +189,14 @@ func (a Api) GetReconciliation(c *gin.Context) {
 func (a Api) CreateMatchingRule(c *gin.Context) {
 	var rule model.MatchingRule
 	if err := c.ShouldBindJSON(&rule); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondCode(c, apierror.ErrGenMalformedRequest, err.Error(), nil)
 		return
 	}
 
 	createdRule, err := a.blnk.CreateMatchingRule(c.Request.Context(), rule)
 	if err != nil {
 		logrus.Error(err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create matching rule"})
+		respondError(c, err, withDefault(apierror.ErrGenInternal), withFallbackMessage("Failed to create matching rule"))
 		return
 	}
 
@@ -218,13 +216,13 @@ func (a Api) CreateMatchingRule(c *gin.Context) {
 func (a Api) UpdateMatchingRule(c *gin.Context) {
 	ruleID := c.Param("id")
 	if ruleID == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Matching Rule ID is required"})
+		respondCode(c, apierror.ErrGenMissingParameter, "Matching Rule ID is required", nil)
 		return
 	}
 
 	var rule model.MatchingRule
 	if err := c.ShouldBindJSON(&rule); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondCode(c, apierror.ErrGenMalformedRequest, err.Error(), nil)
 		return
 	}
 
@@ -232,7 +230,7 @@ func (a Api) UpdateMatchingRule(c *gin.Context) {
 	updatedRule, err := a.blnk.UpdateMatchingRule(c.Request.Context(), rule)
 	if err != nil {
 		logrus.Error(err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update matching rule"})
+		respondError(c, err, withUpgrade(apierror.ErrGenNotFound, apierror.ErrReconRuleNotFound), withDefault(apierror.ErrGenInternal), withFallbackMessage("Failed to update matching rule"))
 		return
 	}
 
@@ -252,14 +250,14 @@ func (a Api) UpdateMatchingRule(c *gin.Context) {
 func (a Api) DeleteMatchingRule(c *gin.Context) {
 	ruleID := c.Param("id")
 	if ruleID == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Matching Rule ID is required"})
+		respondCode(c, apierror.ErrGenMissingParameter, "Matching Rule ID is required", nil)
 		return
 	}
 
 	err := a.blnk.DeleteMatchingRule(c.Request.Context(), ruleID)
 	if err != nil {
 		logrus.Error(err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete matching rule"})
+		respondError(c, err, withUpgrade(apierror.ErrGenNotFound, apierror.ErrReconRuleNotFound), withDefault(apierror.ErrGenInternal), withFallbackMessage("Failed to delete matching rule"))
 		return
 	}
 

--- a/api/reconciliation_api_test.go
+++ b/api/reconciliation_api_test.go
@@ -172,7 +172,7 @@ func TestDeleteMatchingRule(t *testing.T) {
 		req := httptest.NewRequest("DELETE", "/reconciliation/matching-rules/mr_nonexistent", nil)
 		resp := httptest.NewRecorder()
 		router.ServeHTTP(resp, req)
-		assert.Equal(t, http.StatusInternalServerError, resp.Code)
+		assert.Equal(t, http.StatusNotFound, resp.Code)
 	})
 }
 

--- a/api/reindex.go
+++ b/api/reindex.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"sync"
 
+	"github.com/blnkfinance/blnk/internal/apierror"
 	"github.com/blnkfinance/blnk/internal/search"
 	"github.com/gin-gonic/gin"
 )
@@ -61,9 +62,11 @@ func (a Api) StartReindex(c *gin.Context) {
 		progress := globalReindexManager.service.GetProgress()
 		if progress.Status == "in_progress" {
 			globalReindexManager.mu.Unlock()
+			msg := "A reindex operation is already in progress"
 			c.JSON(http.StatusConflict, gin.H{
-				"error":    "A reindex operation is already in progress",
-				"progress": progress,
+				"error":        msg,
+				"progress":     progress,
+				"error_detail": apierror.NewErrorResponse(apierror.ErrSrchReindexInProgress, msg, progress).Error,
 			})
 			return
 		}
@@ -104,9 +107,7 @@ func (a Api) GetReindexProgress(c *gin.Context) {
 	defer globalReindexManager.mu.RUnlock()
 
 	if globalReindexManager.service == nil {
-		c.JSON(http.StatusNotFound, gin.H{
-			"error": "No reindex operation has been started",
-		})
+		respondCode(c, apierror.ErrSrchReindexNotStarted, "No reindex operation has been started", nil)
 		return
 	}
 

--- a/api/testhelpers_test.go
+++ b/api/testhelpers_test.go
@@ -18,7 +18,9 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"io"
+	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
@@ -27,6 +29,7 @@ import (
 	"github.com/blnkfinance/blnk"
 	"github.com/blnkfinance/blnk/config"
 	"github.com/blnkfinance/blnk/database"
+	"github.com/blnkfinance/blnk/internal/apierror"
 	"github.com/blnkfinance/blnk/model"
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/gin-gonic/gin"
@@ -205,4 +208,23 @@ func resetReindexManager() {
 	globalReindexManager.mu.Lock()
 	globalReindexManager.service = nil
 	globalReindexManager.mu.Unlock()
+}
+
+// assertErrorCode asserts the standard dual error payload: the response has
+// the given status, error_detail carries the expected catalog code, and the
+// legacy flat field is still present.
+func assertErrorCode(t *testing.T, w *httptest.ResponseRecorder, status int, code apierror.ErrorCode) {
+	t.Helper()
+
+	require.Equal(t, status, w.Code)
+
+	var body struct {
+		Error       interface{}       `json:"error"`
+		Errors      interface{}       `json:"errors"`
+		ErrorDetail apierror.APIError `json:"error_detail"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	require.Equal(t, code, body.ErrorDetail.Code)
+	require.NotEmpty(t, body.ErrorDetail.Message)
+	require.True(t, body.Error != nil || body.Errors != nil, "legacy error field must still be present")
 }

--- a/api/transaction_api_test.go
+++ b/api/transaction_api_test.go
@@ -396,7 +396,7 @@ func TestRecordTransactionPrecisionValidation(t *testing.T) {
 		}
 
 		payloadBytes, _ := request.ToJsonReq(&invalidPayload)
-		response := map[string]string{}
+		response := map[string]interface{}{}
 		testRequest := TestRequest{
 			Payload:  payloadBytes,
 			Response: &response,

--- a/api/transaction_query_api_test.go
+++ b/api/transaction_query_api_test.go
@@ -174,7 +174,7 @@ func TestGetTransactionByID(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		assert.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.Equal(t, http.StatusNotFound, resp.Code)
 	})
 }
 
@@ -212,7 +212,7 @@ func TestGetTransactionByReference(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		assert.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.Equal(t, http.StatusNotFound, resp.Code)
 	})
 }
 
@@ -320,7 +320,7 @@ func TestGetTransactionLineage(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		assert.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.Equal(t, http.StatusNotFound, resp.Code)
 	})
 }
 

--- a/api/transactions.go
+++ b/api/transactions.go
@@ -29,6 +29,7 @@ import (
 	model2 "github.com/blnkfinance/blnk/api/model"
 	"github.com/blnkfinance/blnk/config"
 	"github.com/blnkfinance/blnk/database"
+	"github.com/blnkfinance/blnk/internal/apierror"
 	"github.com/blnkfinance/blnk/model"
 
 	"github.com/gin-gonic/gin"
@@ -88,54 +89,17 @@ func handleRecordTransactionValidationError(c *gin.Context, err error) {
 	var validationErrors validation.Errors
 	if errors.As(err, &validationErrors) {
 		if precisionErr, ok := validationErrors["Precision"]; ok && errors.Is(precisionErr, model2.ErrPrecisionMustBeInteger) {
-			c.JSON(http.StatusBadRequest, gin.H{"error": precisionErr.Error()})
+			respondCode(c, apierror.ErrTxnPrecisionNotInteger, precisionErr.Error(), nil)
 			return
 		}
 	}
 
 	if errors.Is(err, model2.ErrPrecisionMustBeInteger) {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondCode(c, apierror.ErrTxnPrecisionNotInteger, err.Error(), nil)
 		return
 	}
 
-	c.JSON(http.StatusBadRequest, gin.H{"errors": err.Error()})
-}
-
-// RecordTransaction handles the recording of a new transaction.
-// It binds the incoming JSON request to a RecordTransaction object, validates it,
-// and then records the transaction. If any errors occur during validation or recording,
-// it responds with an appropriate error message.
-//
-// Parameters:
-// - c: The Gin context containing the request and response.
-//
-// Responses:
-// - 400 Bad Request: If there's an error in binding JSON or validating the transaction.
-// - 201 Created: If the transaction is successfully recorded.
-func (a Api) RecordTransaction(c *gin.Context) {
-	var newTransaction model2.RecordTransaction
-	// Bind the incoming JSON request to the newTransaction model
-	if err := c.ShouldBindJSON(&newTransaction); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"errors": err.Error()})
-		return
-	}
-
-	// Validate the transaction data
-	err := newTransaction.ValidateRecordTransaction()
-	if err != nil {
-		handleRecordTransactionValidationError(c, err)
-		return
-	}
-
-	// Record the transaction using the Blnk service
-	resp, err := a.blnk.RecordTransaction(c.Request.Context(), newTransaction.ToTransaction())
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
-	}
-
-	// Return a response with the recorded transaction, properly transformed
-	c.JSON(http.StatusCreated, transformTransaction(resp))
+	respondCode(c, apierror.ErrTxnValidation, err.Error(), nil, withLegacyKey("errors"))
 }
 
 // QueueTransaction handles queuing a new transaction for later processing.
@@ -154,7 +118,7 @@ func (a Api) QueueTransaction(c *gin.Context) {
 	// Bind the incoming JSON request to the newTransaction model
 	if err := c.ShouldBindJSON(&newTransaction); err != nil {
 		logrus.WithError(err).Error("failed to bind transaction JSON")
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid input"})
+		respondCode(c, apierror.ErrGenMalformedRequest, "Invalid input", nil)
 		return
 	}
 
@@ -169,7 +133,7 @@ func (a Api) QueueTransaction(c *gin.Context) {
 	resp, err := a.blnk.QueueTransaction(c.Request.Context(), newTransaction.ToTransaction())
 	if err != nil {
 		logrus.WithError(err).Error("failed to queue transaction")
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondError(c, err, withUpgrade(apierror.ErrGenNotFound, apierror.ErrTxnNotFound), withDefault(apierror.ErrTxnValidation))
 		return
 	}
 
@@ -204,7 +168,7 @@ type refundTransactionRequest struct {
 func (a Api) RefundTransaction(c *gin.Context) {
 	id, passed := c.Params.Get("id")
 	if !passed {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "id is required. pass id in the route /:id"})
+		respondCode(c, apierror.ErrGenMissingParameter, "id is required. pass id in the route /:id", nil)
 		return
 	}
 
@@ -216,17 +180,17 @@ func (a Api) RefundTransaction(c *gin.Context) {
 	// of Content-Length / chunked transfer encoding.
 	var req refundTransactionRequest
 	if err := c.ShouldBindJSON(&req); err != nil && !errors.Is(err, io.EOF) {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondCode(c, apierror.ErrGenMalformedRequest, err.Error(), nil)
 		return
 	}
 
 	transaction, err := a.blnk.ProcessTransactionInBatches(c.Request.Context(), id, big.NewInt(0), 1, false, a.blnk.GetRefundableTransactionsByParentID, a.blnk.RefundWorkerWithOptions(req.SkipQueue))
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondError(c, err, withUpgrade(apierror.ErrGenNotFound, apierror.ErrTxnNotFound), withDefault(apierror.ErrGenBadRequest))
 		return
 	}
 	if len(transaction) == 0 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "no transaction to refund"})
+		respondCode(c, apierror.ErrTxnNotFound, "no transaction to refund", nil)
 		return
 	}
 	resp := transformTransaction(transaction[0])
@@ -247,13 +211,13 @@ func (a Api) GetTransaction(c *gin.Context) {
 	id, passed := c.Params.Get("id")
 
 	if !passed {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "id is required. pass id in the route /:id"})
+		respondCode(c, apierror.ErrGenMissingParameter, "id is required. pass id in the route /:id", nil)
 		return
 	}
 
 	resp, err := a.blnk.GetTransaction(c.Request.Context(), id)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondError(c, err, withUpgrade(apierror.ErrGenNotFound, apierror.ErrTxnNotFound))
 		return
 	}
 
@@ -274,13 +238,13 @@ func (a Api) GetTransactionByRef(c *gin.Context) {
 	reference, passed := c.Params.Get("reference")
 
 	if !passed {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "reference is required. pass reference in the route /ref/:reference"})
+		respondCode(c, apierror.ErrGenMissingParameter, "reference is required. pass reference in the route /ref/:reference", nil)
 		return
 	}
 
 	resp, err := a.blnk.GetTransactionByRef(c.Request.Context(), reference)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondError(c, err, withUpgrade(apierror.ErrGenNotFound, apierror.ErrTxnNotFound))
 		return
 	}
 
@@ -322,14 +286,15 @@ func (a Api) GetAllTransactions(c *gin.Context) {
 	if HasFilters(c) {
 		filters, parseErrors := ParseFiltersFromContext(c, nil)
 		if len(parseErrors) > 0 {
-			c.JSON(http.StatusBadRequest, gin.H{"errors": parseErrors})
+			respondCode(c, apierror.ErrGenValidation, "invalid filter parameters", parseErrors,
+				withLegacyKey("errors"), withLegacyValue(parseErrors))
 			return
 		}
 
 		// Use the new filter method
 		transactions, err := a.blnk.GetAllTransactionsWithFilter(c.Request.Context(), filters, limitInt, offsetInt)
 		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			respondError(c, err)
 			return
 		}
 
@@ -346,7 +311,7 @@ func (a Api) GetAllTransactions(c *gin.Context) {
 	// Fall back to legacy method when no filters are present
 	transactions, err := a.blnk.GetAllTransactions(limitInt, offsetInt)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
 
@@ -384,13 +349,13 @@ func (a Api) GetAllTransactions(c *gin.Context) {
 func (a Api) FilterTransactions(c *gin.Context) {
 	filters, opts, limit, offset, err := ParseFiltersFromBody(c, "transactions")
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondCode(c, apierror.ErrGenValidation, err.Error(), nil)
 		return
 	}
 
 	transactions, count, err := a.blnk.GetAllTransactionsWithFilterAndOptions(c.Request.Context(), filters, opts, limit, offset)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
 
@@ -422,23 +387,23 @@ func (a Api) UpdateInflightStatus(c *gin.Context) {
 	id, passed := c.Params.Get("txID")
 	var req model2.InflightUpdate
 	if !passed {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "id is required. pass id in the route /:id"})
+		respondCode(c, apierror.ErrGenMissingParameter, "id is required. pass id in the route /:id", nil)
 		return
 	}
 	err := c.BindJSON(&req)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondCode(c, apierror.ErrGenMalformedRequest, err.Error(), nil)
 		return
 	}
 
 	cnf, err := config.Fetch()
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
 	ds, err := database.GetDBConnection(cnf)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
 
@@ -452,27 +417,27 @@ func (a Api) UpdateInflightStatus(c *gin.Context) {
 	if status == "commit" {
 		transaction, err := a.blnk.ProcessTransactionInBatches(c.Request.Context(), id, amount, 1, false, a.blnk.GetInflightTransactionsByParentID, a.blnk.CommitWorker)
 		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			respondError(c, err, withUpgrade(apierror.ErrGenNotFound, apierror.ErrTxnNotFound), withDefault(apierror.ErrGenBadRequest))
 			return
 		}
 		if len(transaction) == 0 {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "no transaction to commit"})
+			respondCode(c, apierror.ErrTxnNotInflight, "no transaction to commit", nil)
 			return
 		}
 		resp = transformTransaction(transaction[0])
 	} else if status == "void" {
 		transaction, err := a.blnk.ProcessTransactionInBatches(c.Request.Context(), id, amount, 1, false, a.blnk.GetInflightTransactionsByParentID, a.blnk.VoidWorker)
 		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			respondError(c, err, withUpgrade(apierror.ErrGenNotFound, apierror.ErrTxnNotFound), withDefault(apierror.ErrGenBadRequest))
 			return
 		}
 		if len(transaction) == 0 {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "no transaction to void"})
+			respondCode(c, apierror.ErrTxnNotInflight, "no transaction to void", nil)
 			return
 		}
 		resp = transformTransaction(transaction[0])
 	} else {
-		c.JSON(http.StatusBadRequest, gin.H{"error": errors.New("status not supported. use either commit or void")})
+		respondCode(c, apierror.ErrTxnInvalidStatusAction, "status not supported. use either commit or void", nil)
 		return
 	}
 
@@ -485,18 +450,20 @@ func (a Api) UpdateInflightStatus(c *gin.Context) {
 func (a Api) CreateBulkTransactions(c *gin.Context) {
 	var req model2.BulkTransactionRequest
 	if err := c.BindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body: " + err.Error()})
+		respondCode(c, apierror.ErrGenMalformedRequest, "Invalid request body: "+err.Error(), nil)
 		return
 	}
 
 	for i, transaction := range req.Transactions {
 		if transaction == nil {
-			c.JSON(http.StatusBadRequest, gin.H{"errors": "transactions[" + strconv.Itoa(i) + "] is required"})
+			respondCode(c, apierror.ErrTxnValidation, "transactions["+strconv.Itoa(i)+"] is required",
+				gin.H{"index": i}, withLegacyKey("errors"))
 			return
 		}
 
 		if err := transaction.ValidateRecordTransaction(); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"errors": "transactions[" + strconv.Itoa(i) + "]: " + err.Error()})
+			respondCode(c, apierror.ErrTxnValidation, "transactions["+strconv.Itoa(i)+"]: "+err.Error(),
+				gin.H{"index": i}, withLegacyKey("errors"))
 			return
 		}
 	}
@@ -507,11 +474,18 @@ func (a Api) CreateBulkTransactions(c *gin.Context) {
 	result, err := a.blnk.CreateBulkTransactions(c.Request.Context(), bulkReq)
 	// Handle the response based on the result and error from the service layer
 	if err != nil {
-		// If there was an error during synchronous processing
+		// If there was an error during synchronous processing.
+		// classifyMessage picks the most specific catalog code from the
+		// detailed result error; batch_id stays a top-level sibling field.
 		logrus.WithError(err).WithField("batch_id", result.BatchID).Error("bulk transaction API error")
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":    result.Error, // Use the detailed error from the result
-			"batch_id": result.BatchID,
+		code, ok := classifyMessage(result.Error)
+		if !ok {
+			code = apierror.ErrGenBadRequest
+		}
+		c.JSON(apierror.StatusForCode(code), gin.H{
+			"error":        result.Error, // Use the detailed error from the result
+			"batch_id":     result.BatchID,
+			"error_detail": apierror.NewErrorResponse(code, result.Error, gin.H{"batch_id": result.BatchID}).Error,
 		})
 		return
 	}
@@ -537,13 +511,13 @@ func (a Api) CreateBulkTransactions(c *gin.Context) {
 func (a Api) GetTransactionLineage(c *gin.Context) {
 	id, passed := c.Params.Get("id")
 	if !passed {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "id is required. pass id in the route /:id"})
+		respondCode(c, apierror.ErrGenMissingParameter, "id is required. pass id in the route /:id", nil)
 		return
 	}
 
 	lineage, err := a.blnk.GetTransactionLineage(c.Request.Context(), id)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondError(c, err, withUpgrade(apierror.ErrGenNotFound, apierror.ErrTxnNotFound))
 		return
 	}
 
@@ -559,7 +533,7 @@ func (a Api) RecoverQueuedTransactions(c *gin.Context) {
 	if thresholdStr := c.Query("threshold"); thresholdStr != "" {
 		parsed, err := time.ParseDuration(thresholdStr)
 		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid threshold duration: " + err.Error()})
+			respondCode(c, apierror.ErrGenValidation, "invalid threshold duration: "+err.Error(), nil)
 			return
 		}
 		threshold = parsed
@@ -567,7 +541,7 @@ func (a Api) RecoverQueuedTransactions(c *gin.Context) {
 
 	recovered, err := a.blnk.RecoverQueuedTransactions(c.Request.Context(), threshold)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
 
@@ -613,17 +587,15 @@ func toAPIResults(outcomes []blnk.BulkInflightOutcome) (model2.BulkInflightRespo
 func (a Api) BulkVoidInflight(c *gin.Context) {
 	var req model2.BulkInflightVoidRequest
 	if err := c.BindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondCode(c, apierror.ErrGenMalformedRequest, err.Error(), nil)
 		return
 	}
 	if len(req.TransactionIDs) == 0 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "transaction_ids cannot be empty"})
+		respondCode(c, apierror.ErrTxnBulkEmpty, "transaction_ids cannot be empty", nil)
 		return
 	}
 	if len(req.TransactionIDs) > model2.MaxBulkInflightItems {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error": "too many transaction_ids; max is " + strconv.Itoa(model2.MaxBulkInflightItems),
-		})
+		respondCode(c, apierror.ErrTxnBulkLimitExceeded, "too many transaction_ids; max is "+strconv.Itoa(model2.MaxBulkInflightItems), nil)
 		return
 	}
 
@@ -634,7 +606,7 @@ func (a Api) BulkVoidInflight(c *gin.Context) {
 
 	outcomes, err := a.blnk.BulkInflightUpdate(c.Request.Context(), blnk.BulkInflightVoid, items, bulkInflightMaxWorkers)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondError(c, err, withDefault(apierror.ErrGenBadRequest))
 		return
 	}
 	resp, _ := toAPIResults(outcomes)
@@ -652,28 +624,26 @@ func (a Api) BulkVoidInflight(c *gin.Context) {
 func (a Api) BulkCommitInflight(c *gin.Context) {
 	var req model2.BulkInflightCommitRequest
 	if err := c.BindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondCode(c, apierror.ErrGenMalformedRequest, err.Error(), nil)
 		return
 	}
 	if len(req.Transactions) == 0 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "transactions cannot be empty"})
+		respondCode(c, apierror.ErrTxnBulkEmpty, "transactions cannot be empty", nil)
 		return
 	}
 	if len(req.Transactions) > model2.MaxBulkInflightItems {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error": "too many transactions; max is " + strconv.Itoa(model2.MaxBulkInflightItems),
-		})
+		respondCode(c, apierror.ErrTxnBulkLimitExceeded, "too many transactions; max is "+strconv.Itoa(model2.MaxBulkInflightItems), nil)
 		return
 	}
 
 	cnf, err := config.Fetch()
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
 	ds, err := database.GetDBConnection(cnf)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
 
@@ -692,7 +662,7 @@ func (a Api) BulkCommitInflight(c *gin.Context) {
 
 	outcomes, err := a.blnk.BulkInflightUpdate(c.Request.Context(), blnk.BulkInflightCommit, items, bulkInflightMaxWorkers)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondError(c, err, withDefault(apierror.ErrGenBadRequest))
 		return
 	}
 	resp, _ := toAPIResults(outcomes)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -49,33 +49,42 @@ func recoverPanic() {
 	}
 }
 
+// loadInstance loads the configuration file and initializes the Blnk
+// instance into app. Extracted from preRun so the initialization sequence
+// returns errors instead of exiting, keeping the Fatal at the command layer.
+func loadInstance(app *blnkInstance, configFile string) error {
+	// Initialize configuration from the specified configuration file.
+	if err := config.InitConfig(configFile); err != nil {
+		return fmt.Errorf("error loading config: %w", err)
+	}
+
+	// Fetch the configuration settings.
+	cnf, err := config.Fetch()
+	if err != nil {
+		return err
+	}
+
+	// Initialize the Blnk instance using the fetched configuration.
+	newBlnk, err := setupBlnk(cnf)
+	if err != nil {
+		notification.NotifyError(err) // Notify via the internal notification system
+		return err
+	}
+
+	// Assign the new Blnk instance and configuration to the app struct.
+	app.blnk = newBlnk
+	app.cnf = cnf
+
+	return nil
+}
+
 // preRun sets up the configuration and initializes the Blnk instance before running any command.
 // It ensures that the configuration is loaded, and the Blnk instance is initialized properly.
 func preRun(app *blnkInstance) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		// Initialize configuration from the specified configuration file.
-		err := config.InitConfig("blnk.json")
-		if err != nil {
-			log.Fatal("error loading config", err)
+		if err := loadInstance(app, "blnk.json"); err != nil {
+			log.Fatal(err)
 		}
-
-		// Fetch the configuration settings.
-		cnf, err := config.Fetch()
-		if err != nil {
-			return err
-		}
-
-		// Initialize the Blnk instance using the fetched configuration.
-		newBlnk, err := setupBlnk(cnf)
-		if err != nil {
-			notification.NotifyError(err) // Notify via the internal notification system
-			log.Fatal(err)                // Log the fatal error
-		}
-
-		// Assign the new Blnk instance and configuration to the app struct.
-		app.blnk = newBlnk
-		app.cnf = cnf
-
 		return nil
 	}
 }

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -22,6 +22,8 @@ This includes commands for applying and rolling back migrations.
 package main
 
 import (
+	"fmt"
+
 	"github.com/blnkfinance/blnk"
 	"github.com/blnkfinance/blnk/config"
 	"github.com/blnkfinance/blnk/database"
@@ -44,41 +46,48 @@ func migrateCommands(_ *blnkInstance) *cobra.Command {
 	return cmd
 }
 
+// runMigrations fetches the configuration, connects to the database, and
+// applies (or rolls back) the embedded SQL migrations in the "blnk" schema.
+// It returns the number of migrations applied.
+func runMigrations(direction migrate.MigrationDirection) (int, error) {
+	// Define the source of the migrations.
+	migrations := migrate.EmbedFileSystemMigrationSource{
+		FileSystem: blnk.SQLFiles,
+		Root:       "sql",
+	}
+
+	// Fetch the configuration.
+	cnf, err := config.Fetch()
+	if err != nil {
+		return 0, fmt.Errorf("error fetching config: %w", err)
+	}
+
+	// Connect to the database.
+	db, err := database.ConnectDB(cnf.DataSource)
+	if err != nil {
+		return 0, fmt.Errorf("error connecting to database: %w", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	// Set the schema for the migrations. (Previously only the up path set
+	// this; a standalone `migrate down` would have targeted the default
+	// search_path instead of the blnk schema.)
+	migrate.SetSchema("blnk")
+
+	return migrate.Exec(db, "postgres", migrations, direction)
+}
+
 // migrateUpCommands creates the command for applying migrations.
 func migrateUpCommands() *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "up",
 		Run: func(cmd *cobra.Command, args []string) {
-			// Define the source of the migrations.
-			migrations := migrate.EmbedFileSystemMigrationSource{
-				FileSystem: blnk.SQLFiles,
-				Root:       "sql",
-			}
-
-			// Fetch the configuration.
-			cnf, err := config.Fetch()
-			if err != nil {
-				logrus.Errorf("Error fetching config: %v", err)
-				return
-			}
-
-			// Connect to the database.
-			db, err := database.ConnectDB(cnf.DataSource)
-			if err != nil {
-				logrus.Errorf("Error connecting to database: %v", err)
-				return
-			}
-
-			// Set the schema for the migrations.
-			migrate.SetSchema("blnk")
-
-			// Apply the migrations.
-			n, err := migrate.Exec(db, "postgres", migrations, migrate.Up)
+			n, err := runMigrations(migrate.Up)
 			if err != nil {
 				logrus.Errorf("Error migrating up: %v", err)
-			} else {
-				logrus.Infof("Applied %d migrations!\n", n)
+				return
 			}
+			logrus.Infof("Applied %d migrations!\n", n)
 		},
 	}
 
@@ -90,33 +99,12 @@ func migrateDownCommands() *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "down",
 		Run: func(cmd *cobra.Command, args []string) {
-			// Define the source of the migrations.
-			migrations := migrate.EmbedFileSystemMigrationSource{
-				FileSystem: blnk.SQLFiles,
-				Root:       "sql",
-			}
-
-			// Fetch the configuration.
-			cnf, err := config.Fetch()
-			if err != nil {
-				logrus.Errorf("Error fetching config: %v", err)
-				return
-			}
-
-			// Connect to the database.
-			db, err := database.ConnectDB(cnf.DataSource)
-			if err != nil {
-				logrus.Errorf("Error connecting to database: %v", err)
-				return
-			}
-
-			// Roll back the migrations.
-			n, err := migrate.Exec(db, "postgres", migrations, migrate.Down)
+			n, err := runMigrations(migrate.Down)
 			if err != nil {
 				logrus.Errorf("Error migrating down: %v", err)
-			} else {
-				logrus.Infof("Rolled back %d migrations!\n", n)
+				return
 			}
+			logrus.Infof("Rolled back %d migrations!\n", n)
 		},
 	}
 

--- a/cmd/migrate_test.go
+++ b/cmd/migrate_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2024 Blnk Finance Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/blnkfinance/blnk/config"
+	migrate "github.com/rubenv/sql-migrate"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const migrateScratchDB = "blnk_migrate_cmd_test"
+
+// createScratchDatabase creates a throwaway database on the local test
+// Postgres so migrations can be applied and rolled back without touching
+// the shared blnk test database.
+func createScratchDatabase(t *testing.T) string {
+	t.Helper()
+
+	admin, err := sql.Open("postgres", "postgres://postgres:@localhost:5432/blnk?sslmode=disable")
+	require.NoError(t, err)
+	require.NoError(t, admin.Ping(), "Postgres must be running for the cmd test suite")
+
+	_, _ = admin.Exec("DROP DATABASE IF EXISTS " + migrateScratchDB + " WITH (FORCE)")
+	_, err = admin.Exec("CREATE DATABASE " + migrateScratchDB)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_, _ = admin.Exec("DROP DATABASE IF EXISTS " + migrateScratchDB + " WITH (FORCE)")
+		_ = admin.Close()
+	})
+
+	return "postgres://postgres:@localhost:5432/" + migrateScratchDB + "?sslmode=disable"
+}
+
+func TestRunMigrations_UpAndDown(t *testing.T) {
+	dsn := createScratchDatabase(t)
+	config.MockConfig(&config.Configuration{
+		DataSource: config.DataSourceConfig{Dns: dsn},
+		Redis:      config.RedisConfig{Dns: "localhost:6379"},
+	})
+
+	// Up: a fresh database must receive every embedded migration.
+	applied, err := runMigrations(migrate.Up)
+	require.NoError(t, err)
+	assert.Greater(t, applied, 0, "a fresh database must apply at least one migration")
+
+	// The core schema must genuinely exist afterwards.
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	var tableCount int
+	require.NoError(t, db.QueryRow(
+		`SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = 'blnk'`,
+	).Scan(&tableCount))
+	assert.Greater(t, tableCount, 5, "migrate up must create the blnk schema tables")
+
+	// Up again: idempotent, nothing new to apply.
+	applied, err = runMigrations(migrate.Up)
+	require.NoError(t, err)
+	assert.Equal(t, 0, applied, "re-running migrate up must apply nothing")
+
+	// Down: rollbacks must execute against the same schema.
+	rolledBack, err := runMigrations(migrate.Down)
+	require.NoError(t, err)
+	assert.Greater(t, rolledBack, 0, "migrate down must roll back at least one migration")
+}
+
+func TestRunMigrations_BadDSNFailsFast(t *testing.T) {
+	config.MockConfig(&config.Configuration{
+		DataSource: config.DataSourceConfig{Dns: "postgres://%zz-invalid-dsn"},
+		Redis:      config.RedisConfig{Dns: "localhost:6379"},
+	})
+
+	_, err := runMigrations(migrate.Up)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "error connecting to database")
+}
+
+func TestMigrateCommands_Wiring(t *testing.T) {
+	cmd := migrateCommands(&blnkInstance{})
+	subcommands := make(map[string]bool)
+	for _, sub := range cmd.Commands() {
+		subcommands[sub.Use] = true
+	}
+	assert.True(t, subcommands["up"], "migrate must expose the up subcommand")
+	assert.True(t, subcommands["down"], "migrate must expose the down subcommand")
+}
+
+func TestMigrateUpCommand_RunsViaCobra(t *testing.T) {
+	dsn := createScratchDatabase(t)
+	config.MockConfig(&config.Configuration{
+		DataSource: config.DataSourceConfig{Dns: dsn},
+		Redis:      config.RedisConfig{Dns: "localhost:6379"},
+	})
+
+	// Execute the actual cobra command (bypassing root preRun, which needs a
+	// blnk.json file) and verify it migrated the scratch database.
+	upCmd := migrateUpCommands()
+	upCmd.Run(upCmd, nil)
+
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	var exists bool
+	require.NoError(t, db.QueryRow(
+		`SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'blnk' AND table_name = 'gorp_migrations')`,
+	).Scan(&exists))
+	assert.True(t, exists, "the cobra up command must record applied migrations")
+}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -47,24 +47,37 @@ serveTLS starts an HTTPS server with TLS enabled using CertMagic for automatic c
 It accepts a gin.Engine instance as the router and a ServerConfig struct for server configurations.
 If no domain is specified, the server will default to running on localhost.
 */
+// resolveCertStoragePath returns the configured certificate storage path,
+// falling back to the default location when unset.
+func resolveCertStoragePath(conf config.ServerConfig) string {
+	if conf.CertStoragePath == "" {
+		return "/var/lib/blnk/certs"
+	}
+	return conf.CertStoragePath
+}
+
+// resolveTLSDomains returns the certificate domains, defaulting to localhost
+// when no domain is configured.
+func resolveTLSDomains(conf config.ServerConfig) []string {
+	if conf.Domain == "" {
+		return []string{"localhost"}
+	}
+	return []string{conf.Domain}
+}
+
 func serveTLS(r *gin.Engine, conf config.ServerConfig) error {
 	// Configure CertMagic's ACME (Automatic Certificate Management Environment) for automatic TLS
 	certmagic.DefaultACME.Agreed = true      // Agree to ACME TOS
 	certmagic.DefaultACME.Email = conf.Email // Set email for certificate recovery/notifications
 	cfg := certmagic.NewDefault()
 
-	certPath := conf.CertStoragePath
-	if certPath == "" {
-		certPath = "/var/lib/blnk/certs"
-	}
-	cfg.Storage = &certmagic.FileStorage{Path: certPath}
+	cfg.Storage = &certmagic.FileStorage{Path: resolveCertStoragePath(conf)}
 
 	// Define domain(s) for the certificate
-	domains := []string{conf.Domain}
 	if conf.Domain == "" {
 		logrus.Error("No domain specified, defaulting to localhost")
-		domains = []string{"localhost"} // Use localhost if no domain is provided
 	}
+	domains := resolveTLSDomains(conf)
 
 	// Manage TLS certificates for the specified domains
 	if err := cfg.ManageSync(context.Background(), domains); err != nil {
@@ -107,7 +120,14 @@ func migrateTypeSenseSchema(ctx context.Context, t *search.TypesenseClient) erro
 }
 
 func getOrCreateHeartbeatID() string {
-	db, err := sql.Open("sqlite3", "./heartbeat.db")
+	return getOrCreateHeartbeatIDAt("./heartbeat.db")
+}
+
+// getOrCreateHeartbeatIDAt persists a stable heartbeat UUID in a SQLite file
+// at the given path, creating it on first use. Any storage failure falls
+// back to a fresh (non-persistent) UUID.
+func getOrCreateHeartbeatIDAt(path string) string {
+	db, err := sql.Open("sqlite3", path)
 	if err != nil {
 		logrus.Errorf("Failed to open SQLite DB: %v", err)
 		return uuid.New().String() // fallback to temp UUID
@@ -211,28 +231,39 @@ func initializeTypeSense(ctx context.Context, cfg *config.Configuration) (*searc
 
 	newSearch := search.NewTypesenseClient(cfg.TypeSenseKey, []string{cfg.TypeSense.Dns})
 
-	const maxRetries = 5
-	var retryDelay = 2 * time.Second
-	var err error
+	err := retryWithBackoff(ctx, 5, 2*time.Second, func() error {
+		if err := newSearch.EnsureCollectionsExist(ctx); err != nil {
+			return err
+		}
+		return migrateTypeSenseSchema(ctx, newSearch)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return newSearch, nil
+}
 
-	for i := 0; i < maxRetries; i++ {
-		if err = newSearch.EnsureCollectionsExist(ctx); err == nil {
-			if err = migrateTypeSenseSchema(ctx, newSearch); err == nil {
-				return newSearch, nil
-			}
+// retryWithBackoff runs fn up to attempts times with exponential backoff
+// starting at baseDelay. It stops early when the context is canceled and
+// returns the last error when all attempts fail.
+func retryWithBackoff(ctx context.Context, attempts int, baseDelay time.Duration, fn func() error) error {
+	retryDelay := baseDelay
+	var err error
+	for i := 0; i < attempts; i++ {
+		if err = fn(); err == nil {
+			return nil
 		}
 
-		logrus.Errorf("TypeSense initialization failed (attempt %d/%d): %v. Retrying in %v...", i+1, maxRetries, err, retryDelay)
+		logrus.Errorf("TypeSense initialization failed (attempt %d/%d): %v. Retrying in %v...", i+1, attempts, err, retryDelay)
 
 		select {
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return ctx.Err()
 		case <-time.After(retryDelay):
 			retryDelay *= 2
 		}
 	}
-
-	return nil, fmt.Errorf("failed to initialize TypeSense after %d attempts: %v", maxRetries, err)
+	return fmt.Errorf("failed to initialize TypeSense after %d attempts: %v", attempts, err)
 }
 
 func initializePostHog() (posthog.Client, string) {
@@ -244,10 +275,7 @@ func initializePostHog() (posthog.Client, string) {
 }
 
 func startServer(router *gin.Engine, port string) error {
-	server := &http.Server{
-		Addr:    ":" + port,
-		Handler: router,
-	}
+	server := newHTTPServer(router, port)
 
 	// Start server in goroutine
 	go func() {
@@ -260,12 +288,25 @@ func startServer(router *gin.Engine, port string) error {
 	// Wait for interrupt signal
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+	return gracefulShutdown(server, quit, 30*time.Second)
+}
+
+// newHTTPServer builds the API HTTP server for the given router and port.
+func newHTTPServer(router *gin.Engine, port string) *http.Server {
+	return &http.Server{
+		Addr:    ":" + port,
+		Handler: router,
+	}
+}
+
+// gracefulShutdown blocks until a signal arrives on quit, then shuts the
+// server down, giving outstanding requests up to timeout to complete.
+func gracefulShutdown(server *http.Server, quit <-chan os.Signal, timeout time.Duration) error {
 	<-quit
 
 	logrus.Info("Shutting down server...")
 
-	// Give outstanding requests 30 seconds to complete
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	if err := server.Shutdown(ctx); err != nil {

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -1,0 +1,219 @@
+/*
+Copyright 2024 Blnk Finance Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/blnkfinance/blnk/config"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Genuinely untestable in-process and deliberately not faked here: main(),
+// executeCLI's os.Exit path, ACME certificate issuance in serveTLS, and
+// delivery of real SIGTERM signals (gracefulShutdown is tested by sending on
+// its quit channel instead).
+
+func TestRetryWithBackoff(t *testing.T) {
+	t.Run("succeeds after transient failures", func(t *testing.T) {
+		calls := 0
+		err := retryWithBackoff(context.Background(), 5, time.Millisecond, func() error {
+			calls++
+			if calls < 3 {
+				return errors.New("transient")
+			}
+			return nil
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 3, calls, "must stop retrying after the first success")
+	})
+
+	t.Run("returns last error when all attempts fail", func(t *testing.T) {
+		calls := 0
+		err := retryWithBackoff(context.Background(), 3, time.Millisecond, func() error {
+			calls++
+			return errors.New("permanent failure")
+		})
+		require.Error(t, err)
+		assert.Equal(t, 3, calls)
+		assert.Contains(t, err.Error(), "after 3 attempts")
+		assert.Contains(t, err.Error(), "permanent failure")
+	})
+
+	t.Run("stops when context is canceled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		calls := 0
+		err := retryWithBackoff(ctx, 5, time.Hour, func() error {
+			calls++
+			return errors.New("fails")
+		})
+		require.ErrorIs(t, err, context.Canceled)
+		assert.Equal(t, 1, calls, "a canceled context must short-circuit the backoff sleep")
+	})
+}
+
+func TestResolveTLSDomains(t *testing.T) {
+	assert.Equal(t, []string{"localhost"}, resolveTLSDomains(config.ServerConfig{}))
+	assert.Equal(t, []string{"ledger.example.com"}, resolveTLSDomains(config.ServerConfig{Domain: "ledger.example.com"}))
+}
+
+func TestResolveCertStoragePath(t *testing.T) {
+	assert.Equal(t, "/var/lib/blnk/certs", resolveCertStoragePath(config.ServerConfig{}))
+	assert.Equal(t, "/tmp/certs", resolveCertStoragePath(config.ServerConfig{CertStoragePath: "/tmp/certs"}))
+}
+
+func TestGetOrCreateHeartbeatIDAt(t *testing.T) {
+	t.Run("persists a stable ID", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "heartbeat.db")
+
+		first := getOrCreateHeartbeatIDAt(path)
+		require.NotEmpty(t, first)
+
+		second := getOrCreateHeartbeatIDAt(path)
+		assert.Equal(t, first, second, "the heartbeat ID must survive restarts via SQLite")
+
+		_, err := os.Stat(path)
+		require.NoError(t, err, "the SQLite file must have been created")
+	})
+
+	t.Run("falls back to a fresh ID when storage is unwritable", func(t *testing.T) {
+		// A directory path is not a valid SQLite file: storage fails, but the
+		// function must still return a usable (non-persistent) UUID.
+		id := getOrCreateHeartbeatIDAt(t.TempDir())
+		assert.NotEmpty(t, id)
+	})
+}
+
+func TestNewHTTPServerAndGracefulShutdown(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.GET("/ping", func(c *gin.Context) { c.String(http.StatusOK, "pong") })
+
+	server := newHTTPServer(router, "0")
+	assert.Equal(t, ":0", server.Addr)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := ln.Addr().String()
+
+	go func() { _ = server.Serve(ln) }()
+
+	// The server must actually serve requests before shutdown.
+	require.Eventually(t, func() bool {
+		resp, err := http.Get("http://" + addr + "/ping")
+		if err != nil {
+			return false
+		}
+		defer func() { _ = resp.Body.Close() }()
+		return resp.StatusCode == http.StatusOK
+	}, 3*time.Second, 50*time.Millisecond)
+
+	quit := make(chan os.Signal, 1)
+	done := make(chan error, 1)
+	go func() { done <- gracefulShutdown(server, quit, 5*time.Second) }()
+
+	quit <- os.Interrupt
+
+	select {
+	case err := <-done:
+		require.NoError(t, err, "graceful shutdown must complete cleanly")
+	case <-time.After(10 * time.Second):
+		t.Fatal("gracefulShutdown did not return after the quit signal")
+	}
+
+	// After shutdown the server must refuse new connections.
+	_, err = http.Get("http://" + addr + "/ping")
+	require.Error(t, err, "server must not accept requests after shutdown")
+}
+
+func TestHealthCheckHandler(t *testing.T) {
+	cfg := realInfraConfig(t)
+	_ = cfg
+
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/health", nil)
+
+	healthCheckHandler(c)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"status":"UP"`)
+}
+
+func TestInitializeTypeSense(t *testing.T) {
+	t.Run("disabled when DNS not configured", func(t *testing.T) {
+		client, err := initializeTypeSense(context.Background(), &config.Configuration{})
+		require.NoError(t, err)
+		assert.Nil(t, client, "search must be disabled, not an error, without a TypeSense DNS")
+	})
+
+	t.Run("real typesense initializes collections", func(t *testing.T) {
+		cfg := &config.Configuration{
+			TypeSenseKey: "blnk-api-key",
+			TypeSense:    config.TypeSenseConfig{Dns: "http://localhost:8108"},
+		}
+		client, err := initializeTypeSense(context.Background(), cfg)
+		require.NoError(t, err)
+		require.NotNil(t, client)
+	})
+
+	t.Run("dead server fails once the context expires", func(t *testing.T) {
+		cfg := &config.Configuration{
+			TypeSenseKey: "any",
+			TypeSense:    config.TypeSenseConfig{Dns: "http://localhost:1"},
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+		defer cancel()
+
+		start := time.Now()
+		client, err := initializeTypeSense(ctx, cfg)
+		require.Error(t, err)
+		assert.Nil(t, client)
+		assert.Less(t, time.Since(start), 10*time.Second, "context expiry must cut the retry loop short")
+	})
+}
+
+func TestInitializeRouter(t *testing.T) {
+	b := newCmdTestInstance(t)
+	router := initializeRouter(b)
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/health", nil))
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"status":"UP"`)
+}
+
+func TestSetupBlnk(t *testing.T) {
+	cfg := realInfraConfig(t)
+
+	instance, err := setupBlnk(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, instance)
+	require.NotNil(t, instance.GetDataSource(), "a real config must produce a wired Blnk instance")
+}

--- a/cmd/testhelpers_test.go
+++ b/cmd/testhelpers_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2024 Blnk Finance Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/blnkfinance/blnk/config"
+	"github.com/blnkfinance/blnk/model"
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/stretchr/testify/require"
+)
+
+// realInfraConfig installs (via config.MockConfig) and returns a configuration
+// pointing at the local test services, following the same convention as the
+// api and root package suites: Postgres on :5432, Redis on :6379, and
+// Typesense on :8108 are hard test dependencies.
+func realInfraConfig(t *testing.T) *config.Configuration {
+	t.Helper()
+	cfg := &config.Configuration{
+		DataSource: config.DataSourceConfig{Dns: "postgres://postgres:@localhost:5432/blnk?sslmode=disable"},
+		Redis:      config.RedisConfig{Dns: "localhost:6379"},
+		Queue: config.QueueConfig{
+			TransactionQueue:    "transaction_queue_cmd_test",
+			NumberOfQueues:      1,
+			WebhookQueue:        "webhook_queue_cmd_test",
+			IndexQueue:          "index_queue_cmd_test",
+			InflightExpiryQueue: "inflight_expiry_cmd_test",
+			InflightCommitQueue: "inflight_commit_cmd_test",
+			MonitoringPort:      "5117",
+		},
+		Transaction: config.TransactionConfig{
+			BatchSize:    100,
+			MaxQueueSize: 1000,
+			MaxWorkers:   2,
+			// MockConfig runs validateAndAddDefaults, which interprets a
+			// non-zero LockDuration as SECONDS and multiplies by time.Second.
+			LockDuration: 30,
+		},
+	}
+	config.MockConfig(cfg)
+	fetched, err := config.Fetch()
+	require.NoError(t, err)
+	return fetched
+}
+
+// newCmdTestInstance builds a blnkInstance backed by the real local Postgres
+// and Redis, mirroring how preRun wires the production instance.
+func newCmdTestInstance(t *testing.T) *blnkInstance {
+	t.Helper()
+	cfg := realInfraConfig(t)
+
+	newBlnk, err := setupBlnk(cfg)
+	require.NoError(t, err, "Postgres and Redis must be running for the cmd test suite")
+
+	return &blnkInstance{blnk: newBlnk, cnf: cfg}
+}
+
+// createBalancePair creates two USD balances in the general ledger.
+func createBalancePair(t *testing.T, b *blnkInstance) (*model.Balance, *model.Balance) {
+	t.Helper()
+	ds := b.blnk.GetDataSource()
+	src, err := ds.CreateBalance(model.Balance{Currency: "USD", LedgerID: "general_ledger_id"})
+	require.NoError(t, err)
+	dst, err := ds.CreateBalance(model.Balance{Currency: "USD", LedgerID: "general_ledger_id"})
+	require.NoError(t, err)
+	return &src, &dst
+}
+
+// queuedTransaction builds a QUEUED-status transaction payload exactly like
+// the queue producer would put on the wire for processTransaction.
+func queuedTransaction(src, dst string, amount float64, allowOverdraft bool) *model.Transaction {
+	txn := &model.Transaction{
+		TransactionID:  model.GenerateUUIDWithSuffix("txn"),
+		Reference:      "ref_" + gofakeit.UUID(),
+		Source:         src,
+		Destination:    dst,
+		Amount:         amount,
+		Precision:      100,
+		Currency:       "USD",
+		AllowOverdraft: allowOverdraft,
+		Status:         "QUEUED",
+		CreatedAt:      time.Now(),
+	}
+	model.ApplyPrecision(txn)
+	// The queue producer ships AmountString on the wire; the rejection path
+	// persists it verbatim into the numeric amount column.
+	txn.AmountString = strconv.FormatFloat(amount, 'f', -1, 64)
+	return txn
+}

--- a/cmd/workers.go
+++ b/cmd/workers.go
@@ -446,73 +446,85 @@ func workerCommands(b *blnkInstance) *cobra.Command {
 				logrus.Fatal("Error fetching config:", err)
 			}
 
-			phClient, shutdown, err := initializeTelemetryAndObservability(context.Background(), conf)
-			if err != nil {
+			if err := runWorkers(ctx, b, conf); err != nil {
 				logrus.Fatal(err)
 			}
-			if shutdown != nil {
-				defer func() {
-					tctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-					defer cancel()
-					if err := shutdown(tctx); err != nil {
-						logrus.Errorf("Error during shutdown: %v", err)
-					}
-				}()
-			}
-			if phClient != nil {
-				defer phClient.Close()
-			}
-
-			srv, hotSrv, webhookSrv, mux, webhookMux, err := setupWorkerServers(b, conf)
-			if err != nil {
-				logrus.Fatal(err)
-			}
-
-			monitoringSrv := startMonitoringServer(conf)
-
-			if err := srv.Start(mux); err != nil {
-				logrus.Fatalf("could not start transaction worker server: %v", err)
-			}
-			if hotSrv != nil {
-				if err := hotSrv.Start(mux); err != nil {
-					logrus.Fatalf("could not start hot transaction worker server: %v", err)
-				}
-			}
-			if err := webhookSrv.Start(webhookMux); err != nil {
-				logrus.Fatalf("could not start webhook worker server: %v", err)
-			}
-
-			recoveryProcessor := blnk.NewQueuedTransactionRecoveryProcessor(b.blnk)
-			recoveryProcessor.Start(ctx)
-
-			logrus.Info("Workers started.")
-
-			// Wait for SIGINT/SIGTERM.
-			<-ctx.Done()
-
-			logrus.Info("Shutdown signal received. Shutting down...")
-
-			recoveryProcessor.Stop()
-
-			if monitoringSrv != nil {
-				sctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-				defer cancel()
-				if err := monitoringSrv.Shutdown(sctx); err != nil {
-					logrus.Errorf("monitoring shutdown error: %v", err)
-				}
-			}
-
-			webhookSrv.Shutdown()
-			if hotSrv != nil {
-				hotSrv.Shutdown()
-			}
-			srv.Shutdown()
-
-			logrus.Info("Shutdown complete.")
 		},
 	}
 
 	return cmd
+}
+
+// runWorkers starts the transaction, hot-lane (optional), and webhook worker
+// servers plus the monitoring HTTP server, then blocks until ctx is canceled
+// and shuts everything down gracefully. Extracted from the cobra Run closure
+// so the full worker lifecycle is testable; startup failures are returned to
+// the caller, which keeps the process-exit decision at the command layer.
+func runWorkers(ctx context.Context, b *blnkInstance, conf *config.Configuration) error {
+	phClient, shutdown, err := initializeTelemetryAndObservability(context.Background(), conf)
+	if err != nil {
+		return err
+	}
+	if shutdown != nil {
+		defer func() {
+			tctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			if err := shutdown(tctx); err != nil {
+				logrus.Errorf("Error during shutdown: %v", err)
+			}
+		}()
+	}
+	if phClient != nil {
+		defer phClient.Close()
+	}
+
+	srv, hotSrv, webhookSrv, mux, webhookMux, err := setupWorkerServers(b, conf)
+	if err != nil {
+		return err
+	}
+
+	monitoringSrv := startMonitoringServer(conf)
+
+	if err := srv.Start(mux); err != nil {
+		return fmt.Errorf("could not start transaction worker server: %w", err)
+	}
+	if hotSrv != nil {
+		if err := hotSrv.Start(mux); err != nil {
+			return fmt.Errorf("could not start hot transaction worker server: %w", err)
+		}
+	}
+	if err := webhookSrv.Start(webhookMux); err != nil {
+		return fmt.Errorf("could not start webhook worker server: %w", err)
+	}
+
+	recoveryProcessor := blnk.NewQueuedTransactionRecoveryProcessor(b.blnk)
+	recoveryProcessor.Start(ctx)
+
+	logrus.Info("Workers started.")
+
+	// Wait for SIGINT/SIGTERM (or test-driven context cancellation).
+	<-ctx.Done()
+
+	logrus.Info("Shutdown signal received. Shutting down...")
+
+	recoveryProcessor.Stop()
+
+	if monitoringSrv != nil {
+		sctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := monitoringSrv.Shutdown(sctx); err != nil {
+			logrus.Errorf("monitoring shutdown error: %v", err)
+		}
+	}
+
+	webhookSrv.Shutdown()
+	if hotSrv != nil {
+		hotSrv.Shutdown()
+	}
+	srv.Shutdown()
+
+	logrus.Info("Shutdown complete.")
+	return nil
 }
 
 func setupWorkerServers(b *blnkInstance, conf *config.Configuration) (*asynq.Server, *asynq.Server, *asynq.Server, *asynq.ServeMux, *asynq.ServeMux, error) {

--- a/cmd/workers.go
+++ b/cmd/workers.go
@@ -475,7 +475,7 @@ func runWorkers(ctx context.Context, b *blnkInstance, conf *config.Configuration
 		}()
 	}
 	if phClient != nil {
-		defer phClient.Close()
+		defer func() { _ = phClient.Close() }()
 	}
 
 	srv, hotSrv, webhookSrv, mux, webhookMux, err := setupWorkerServers(b, conf)

--- a/cmd/workers_lifecycle_test.go
+++ b/cmd/workers_lifecycle_test.go
@@ -1,0 +1,206 @@
+/*
+Copyright 2024 Blnk Finance Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/blnkfinance/blnk/config"
+	"github.com/hibiken/asynq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Real lifecycle and handler tests for the worker process, against the local
+// Postgres, Redis, and Typesense (the suite's hard dependencies).
+//
+// Not covered on purpose: the max-retry branch of processTransaction needs
+// asynq.GetRetryCount, which only carries a value inside a running asynq
+// server context; its decision helper hasReachedMaxRetryAttempt is unit-
+// tested separately in workers_test.go.
+
+func TestProcessTransaction_AppliesQueuedTransaction(t *testing.T) {
+	b := newCmdTestInstance(t)
+	src, dst := createBalancePair(t, b)
+
+	txn := queuedTransaction(src.BalanceID, dst.BalanceID, 50, true)
+	payload, err := json.Marshal(txn)
+	require.NoError(t, err)
+
+	task := asynq.NewTask("transaction_queue_cmd_test_1", payload)
+	require.NoError(t, b.processTransaction(context.Background(), task))
+
+	// The money must actually have moved.
+	dstAfter, err := b.blnk.GetDataSource().GetBalanceByIDLite(dst.BalanceID)
+	require.NoError(t, err)
+	assert.Equal(t, "5000", dstAfter.Balance.String(), "destination must be credited 50 at precision 100")
+}
+
+func TestProcessTransaction_MalformedPayload(t *testing.T) {
+	b := newCmdTestInstance(t)
+
+	task := asynq.NewTask("transaction_queue_cmd_test_1", []byte("{not json"))
+	err := b.processTransaction(context.Background(), task)
+	require.Error(t, err, "a malformed payload must error so asynq can retry/dead-letter it")
+}
+
+func TestProcessTransaction_InsufficientFundsRejects(t *testing.T) {
+	b := newCmdTestInstance(t)
+	// Disable retries so the insufficient-funds branch rejects immediately.
+	b.cnf.Queue.InsufficientFundRetries = false
+
+	src, dst := createBalancePair(t, b)
+
+	// No overdraft and an empty source balance: processing must fail with
+	// insufficient funds and the transaction must be REJECTED, not retried.
+	txn := queuedTransaction(src.BalanceID, dst.BalanceID, 75, false)
+	payload, err := json.Marshal(txn)
+	require.NoError(t, err)
+
+	task := asynq.NewTask("transaction_queue_cmd_test_1", payload)
+	require.NoError(t, b.processTransaction(context.Background(), task), "rejection is a handled outcome, not a handler error")
+
+	recorded, err := b.blnk.GetTransactionByRef(context.Background(), txn.Reference)
+	require.NoError(t, err)
+	assert.Equal(t, "REJECTED", recorded.Status)
+
+	// The destination must not have been credited.
+	dstAfter, err := b.blnk.GetDataSource().GetBalanceByIDLite(dst.BalanceID)
+	require.NoError(t, err)
+	assert.Equal(t, "0", dstAfter.Balance.String())
+}
+
+func TestProcessInflightCommitAndExpiry(t *testing.T) {
+	b := newCmdTestInstance(t)
+	ctx := context.Background()
+
+	startInflight := func() string {
+		src, dst := createBalancePair(t, b)
+		txn := queuedTransaction(src.BalanceID, dst.BalanceID, 20, true)
+		txn.Inflight = true
+		recorded, err := b.blnk.RecordTransaction(ctx, txn)
+		require.NoError(t, err)
+		require.Equal(t, "INFLIGHT", recorded.Status)
+		return recorded.TransactionID
+	}
+
+	t.Run("commit", func(t *testing.T) {
+		txnID := startInflight()
+		payload, err := json.Marshal(txnID)
+		require.NoError(t, err)
+
+		task := asynq.NewTask("inflight_commit_cmd_test", payload)
+		require.NoError(t, b.processInflightCommit(ctx, task))
+
+		committed, err := b.blnk.GetTransaction(ctx, txnID)
+		require.NoError(t, err)
+		// Committing creates a child COMMIT entry; the parent leaves INFLIGHT.
+		assert.NotEqual(t, "VOID", committed.Status)
+
+		// Committing again must fail: it is already committed.
+		err = b.processInflightCommit(ctx, task)
+		require.Error(t, err, "double commit must surface an error")
+	})
+
+	t.Run("expiry voids", func(t *testing.T) {
+		txnID := startInflight()
+		payload, err := json.Marshal(txnID)
+		require.NoError(t, err)
+
+		task := asynq.NewTask("inflight_expiry_cmd_test", payload)
+		require.NoError(t, b.processInflightExpiry(ctx, task))
+
+		// Voiding again must fail: it has already been voided.
+		err = b.processInflightExpiry(ctx, task)
+		require.Error(t, err, "double void must surface an error")
+	})
+
+	t.Run("malformed payload", func(t *testing.T) {
+		task := asynq.NewTask("inflight_commit_cmd_test", []byte("{bad"))
+		require.Error(t, b.processInflightCommit(ctx, task))
+		require.Error(t, b.processInflightExpiry(ctx, task))
+	})
+}
+
+func TestIndexData(t *testing.T) {
+	b := newCmdTestInstance(t)
+	ctx := context.Background()
+
+	t.Run("disabled without typesense DNS", func(t *testing.T) {
+		task := asynq.NewTask("index_queue_cmd_test", []byte("ignored"))
+		require.NoError(t, b.indexData(ctx, task), "indexing must be a silent no-op when search is not configured")
+	})
+
+	b.cnf.TypeSenseKey = "blnk-api-key"
+	b.cnf.TypeSense = config.TypeSenseConfig{Dns: "http://localhost:8108"}
+
+	t.Run("malformed payload errors", func(t *testing.T) {
+		task := asynq.NewTask("index_queue_cmd_test", []byte("{bad json"))
+		require.Error(t, b.indexData(ctx, task))
+		require.Error(t, b.indexBatchData(ctx, task))
+	})
+
+	t.Run("indexes a document into typesense", func(t *testing.T) {
+		payload, err := json.Marshal(indexData{
+			Collection: "ledgers",
+			Payload: map[string]interface{}{
+				"ledger_id":  "ldg_worker_idx_test",
+				"name":       "worker indexed ledger",
+				"created_at": time.Now().Format(time.RFC3339),
+			},
+		})
+		require.NoError(t, err)
+
+		task := asynq.NewTask("index_queue_cmd_test", payload)
+		require.NoError(t, b.indexData(ctx, task))
+	})
+}
+
+func TestRunWorkers_LifecycleStartsAndShutsDown(t *testing.T) {
+	b := newCmdTestInstance(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- runWorkers(ctx, b, b.cnf) }()
+
+	// The monitoring server proves the worker stack came up.
+	require.Eventually(t, func() bool {
+		resp, err := http.Get("http://localhost:" + b.cnf.Queue.MonitoringPort + "/health")
+		if err != nil {
+			return false
+		}
+		defer func() { _ = resp.Body.Close() }()
+		return resp.StatusCode == http.StatusOK
+	}, 10*time.Second, 100*time.Millisecond, "worker monitoring server must come up")
+
+	// Cancel = SIGTERM equivalent; the full stack must shut down cleanly.
+	cancel()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(45 * time.Second):
+		t.Fatal("runWorkers did not shut down after context cancellation")
+	}
+
+	// Monitoring server must be gone after shutdown.
+	_, err := http.Get("http://localhost:" + b.cnf.Queue.MonitoringPort + "/health")
+	require.Error(t, err, "monitoring server must stop with the workers")
+}

--- a/database/lineage.go
+++ b/database/lineage.go
@@ -277,19 +277,25 @@ func (d Datasource) InsertLineageOutbox(ctx context.Context, outbox *model.Linea
 // ClaimPendingOutboxEntries claims a batch of pending outbox entries for processing.
 // It uses SELECT FOR UPDATE SKIP LOCKED to allow concurrent processors.
 func (d Datasource) ClaimPendingOutboxEntries(ctx context.Context, batchSize int, lockDuration time.Duration) ([]model.LineageOutbox, error) {
+	// UPDATE ... RETURNING does not preserve the inner ORDER BY, so the
+	// claimed rows are re-ordered through a CTE to guarantee FIFO delivery
+	// within the batch.
 	query := `
-		UPDATE blnk.lineage_outbox
-		SET status = $1, locked_until = NOW() + $2::interval
-		WHERE id IN (
-			SELECT id FROM blnk.lineage_outbox
-			WHERE status IN ('pending', 'processing')
-			  AND (locked_until IS NULL OR locked_until < NOW())
-			  AND attempts < max_attempts
-			ORDER BY created_at ASC
-			LIMIT $3
-			FOR UPDATE SKIP LOCKED
+		WITH claimed AS (
+			UPDATE blnk.lineage_outbox
+			SET status = $1, locked_until = NOW() + $2::interval
+			WHERE id IN (
+				SELECT id FROM blnk.lineage_outbox
+				WHERE status IN ('pending', 'processing')
+				  AND (locked_until IS NULL OR locked_until < NOW())
+				  AND attempts < max_attempts
+				ORDER BY created_at ASC
+				LIMIT $3
+				FOR UPDATE SKIP LOCKED
+			)
+			RETURNING id, transaction_id, source_balance_id, destination_balance_id, provider, lineage_type, payload, status, attempts, max_attempts, last_error, created_at, processed_at, locked_until, inflight
 		)
-		RETURNING id, transaction_id, source_balance_id, destination_balance_id, provider, lineage_type, payload, status, attempts, max_attempts, last_error, created_at, processed_at, locked_until, inflight
+		SELECT * FROM claimed ORDER BY created_at ASC
 	`
 
 	rows, err := d.Conn.QueryContext(ctx, query, model.OutboxStatusProcessing, lockDuration.String(), batchSize)

--- a/database/lineage_outbox_test.go
+++ b/database/lineage_outbox_test.go
@@ -33,7 +33,9 @@ import (
 
 // quiesceOutbox parks all unrelated pending outbox rows behind a future lock
 // so that claim assertions only see this test's fixtures. The shared database
-// persists rows between runs, so this keeps claims deterministic.
+// persists rows between runs, so this keeps claims deterministic. It also
+// registers a cleanup that marks this test's fixtures terminal so they never
+// leak into later runs or get chewed by lineage processors started elsewhere.
 func quiesceOutbox(t *testing.T, ds Datasource, markerPrefix string) {
 	t.Helper()
 	_, err := ds.Conn.Exec(`
@@ -44,6 +46,18 @@ func quiesceOutbox(t *testing.T, ds Datasource, markerPrefix string) {
 		  AND transaction_id NOT LIKE $1
 	`, markerPrefix+"%")
 	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_, err := ds.Conn.Exec(`
+			UPDATE blnk.lineage_outbox
+			SET status = 'completed', processed_at = NOW()
+			WHERE transaction_id LIKE $1
+			  AND status IN ('pending', 'processing')
+		`, markerPrefix+"%")
+		if err != nil {
+			t.Logf("failed to retire outbox fixtures: %v", err)
+		}
+	})
 }
 
 func newOutboxEntry(markerPrefix string) *model.LineageOutbox {

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -21,6 +21,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/blnkfinance/blnk/internal/apierror"
 	"github.com/blnkfinance/blnk/model"
@@ -29,6 +30,16 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
+
+// utcOrNil normalizes an optional timestamp to UTC so the naive value stored
+// in timestamp-without-time-zone columns is timezone-independent.
+func utcOrNil(t *time.Time) *time.Time {
+	if t == nil {
+		return nil
+	}
+	u := t.UTC()
+	return &u
+}
 
 func (d Datasource) RecordTransaction(ctx context.Context, txn *model.Transaction) (*model.Transaction, error) {
 	// Start a new tracing span for the database operation
@@ -46,7 +57,7 @@ func (d Datasource) RecordTransaction(ctx context.Context, txn *model.Transactio
 	_, err = d.Conn.ExecContext(ctx,
 		`INSERT INTO blnk.transactions(transaction_id, parent_transaction, source, reference, amount, precise_amount, precision, rate, currency, destination, description, status, created_at, meta_data, scheduled_for, hash, effective_date) 
 		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)`,
-		txn.TransactionID, txn.ParentTransaction, txn.Source, txn.Reference, txn.AmountString, txn.PreciseAmount.String(), txn.Precision, txn.Rate, txn.Currency, txn.Destination, txn.Description, txn.Status, txn.CreatedAt, metaDataJSON, txn.ScheduledFor, txn.Hash, txn.EffectiveDate,
+		txn.TransactionID, txn.ParentTransaction, txn.Source, txn.Reference, txn.AmountString, txn.PreciseAmount.String(), txn.Precision, txn.Rate, txn.Currency, txn.Destination, txn.Description, txn.Status, txn.CreatedAt.UTC(), metaDataJSON, txn.ScheduledFor.UTC(), txn.Hash, utcOrNil(txn.EffectiveDate),
 	)
 	// Handle errors that may occur during the execution of the query
 	if err != nil {
@@ -78,7 +89,7 @@ func recordTransactionInTx(ctx context.Context, tx *sql.Tx, txn *model.Transacti
 	_, err = tx.ExecContext(ctx,
 		`INSERT INTO blnk.transactions(transaction_id, parent_transaction, source, reference, amount, precise_amount, precision, rate, currency, destination, description, status, created_at, meta_data, scheduled_for, hash, effective_date) 
 		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)`,
-		txn.TransactionID, txn.ParentTransaction, txn.Source, txn.Reference, txn.AmountString, txn.PreciseAmount.String(), txn.Precision, txn.Rate, txn.Currency, txn.Destination, txn.Description, txn.Status, txn.CreatedAt, metaDataJSON, txn.ScheduledFor, txn.Hash, txn.EffectiveDate,
+		txn.TransactionID, txn.ParentTransaction, txn.Source, txn.Reference, txn.AmountString, txn.PreciseAmount.String(), txn.Precision, txn.Rate, txn.Currency, txn.Destination, txn.Description, txn.Status, txn.CreatedAt.UTC(), metaDataJSON, txn.ScheduledFor.UTC(), txn.Hash, utcOrNil(txn.EffectiveDate),
 	)
 	if err != nil {
 		span.RecordError(err)
@@ -152,11 +163,11 @@ func recordTransactionsInTx(ctx context.Context, tx *sql.Tx, txns []*model.Trans
 			txn.Destination,
 			txn.Description,
 			txn.Status,
-			txn.CreatedAt,
+			txn.CreatedAt.UTC(),
 			string(metaDataJSON),
-			txn.ScheduledFor,
+			txn.ScheduledFor.UTC(),
 			txn.Hash,
-			txn.EffectiveDate,
+			utcOrNil(txn.EffectiveDate),
 		); err != nil {
 			span.RecordError(err)
 			return apierror.NewAPIError(apierror.ErrInternalServer, "Failed to stream transaction copy row", err)

--- a/database/transactions_test.go
+++ b/database/transactions_test.go
@@ -102,8 +102,10 @@ func TestRecordTransaction_Success(t *testing.T) {
 	metaDataJSON, err := json.Marshal(transaction.MetaData)
 	assert.NoError(t, err)
 
+	// Timestamps are normalized to UTC at the insert boundary so the naive
+	// values stored in timestamp-without-time-zone columns are TZ-independent.
 	mock.ExpectExec("INSERT INTO blnk.transactions").
-		WithArgs(transaction.TransactionID, transaction.ParentTransaction, transaction.Source, transaction.Reference, transaction.AmountString, transaction.PreciseAmount.String(), transaction.Precision, transaction.Rate, transaction.Currency, transaction.Destination, transaction.Description, transaction.Status, transaction.CreatedAt, metaDataJSON, transaction.ScheduledFor, transaction.Hash, transaction.EffectiveDate).
+		WithArgs(transaction.TransactionID, transaction.ParentTransaction, transaction.Source, transaction.Reference, transaction.AmountString, transaction.PreciseAmount.String(), transaction.Precision, transaction.Rate, transaction.Currency, transaction.Destination, transaction.Description, transaction.Status, transaction.CreatedAt.UTC(), metaDataJSON, transaction.ScheduledFor.UTC(), transaction.Hash, nil).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	result, err := ds.RecordTransaction(ctx, transaction)

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-version: '3.8'
+version: "3.8"
 
 services:
   server:
@@ -36,7 +36,7 @@ services:
     build: .
     container_name: worker
     restart: on-failure
-    entrypoint: [ "blnk", "workers"]
+    entrypoint: ["blnk", "workers"]
     environment:
       OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: http://jaeger:4318/v1/traces
     ports:
@@ -49,8 +49,8 @@ services:
       - ./blnk.json:/blnk.json
 
   migration:
-    build:  .
-    entrypoint: [ "blnk", "migrate","up" ]
+    build: .
+    entrypoint: ["blnk", "migrate", "up"]
     restart: on-failure
     depends_on:
       - postgres
@@ -75,7 +75,7 @@ services:
     volumes:
       - pg_data:/var/lib/postgresql/data
     healthcheck:
-      test: [ "CMD", "pg_isready", "-U", "${POSTGRES_USER:-postgres}" ]
+      test: ["CMD", "pg_isready", "-U", "${POSTGRES_USER:-postgres}"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -83,7 +83,10 @@ services:
   typesense:
     image: typesense/typesense:29.0
     container_name: typesense
-    command: ["--data-dir", "/data", "--api-key=blnk-api-key", "--listen-port", "8108"]
+    command:
+      ["--data-dir", "/data", "--api-key=blnk-api-key", "--listen-port", "8108"]
+    ports:
+      - "8108:8108"
     volumes:
       - typesense_data:/data
     logging:
@@ -98,9 +101,9 @@ services:
     image: jaegertracing/all-in-one:latest
     container_name: jaeger
     ports:
-      - "16686:16686"  # Jaeger UI
-      - "4317:4317"    # OTLP gRPC
-      - "4318:4318"    # OTLP HTTP
+      - "16686:16686" # Jaeger UI
+      - "4317:4317" # OTLP gRPC
+      - "4318:4318" # OTLP HTTP
     environment:
       - COLLECTOR_OTLP_ENABLED=true
     healthcheck:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -80,6 +80,8 @@ services:
     container_name: typesense
     command:
       ["--data-dir", "/data", "--api-key=blnk-api-key", "--listen-port", "8108"]
+    ports:
+      - "8108:8108"
     volumes:
       - typesense_data:/data
     logging:

--- a/internal/apierror/apierror.go
+++ b/internal/apierror/apierror.go
@@ -17,6 +17,7 @@ limitations under the License.
 package apierror
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -61,24 +62,34 @@ func NewAPIError(code ErrorCode, message string, details interface{}) APIError {
 	}
 }
 
+// ErrorResponse is the standard envelope for structured error payloads.
+type ErrorResponse struct {
+	Error APIError `json:"error"`
+}
+
+// NewErrorResponse builds an ErrorResponse with the code normalized to its
+// canonical form. Unlike NewAPIError it does not log; callers own logging.
+func NewErrorResponse(code ErrorCode, message string, details interface{}) ErrorResponse {
+	return ErrorResponse{
+		Error: APIError{
+			Code:    Normalize(code),
+			Message: message,
+			Details: details,
+		},
+	}
+}
+
 // MapErrorToHTTPStatus maps APIError codes to appropriate HTTP status codes.
-// It returns the corresponding HTTP status code for the given APIError.
+// It unwraps the error chain to find an APIError (value or pointer) and
+// resolves the status from the code catalog, normalizing legacy codes.
 func MapErrorToHTTPStatus(err error) int {
-	if apiErr, ok := err.(APIError); ok {
-		switch apiErr.Code {
-		case ErrNotFound:
-			return http.StatusNotFound // HTTP 404 Not Found for missing resources.
-		case ErrConflict:
-			return http.StatusConflict // HTTP 409 Conflict for conflicting requests.
-		case ErrInvalidInput:
-			return http.StatusBadRequest // HTTP 400 Bad Request for invalid inputs.
-		case ErrInternalServer:
-			return http.StatusInternalServerError // HTTP 500 Internal Server Error for server issues.
-		case ErrRateLimited:
-			return http.StatusTooManyRequests // HTTP 429 Too Many Requests for rate limiting.
-		default:
-			return http.StatusInternalServerError
-		}
+	var apiErr APIError
+	if errors.As(err, &apiErr) {
+		return StatusForCode(Normalize(apiErr.Code))
+	}
+	var apiErrPtr *APIError
+	if errors.As(err, &apiErrPtr) && apiErrPtr != nil {
+		return StatusForCode(Normalize(apiErrPtr.Code))
 	}
 	return http.StatusInternalServerError // Default to 500 Internal Server Error if no specific mapping is found.
 }

--- a/internal/apierror/codes.go
+++ b/internal/apierror/codes.go
@@ -1,0 +1,258 @@
+/*
+Copyright 2024 Blnk Finance Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apierror
+
+import "net/http"
+
+// Domain-prefixed error codes. These are the canonical, client-facing codes
+// returned in the `error_detail.code` field of every error response.
+// Each code maps to exactly one default HTTP status (see statusByCode).
+//
+// The six legacy codes in apierror.go (NOT_FOUND, CONFLICT, ...) remain valid
+// for internal construction — they are normalized to their GEN_* equivalents
+// at the response boundary via Normalize.
+const (
+	// GEN — generic / cross-cutting
+	ErrGenMalformedRequest ErrorCode = "GEN_MALFORMED_REQUEST"
+	ErrGenValidation       ErrorCode = "GEN_VALIDATION_ERROR"
+	ErrGenMissingParameter ErrorCode = "GEN_MISSING_PARAMETER"
+	ErrGenBadRequest       ErrorCode = "GEN_BAD_REQUEST"
+	ErrGenNotFound         ErrorCode = "GEN_NOT_FOUND"
+	ErrGenConflict         ErrorCode = "GEN_CONFLICT"
+	ErrGenResourceLocked   ErrorCode = "GEN_RESOURCE_LOCKED"
+	ErrGenRateLimited      ErrorCode = "GEN_RATE_LIMITED"
+	ErrGenInternal         ErrorCode = "GEN_INTERNAL"
+
+	// AUTH — authentication / authorization
+	ErrAuthMissingAPIKey           ErrorCode = "AUTH_MISSING_API_KEY"
+	ErrAuthInvalidAPIKey           ErrorCode = "AUTH_INVALID_API_KEY"
+	ErrAuthExpiredAPIKey           ErrorCode = "AUTH_EXPIRED_API_KEY"
+	ErrAuthMissingPrincipal        ErrorCode = "AUTH_MISSING_PRINCIPAL"
+	ErrAuthInsufficientPermissions ErrorCode = "AUTH_INSUFFICIENT_PERMISSIONS"
+	ErrAuthUnknownResource         ErrorCode = "AUTH_UNKNOWN_RESOURCE"
+	ErrAuthMasterKeyRequired       ErrorCode = "AUTH_MASTER_KEY_REQUIRED"
+	ErrAuthCrossOwnerAccess        ErrorCode = "AUTH_CROSS_OWNER_ACCESS"
+	ErrAuthScopeEscalation         ErrorCode = "AUTH_SCOPE_ESCALATION"
+	ErrAuthMetricsTokenRequired    ErrorCode = "AUTH_METRICS_TOKEN_REQUIRED"
+	ErrAuthInvalidBearerToken      ErrorCode = "AUTH_INVALID_BEARER_TOKEN"
+	ErrAuthMetricsDisabled         ErrorCode = "AUTH_METRICS_DISABLED"
+
+	// APIKEY — API-key resource management
+	ErrAPIKeyNotFound      ErrorCode = "APIKEY_NOT_FOUND"
+	ErrAPIKeyOwnerRequired ErrorCode = "APIKEY_OWNER_REQUIRED"
+	ErrAPIKeyInvalid       ErrorCode = "APIKEY_INVALID"
+
+	// TXN — transactions
+	ErrTxnNotFound             ErrorCode = "TXN_NOT_FOUND"
+	ErrTxnInsufficientFunds    ErrorCode = "TXN_INSUFFICIENT_FUNDS"
+	ErrTxnInvalidAmount        ErrorCode = "TXN_INVALID_AMOUNT"
+	ErrTxnPrecisionNotInteger  ErrorCode = "TXN_PRECISION_NOT_INTEGER"
+	ErrTxnInvalidDistribution  ErrorCode = "TXN_INVALID_DISTRIBUTION"
+	ErrTxnDuplicateReference   ErrorCode = "TXN_DUPLICATE_REFERENCE"
+	ErrTxnNotInflight          ErrorCode = "TXN_NOT_INFLIGHT"
+	ErrTxnAlreadyCommitted     ErrorCode = "TXN_ALREADY_COMMITTED"
+	ErrTxnAlreadyVoided        ErrorCode = "TXN_ALREADY_VOIDED"
+	ErrTxnCommitAmountExceeded ErrorCode = "TXN_COMMIT_AMOUNT_EXCEEDED"
+	ErrTxnInvalidStatusAction  ErrorCode = "TXN_INVALID_STATUS_ACTION"
+	ErrTxnBulkEmpty            ErrorCode = "TXN_BULK_EMPTY"
+	ErrTxnBulkLimitExceeded    ErrorCode = "TXN_BULK_LIMIT_EXCEEDED"
+	ErrTxnValidation           ErrorCode = "TXN_VALIDATION_ERROR"
+
+	// BAL — balances & monitors
+	ErrBalNotFound         ErrorCode = "BAL_NOT_FOUND"
+	ErrBalHistoryNotFound  ErrorCode = "BAL_HISTORY_NOT_FOUND"
+	ErrBalInvalidTimestamp ErrorCode = "BAL_INVALID_TIMESTAMP"
+	ErrBalValidation       ErrorCode = "BAL_VALIDATION_ERROR"
+	ErrBalMonitorNotFound  ErrorCode = "BAL_MONITOR_NOT_FOUND"
+
+	// LGR — ledgers
+	ErrLgrNotFound  ErrorCode = "LGR_NOT_FOUND"
+	ErrLgrDuplicate ErrorCode = "LGR_DUPLICATE"
+
+	// ACC — accounts
+	ErrAccNotFound         ErrorCode = "ACC_NOT_FOUND"
+	ErrAccDuplicate        ErrorCode = "ACC_DUPLICATE"
+	ErrAccGenerationFailed ErrorCode = "ACC_GENERATION_FAILED"
+
+	// IDT — identities & tokenization
+	ErrIdtNotFound              ErrorCode = "IDT_NOT_FOUND"
+	ErrIdtValidation            ErrorCode = "IDT_VALIDATION_ERROR"
+	ErrIdtFieldNotTokenizable   ErrorCode = "IDT_FIELD_NOT_TOKENIZABLE"
+	ErrIdtFieldAlreadyTokenized ErrorCode = "IDT_FIELD_ALREADY_TOKENIZED"
+	ErrIdtFieldNotTokenized     ErrorCode = "IDT_FIELD_NOT_TOKENIZED"
+	ErrIdtFieldNotFound         ErrorCode = "IDT_FIELD_NOT_FOUND"
+	ErrIdtTokenizationDisabled  ErrorCode = "IDT_TOKENIZATION_DISABLED"
+
+	// RECON — reconciliation
+	ErrReconNotFound               ErrorCode = "RECON_NOT_FOUND"
+	ErrReconRuleNotFound           ErrorCode = "RECON_RULE_NOT_FOUND"
+	ErrReconUploadFailed           ErrorCode = "RECON_UPLOAD_FAILED"
+	ErrReconUploadProcessingFailed ErrorCode = "RECON_UPLOAD_PROCESSING_FAILED"
+	ErrReconRuleInvalid            ErrorCode = "RECON_RULE_INVALID"
+	ErrReconMatchingRulesRequired  ErrorCode = "RECON_MATCHING_RULES_REQUIRED"
+	ErrReconExternalTxnsRequired   ErrorCode = "RECON_EXTERNAL_TXNS_REQUIRED"
+	ErrReconStartFailed            ErrorCode = "RECON_START_FAILED"
+
+	// META — entity metadata
+	ErrMetaEntityNotFound    ErrorCode = "META_ENTITY_NOT_FOUND"
+	ErrMetaUnsupportedEntity ErrorCode = "META_UNSUPPORTED_ENTITY"
+	ErrMetaInvalidEntityID   ErrorCode = "META_INVALID_ENTITY_ID"
+
+	// HOOK — webhook management
+	ErrHookNotFound        ErrorCode = "HOOK_NOT_FOUND"
+	ErrHookInvalid         ErrorCode = "HOOK_INVALID"
+	ErrHookOperationFailed ErrorCode = "HOOK_OPERATION_FAILED"
+
+	// SRCH — search & reindex
+	ErrSrchQueryInvalid       ErrorCode = "SRCH_QUERY_INVALID"
+	ErrSrchFailed             ErrorCode = "SRCH_FAILED"
+	ErrSrchReindexInProgress  ErrorCode = "SRCH_REINDEX_IN_PROGRESS"
+	ErrSrchReindexNotStarted  ErrorCode = "SRCH_REINDEX_NOT_STARTED"
+
+	// ADMIN — administrative operations
+	ErrAdminBackupFailed ErrorCode = "ADMIN_BACKUP_FAILED"
+)
+
+// statusByCode is the single source of truth for the default HTTP status of
+// every error code, including the six legacy codes.
+var statusByCode = map[ErrorCode]int{
+	ErrGenMalformedRequest: http.StatusBadRequest,
+	ErrGenValidation:       http.StatusBadRequest,
+	ErrGenMissingParameter: http.StatusBadRequest,
+	ErrGenBadRequest:       http.StatusBadRequest,
+	ErrGenNotFound:         http.StatusNotFound,
+	ErrGenConflict:         http.StatusConflict,
+	ErrGenResourceLocked:   http.StatusLocked,
+	ErrGenRateLimited:      http.StatusTooManyRequests,
+	ErrGenInternal:         http.StatusInternalServerError,
+
+	ErrAuthMissingAPIKey:           http.StatusUnauthorized,
+	ErrAuthInvalidAPIKey:           http.StatusUnauthorized,
+	ErrAuthExpiredAPIKey:           http.StatusUnauthorized,
+	ErrAuthMissingPrincipal:        http.StatusUnauthorized,
+	ErrAuthInsufficientPermissions: http.StatusForbidden,
+	ErrAuthUnknownResource:         http.StatusForbidden,
+	ErrAuthMasterKeyRequired:       http.StatusForbidden,
+	ErrAuthCrossOwnerAccess:        http.StatusForbidden,
+	ErrAuthScopeEscalation:         http.StatusForbidden,
+	ErrAuthMetricsTokenRequired:    http.StatusUnauthorized,
+	ErrAuthInvalidBearerToken:      http.StatusUnauthorized,
+	ErrAuthMetricsDisabled:         http.StatusForbidden,
+
+	ErrAPIKeyNotFound:      http.StatusNotFound,
+	ErrAPIKeyOwnerRequired: http.StatusBadRequest,
+	ErrAPIKeyInvalid:       http.StatusBadRequest,
+
+	ErrTxnNotFound:             http.StatusNotFound,
+	ErrTxnInsufficientFunds:    http.StatusBadRequest,
+	ErrTxnInvalidAmount:        http.StatusBadRequest,
+	ErrTxnPrecisionNotInteger:  http.StatusBadRequest,
+	ErrTxnInvalidDistribution:  http.StatusBadRequest,
+	ErrTxnDuplicateReference:   http.StatusConflict,
+	ErrTxnNotInflight:          http.StatusBadRequest,
+	ErrTxnAlreadyCommitted:     http.StatusConflict,
+	ErrTxnAlreadyVoided:        http.StatusConflict,
+	ErrTxnCommitAmountExceeded: http.StatusBadRequest,
+	ErrTxnInvalidStatusAction:  http.StatusBadRequest,
+	ErrTxnBulkEmpty:            http.StatusBadRequest,
+	ErrTxnBulkLimitExceeded:    http.StatusBadRequest,
+	ErrTxnValidation:           http.StatusBadRequest,
+
+	ErrBalNotFound:         http.StatusNotFound,
+	ErrBalHistoryNotFound:  http.StatusNotFound,
+	ErrBalInvalidTimestamp: http.StatusBadRequest,
+	ErrBalValidation:       http.StatusBadRequest,
+	ErrBalMonitorNotFound:  http.StatusNotFound,
+
+	ErrLgrNotFound:  http.StatusNotFound,
+	ErrLgrDuplicate: http.StatusConflict,
+
+	ErrAccNotFound:         http.StatusNotFound,
+	ErrAccDuplicate:        http.StatusConflict,
+	ErrAccGenerationFailed: http.StatusInternalServerError,
+
+	ErrIdtNotFound:              http.StatusNotFound,
+	ErrIdtValidation:            http.StatusBadRequest,
+	ErrIdtFieldNotTokenizable:   http.StatusBadRequest,
+	ErrIdtFieldAlreadyTokenized: http.StatusConflict,
+	ErrIdtFieldNotTokenized:     http.StatusBadRequest,
+	ErrIdtFieldNotFound:         http.StatusBadRequest,
+	ErrIdtTokenizationDisabled:  http.StatusForbidden,
+
+	ErrReconNotFound:               http.StatusNotFound,
+	ErrReconRuleNotFound:           http.StatusNotFound,
+	ErrReconUploadFailed:           http.StatusBadRequest,
+	ErrReconUploadProcessingFailed: http.StatusInternalServerError,
+	ErrReconRuleInvalid:            http.StatusBadRequest,
+	ErrReconMatchingRulesRequired:  http.StatusBadRequest,
+	ErrReconExternalTxnsRequired:   http.StatusBadRequest,
+	ErrReconStartFailed:            http.StatusInternalServerError,
+
+	ErrMetaEntityNotFound:    http.StatusNotFound,
+	ErrMetaUnsupportedEntity: http.StatusBadRequest,
+	ErrMetaInvalidEntityID:   http.StatusBadRequest,
+
+	ErrHookNotFound:        http.StatusNotFound,
+	ErrHookInvalid:         http.StatusBadRequest,
+	ErrHookOperationFailed: http.StatusInternalServerError,
+
+	ErrSrchQueryInvalid:      http.StatusBadRequest,
+	ErrSrchFailed:            http.StatusInternalServerError,
+	ErrSrchReindexInProgress: http.StatusConflict,
+	ErrSrchReindexNotStarted: http.StatusNotFound,
+
+	ErrAdminBackupFailed: http.StatusInternalServerError,
+
+	// Legacy codes — same statuses MapErrorToHTTPStatus implied, with the
+	// BAD_REQUEST omission fixed (it previously fell through to 500).
+	ErrNotFound:       http.StatusNotFound,
+	ErrConflict:       http.StatusConflict,
+	ErrBadRequest:     http.StatusBadRequest,
+	ErrInvalidInput:   http.StatusBadRequest,
+	ErrInternalServer: http.StatusInternalServerError,
+	ErrRateLimited:    http.StatusTooManyRequests,
+}
+
+// legacyToCanonical maps the pre-catalog generic codes to their canonical
+// GEN_* replacements. Internal layers (notably database/) keep constructing
+// errors with the legacy codes; responses always surface canonical ones.
+var legacyToCanonical = map[ErrorCode]ErrorCode{
+	ErrNotFound:       ErrGenNotFound,
+	ErrConflict:       ErrGenConflict,
+	ErrBadRequest:     ErrGenBadRequest,
+	ErrInvalidInput:   ErrGenValidation,
+	ErrInternalServer: ErrGenInternal,
+	ErrRateLimited:    ErrGenRateLimited,
+}
+
+// Normalize converts a legacy error code to its canonical equivalent.
+// Canonical codes pass through unchanged.
+func Normalize(code ErrorCode) ErrorCode {
+	if canonical, ok := legacyToCanonical[code]; ok {
+		return canonical
+	}
+	return code
+}
+
+// StatusForCode returns the default HTTP status for an error code.
+// Unknown codes default to 500.
+func StatusForCode(code ErrorCode) int {
+	if status, ok := statusByCode[code]; ok {
+		return status
+	}
+	return http.StatusInternalServerError
+}

--- a/internal/apierror/codes_test.go
+++ b/internal/apierror/codes_test.go
@@ -1,0 +1,205 @@
+/*
+Copyright 2024 Blnk Finance Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apierror
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestStatusForCode(t *testing.T) {
+	tests := []struct {
+		code   ErrorCode
+		status int
+	}{
+		{ErrGenMalformedRequest, http.StatusBadRequest},
+		{ErrGenValidation, http.StatusBadRequest},
+		{ErrGenMissingParameter, http.StatusBadRequest},
+		{ErrGenBadRequest, http.StatusBadRequest},
+		{ErrGenNotFound, http.StatusNotFound},
+		{ErrGenConflict, http.StatusConflict},
+		{ErrGenResourceLocked, http.StatusLocked},
+		{ErrGenRateLimited, http.StatusTooManyRequests},
+		{ErrGenInternal, http.StatusInternalServerError},
+		{ErrAuthMissingAPIKey, http.StatusUnauthorized},
+		{ErrAuthInvalidAPIKey, http.StatusUnauthorized},
+		{ErrAuthExpiredAPIKey, http.StatusUnauthorized},
+		{ErrAuthMissingPrincipal, http.StatusUnauthorized},
+		{ErrAuthInsufficientPermissions, http.StatusForbidden},
+		{ErrAuthUnknownResource, http.StatusForbidden},
+		{ErrAuthMasterKeyRequired, http.StatusForbidden},
+		{ErrAuthCrossOwnerAccess, http.StatusForbidden},
+		{ErrAuthScopeEscalation, http.StatusForbidden},
+		{ErrAuthMetricsTokenRequired, http.StatusUnauthorized},
+		{ErrAuthInvalidBearerToken, http.StatusUnauthorized},
+		{ErrAuthMetricsDisabled, http.StatusForbidden},
+		{ErrAPIKeyNotFound, http.StatusNotFound},
+		{ErrAPIKeyOwnerRequired, http.StatusBadRequest},
+		{ErrAPIKeyInvalid, http.StatusBadRequest},
+		{ErrTxnNotFound, http.StatusNotFound},
+		{ErrTxnInsufficientFunds, http.StatusBadRequest},
+		{ErrTxnInvalidAmount, http.StatusBadRequest},
+		{ErrTxnPrecisionNotInteger, http.StatusBadRequest},
+		{ErrTxnInvalidDistribution, http.StatusBadRequest},
+		{ErrTxnDuplicateReference, http.StatusConflict},
+		{ErrTxnNotInflight, http.StatusBadRequest},
+		{ErrTxnAlreadyCommitted, http.StatusConflict},
+		{ErrTxnAlreadyVoided, http.StatusConflict},
+		{ErrTxnCommitAmountExceeded, http.StatusBadRequest},
+		{ErrTxnInvalidStatusAction, http.StatusBadRequest},
+		{ErrTxnBulkEmpty, http.StatusBadRequest},
+		{ErrTxnBulkLimitExceeded, http.StatusBadRequest},
+		{ErrTxnValidation, http.StatusBadRequest},
+		{ErrBalNotFound, http.StatusNotFound},
+		{ErrBalHistoryNotFound, http.StatusNotFound},
+		{ErrBalInvalidTimestamp, http.StatusBadRequest},
+		{ErrBalValidation, http.StatusBadRequest},
+		{ErrBalMonitorNotFound, http.StatusNotFound},
+		{ErrLgrNotFound, http.StatusNotFound},
+		{ErrLgrDuplicate, http.StatusConflict},
+		{ErrAccNotFound, http.StatusNotFound},
+		{ErrAccDuplicate, http.StatusConflict},
+		{ErrAccGenerationFailed, http.StatusInternalServerError},
+		{ErrIdtNotFound, http.StatusNotFound},
+		{ErrIdtValidation, http.StatusBadRequest},
+		{ErrIdtFieldNotTokenizable, http.StatusBadRequest},
+		{ErrIdtFieldAlreadyTokenized, http.StatusConflict},
+		{ErrIdtFieldNotTokenized, http.StatusBadRequest},
+		{ErrIdtFieldNotFound, http.StatusBadRequest},
+		{ErrIdtTokenizationDisabled, http.StatusForbidden},
+		{ErrReconNotFound, http.StatusNotFound},
+		{ErrReconRuleNotFound, http.StatusNotFound},
+		{ErrReconUploadFailed, http.StatusBadRequest},
+		{ErrReconUploadProcessingFailed, http.StatusInternalServerError},
+		{ErrReconRuleInvalid, http.StatusBadRequest},
+		{ErrReconMatchingRulesRequired, http.StatusBadRequest},
+		{ErrReconExternalTxnsRequired, http.StatusBadRequest},
+		{ErrReconStartFailed, http.StatusInternalServerError},
+		{ErrMetaEntityNotFound, http.StatusNotFound},
+		{ErrMetaUnsupportedEntity, http.StatusBadRequest},
+		{ErrMetaInvalidEntityID, http.StatusBadRequest},
+		{ErrHookNotFound, http.StatusNotFound},
+		{ErrHookInvalid, http.StatusBadRequest},
+		{ErrHookOperationFailed, http.StatusInternalServerError},
+		{ErrSrchQueryInvalid, http.StatusBadRequest},
+		{ErrSrchFailed, http.StatusInternalServerError},
+		{ErrSrchReindexInProgress, http.StatusConflict},
+		{ErrSrchReindexNotStarted, http.StatusNotFound},
+		{ErrAdminBackupFailed, http.StatusInternalServerError},
+		// Legacy codes, including the BAD_REQUEST fix (was 500).
+		{ErrNotFound, http.StatusNotFound},
+		{ErrConflict, http.StatusConflict},
+		{ErrBadRequest, http.StatusBadRequest},
+		{ErrInvalidInput, http.StatusBadRequest},
+		{ErrInternalServer, http.StatusInternalServerError},
+		{ErrRateLimited, http.StatusTooManyRequests},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.code), func(t *testing.T) {
+			if got := StatusForCode(tt.code); got != tt.status {
+				t.Errorf("StatusForCode(%s) = %d, want %d", tt.code, got, tt.status)
+			}
+		})
+	}
+}
+
+func TestStatusForCodeUnknown(t *testing.T) {
+	if got := StatusForCode("NO_SUCH_CODE"); got != http.StatusInternalServerError {
+		t.Errorf("StatusForCode(unknown) = %d, want 500", got)
+	}
+}
+
+func TestNormalize(t *testing.T) {
+	legacy := map[ErrorCode]ErrorCode{
+		ErrNotFound:       ErrGenNotFound,
+		ErrConflict:       ErrGenConflict,
+		ErrBadRequest:     ErrGenBadRequest,
+		ErrInvalidInput:   ErrGenValidation,
+		ErrInternalServer: ErrGenInternal,
+		ErrRateLimited:    ErrGenRateLimited,
+	}
+	for old, canonical := range legacy {
+		if got := Normalize(old); got != canonical {
+			t.Errorf("Normalize(%s) = %s, want %s", old, got, canonical)
+		}
+	}
+	// Canonical codes pass through.
+	if got := Normalize(ErrTxnNotFound); got != ErrTxnNotFound {
+		t.Errorf("Normalize(%s) = %s, want unchanged", ErrTxnNotFound, got)
+	}
+}
+
+func TestAllCodesHaveStatus(t *testing.T) {
+	// Every catalog code must resolve via the status map, and normalization
+	// must never produce a code without a status.
+	for code := range statusByCode {
+		normalized := Normalize(code)
+		if _, ok := statusByCode[normalized]; !ok {
+			t.Errorf("Normalize(%s) = %s has no status mapping", code, normalized)
+		}
+	}
+}
+
+func TestCodeNamingConvention(t *testing.T) {
+	legacySet := map[ErrorCode]bool{
+		ErrNotFound: true, ErrConflict: true, ErrBadRequest: true,
+		ErrInvalidInput: true, ErrInternalServer: true, ErrRateLimited: true,
+	}
+	prefixes := []string{"GEN_", "AUTH_", "APIKEY_", "TXN_", "BAL_", "LGR_", "ACC_", "IDT_", "RECON_", "META_", "HOOK_", "SRCH_", "ADMIN_"}
+	for code := range statusByCode {
+		if legacySet[code] {
+			continue
+		}
+		ok := false
+		for _, p := range prefixes {
+			if strings.HasPrefix(string(code), p) {
+				ok = true
+				break
+			}
+		}
+		if !ok {
+			t.Errorf("code %s does not use a known domain prefix", code)
+		}
+	}
+}
+
+func TestMapErrorToHTTPStatusUnwrapping(t *testing.T) {
+	base := NewAPIError(ErrTxnDuplicateReference, "reference used", nil)
+	wrapped := fmt.Errorf("queueing failed: %w", base)
+	if got := MapErrorToHTTPStatus(wrapped); got != http.StatusConflict {
+		t.Errorf("MapErrorToHTTPStatus(wrapped) = %d, want 409", got)
+	}
+	if got := MapErrorToHTTPStatus(fmt.Errorf("plain error")); got != http.StatusInternalServerError {
+		t.Errorf("MapErrorToHTTPStatus(plain) = %d, want 500", got)
+	}
+	// Legacy BAD_REQUEST now maps to 400 (previously fell through to 500).
+	if got := MapErrorToHTTPStatus(NewAPIError(ErrBadRequest, "bad", nil)); got != http.StatusBadRequest {
+		t.Errorf("MapErrorToHTTPStatus(BAD_REQUEST) = %d, want 400", got)
+	}
+}
+
+func TestNewErrorResponseNormalizes(t *testing.T) {
+	resp := NewErrorResponse(ErrNotFound, "missing", nil)
+	if resp.Error.Code != ErrGenNotFound {
+		t.Errorf("NewErrorResponse code = %s, want %s", resp.Error.Code, ErrGenNotFound)
+	}
+	if resp.Error.Message != "missing" {
+		t.Errorf("NewErrorResponse message = %q", resp.Error.Message)
+	}
+}

--- a/internal/search/reindex_test.go
+++ b/internal/search/reindex_test.go
@@ -1,0 +1,253 @@
+/*
+Copyright 2024 Blnk Finance Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package search
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/blnkfinance/blnk/database/mocks"
+	"github.com/blnkfinance/blnk/model"
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/typesense/typesense-go/typesense/api"
+)
+
+func testLedger(id string) model.Ledger {
+	return model.Ledger{LedgerID: id, Name: "ledger " + id, CreatedAt: time.Now().UTC()}
+}
+
+func testIdentity(id string) model.Identity {
+	return model.Identity{IdentityID: id, FirstName: "Re", LastName: "Index", CreatedAt: time.Now().UTC()}
+}
+
+func testBalance(id, ledgerID string) model.Balance {
+	return model.Balance{
+		BalanceID:             id,
+		LedgerID:              ledgerID,
+		Currency:              "USD",
+		Balance:               big.NewInt(1000),
+		CreditBalance:         big.NewInt(1000),
+		DebitBalance:          big.NewInt(0),
+		InflightBalance:       big.NewInt(0),
+		InflightCreditBalance: big.NewInt(0),
+		InflightDebitBalance:  big.NewInt(0),
+		CreatedAt:             time.Now().UTC(),
+	}
+}
+
+func testTransaction(id, source, destination string) model.Transaction {
+	return model.Transaction{
+		TransactionID: id,
+		Source:        source,
+		Destination:   destination,
+		Reference:     "ref_" + id,
+		Currency:      "USD",
+		Amount:        10,
+		PreciseAmount: big.NewInt(1000),
+		Status:        "APPLIED",
+		CreatedAt:     time.Now().UTC(),
+	}
+}
+
+func TestNewReindexService_ClampsBatchSize(t *testing.T) {
+	for _, size := range []int{0, -5} {
+		svc := NewReindexService(nil, nil, ReindexConfig{BatchSize: size})
+		assert.Equal(t, 1000, svc.config.BatchSize, "batch size %d should clamp to default", size)
+	}
+	svc := NewReindexService(nil, nil, ReindexConfig{BatchSize: 25})
+	assert.Equal(t, 25, svc.config.BatchSize)
+	assert.Equal(t, "pending", svc.GetProgress().Status)
+}
+
+func TestGetProgress_ReturnsCopy(t *testing.T) {
+	svc := NewReindexService(nil, nil, ReindexConfig{})
+
+	copy1 := svc.GetProgress()
+	copy1.Status = "mutated"
+	assert.Equal(t, "pending", svc.GetProgress().Status, "mutating the returned copy must not affect internal state")
+
+	ptr := svc.GetProgressPtr()
+	ptr.Status = "mutated"
+	assert.Equal(t, "pending", svc.GetProgress().Status, "GetProgressPtr must also return a detached copy")
+}
+
+func TestStartReindex_HappyPath(t *testing.T) {
+	client := newTestTypesenseClient(t)
+	ctx := context.Background()
+
+	ledgerID := "ldg_" + gofakeit.UUID()
+	identityID := "idt_" + gofakeit.UUID()
+	balSrc := "bln_" + gofakeit.UUID()
+	balDst := "bln_" + gofakeit.UUID()
+	txnID := "txn_" + gofakeit.UUID()
+
+	batchSize := 2
+	ds := new(mocks.MockDataSource)
+	// Two pages of ledgers (2 + 1) then the empty terminator page.
+	ds.On("GetAllLedgers", batchSize, 0).Return([]model.Ledger{testLedger(ledgerID), testLedger("ldg_" + gofakeit.UUID())}, nil).Once()
+	ds.On("GetAllLedgers", batchSize, 2).Return([]model.Ledger{testLedger("ldg_" + gofakeit.UUID())}, nil).Once()
+	ds.On("GetAllLedgers", batchSize, 3).Return([]model.Ledger{}, nil).Once()
+	ds.On("GetAllIdentitiesPaginated", batchSize, 0).Return([]model.Identity{testIdentity(identityID)}, nil).Once()
+	ds.On("GetAllIdentitiesPaginated", batchSize, 1).Return([]model.Identity{}, nil).Once()
+	ds.On("GetAllBalances", batchSize, 0).Return([]model.Balance{testBalance(balSrc, ledgerID), testBalance(balDst, ledgerID)}, nil).Once()
+	ds.On("GetAllBalances", batchSize, 2).Return([]model.Balance{}, nil).Once()
+	ds.On("GetAllTransactions", batchSize, 0).Return([]model.Transaction{testTransaction(txnID, balSrc, balDst)}, nil).Once()
+	ds.On("GetAllTransactions", batchSize, 1).Return([]model.Transaction{}, nil).Once()
+
+	svc := NewReindexService(client, ds, ReindexConfig{BatchSize: batchSize})
+
+	// Hammer GetProgress concurrently while the reindex runs; the -race
+	// detector is the assertion for the progress mutex.
+	stop := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = svc.GetProgress()
+			}
+		}
+	}()
+
+	progress, err := svc.StartReindex(ctx)
+	close(stop)
+
+	require.NoError(t, err)
+	require.NotNil(t, progress)
+	assert.Equal(t, "completed", progress.Status)
+	assert.Equal(t, "done", progress.Phase)
+	assert.NotNil(t, progress.CompletedAt)
+	assert.Empty(t, progress.Errors)
+	ds.AssertExpectations(t)
+
+	// The reindexed documents must actually be searchable.
+	for id, spec := range map[string]struct{ collection, field string }{
+		ledgerID:   {CollectionLedgers, "ledger_id"},
+		identityID: {CollectionIdentities, "identity_id"},
+		balSrc:     {CollectionBalances, "balance_id"},
+		txnID:      {CollectionTransactions, "transaction_id"},
+	} {
+		result, err := client.Search(ctx, spec.collection, &api.SearchCollectionParams{Q: id, QueryBy: spec.field})
+		require.NoError(t, err)
+		require.NotNil(t, result.Found)
+		assert.Equal(t, 1, *result.Found, "%s should be indexed in %s after reindex", id, spec.collection)
+	}
+}
+
+func TestStartReindex_DataSourceFailureMarksFailed(t *testing.T) {
+	client := newTestTypesenseClient(t)
+
+	batchSize := 5
+	ledgerID := "ldg_" + gofakeit.UUID()
+	ds := new(mocks.MockDataSource)
+	ds.On("GetAllLedgers", batchSize, 0).Return([]model.Ledger{testLedger(ledgerID)}, nil).Once()
+	ds.On("GetAllLedgers", batchSize, 1).Return([]model.Ledger{}, nil).Once()
+	ds.On("GetAllIdentitiesPaginated", batchSize, 0).Return([]model.Identity(nil), errors.New("identities table unavailable")).Once()
+
+	svc := NewReindexService(client, ds, ReindexConfig{BatchSize: batchSize})
+	progress, err := svc.StartReindex(context.Background())
+
+	require.Error(t, err)
+	require.NotNil(t, progress)
+	assert.Equal(t, "failed", progress.Status, "a datasource failure must not leave the reindex in_progress")
+	assert.Equal(t, "indexing_identities", progress.Phase)
+	assert.NotNil(t, progress.CompletedAt)
+	require.NotEmpty(t, progress.Errors)
+	assert.Contains(t, progress.Errors[0], "identities table unavailable")
+	ds.AssertExpectations(t)
+
+	// Earlier phases still ran: the ledger indexed before the failure exists.
+	result, searchErr := client.Search(context.Background(), CollectionLedgers, &api.SearchCollectionParams{Q: ledgerID, QueryBy: "ledger_id"})
+	require.NoError(t, searchErr)
+	assert.Equal(t, 1, *result.Found)
+}
+
+func TestStartReindex_TypesenseDownFails(t *testing.T) {
+	// A dead Typesense must fail the run at the first phase, not hang or
+	// report in_progress forever.
+	client := NewTypesenseClient("any-key", []string{"http://localhost:1"})
+	ds := new(mocks.MockDataSource)
+
+	svc := NewReindexService(client, ds, ReindexConfig{BatchSize: 10})
+	progress, err := svc.StartReindex(context.Background())
+
+	require.Error(t, err)
+	assert.Equal(t, "failed", progress.Status)
+	assert.Equal(t, "drop_collections", progress.Phase)
+	ds.AssertNotCalled(t, "GetAllLedgers")
+}
+
+func TestShouldReindex(t *testing.T) {
+	client := newTestTypesenseClient(t)
+	ctx := context.Background()
+	resetCollections(t, client) // transactions collection exists and is empty
+
+	t.Run("db has data and typesense empty -> reindex", func(t *testing.T) {
+		ds := new(mocks.MockDataSource)
+		// Two ledgers (more than just the default general ledger) signal data.
+		ds.On("GetAllLedgers", 2, 0).Return([]model.Ledger{testLedger("a"), testLedger("b")}, nil).Once()
+		assert.True(t, shouldReindex(ctx, client, ds))
+		ds.AssertExpectations(t)
+	})
+
+	t.Run("empty db -> no reindex", func(t *testing.T) {
+		ds := new(mocks.MockDataSource)
+		ds.On("GetAllLedgers", 2, 0).Return([]model.Ledger{testLedger("only-general")}, nil).Once()
+		ds.On("GetAllTransactions", 1, 0).Return([]model.Transaction{}, nil).Once()
+		ds.On("GetAllBalances", 1, 0).Return([]model.Balance{}, nil).Once()
+		ds.On("GetAllIdentitiesPaginated", 1, 0).Return([]model.Identity{}, nil).Once()
+		assert.False(t, shouldReindex(ctx, client, ds))
+		ds.AssertExpectations(t)
+	})
+
+	t.Run("typesense already has data -> no reindex", func(t *testing.T) {
+		// Transactions reference balances, so the balance must exist first
+		// (Typesense enforces reference integrity on insert).
+		balID := "bln_existing_" + gofakeit.UUID()
+		require.NoError(t, client.HandleNotification(ctx, CollectionBalances, map[string]interface{}{
+			"balance_id": balID,
+			"ledger_id":  "general_ledger_id",
+			"currency":   "USD",
+			"created_at": time.Now(),
+		}))
+		require.NoError(t, client.HandleNotification(ctx, CollectionTransactions, map[string]interface{}{
+			"transaction_id": "txn_existing_" + gofakeit.UUID(),
+			"source":         balID,
+			"destination":    balID,
+			"created_at":     time.Now(),
+		}))
+		ds := new(mocks.MockDataSource)
+		ds.On("GetAllLedgers", 2, 0).Return([]model.Ledger{testLedger("a"), testLedger("b")}, nil).Once()
+		assert.False(t, shouldReindex(ctx, client, ds))
+		ds.AssertExpectations(t)
+	})
+}
+
+func TestTryReindexIfNeeded_NilArgsAreSafe(t *testing.T) {
+	// Must not panic and must not touch the datasource.
+	TryReindexIfNeeded(context.Background(), nil, nil)
+
+	ds := new(mocks.MockDataSource)
+	TryReindexIfNeeded(context.Background(), nil, ds)
+	ds.AssertNotCalled(t, "GetAllLedgers")
+}

--- a/internal/search/search_fault_test.go
+++ b/internal/search/search_fault_test.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2024 Blnk Finance Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package search
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/typesense/typesense-go/typesense"
+)
+
+// Fault-injection tests: typesense-go accepts any server URL, so these point
+// the client at an httptest.Server scripted to fail in ways a healthy real
+// Typesense cannot produce (5xx, timeouts, garbage responses).
+
+// newFaultClient builds a TypesenseClient against the fake server with a
+// short timeout so failure tests stay fast. Constructed directly (instead of
+// NewTypesenseClient) to override the production 5s connection timeout.
+func newFaultClient(serverURL string, timeout time.Duration) *TypesenseClient {
+	return &TypesenseClient{Client: typesense.NewClient(
+		typesense.WithServer(serverURL),
+		typesense.WithAPIKey("test-key"),
+		typesense.WithConnectionTimeout(timeout),
+	)}
+}
+
+func TestCreateCollection_ServerErrorIsNotSwallowed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message": "disk full"}`))
+	}))
+	defer srv.Close()
+
+	client := newFaultClient(srv.URL, time.Second)
+	resp, err := client.CreateCollection(context.Background(), getLedgerSchema())
+
+	// A 500 must propagate — only "already exists" errors are suppressed.
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.NotContains(t, err.Error(), "already exists")
+}
+
+func TestHandleNotification_UpsertServerErrorPropagates(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"message": "service unavailable"}`))
+	}))
+	defer srv.Close()
+
+	client := newFaultClient(srv.URL, time.Second)
+	err := client.HandleNotification(context.Background(), CollectionLedgers, map[string]interface{}{
+		"ledger_id":  "ldg_fault",
+		"name":       "fault ledger",
+		"created_at": time.Now(),
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to upsert document")
+}
+
+func TestUpsert_SlowServerTimesOut(t *testing.T) {
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-release:
+		case <-r.Context().Done():
+		}
+	}))
+	defer srv.Close()
+	defer close(release)
+
+	client := newFaultClient(srv.URL, 150*time.Millisecond)
+
+	start := time.Now()
+	err := client.HandleNotification(context.Background(), CollectionLedgers, map[string]interface{}{
+		"ledger_id":  "ldg_slow",
+		"name":       "slow ledger",
+		"created_at": time.Now(),
+	})
+
+	require.Error(t, err, "a server slower than the client timeout must produce an error")
+	assert.Less(t, time.Since(start), 5*time.Second, "timeout should respect the configured budget, not hang")
+}
+
+func TestMigrateTypeSenseSchema_MalformedResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{not valid json`))
+	}))
+	defer srv.Close()
+
+	client := newFaultClient(srv.URL, time.Second)
+	err := client.MigrateTypeSenseSchema(context.Background(), CollectionLedgers)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to retrieve current schema")
+}
+
+func TestHandleBatchNotification_FailingDependencyStopsBatch(t *testing.T) {
+	// Server fails every document write: the batch must abort on the first
+	// dependency and never reach the primary item.
+	var requests int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requests, 1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"message": "down"}`))
+	}))
+	defer srv.Close()
+
+	client := newFaultClient(srv.URL, time.Second)
+	batch := NewIndexBatch("b1")
+	batch.AddDependency(CollectionBalances, "bln_1", map[string]interface{}{"balance_id": "bln_1", "created_at": time.Now()})
+	batch.SetPrimary(CollectionTransactions, "txn_1", map[string]interface{}{"transaction_id": "txn_1", "created_at": time.Now()})
+
+	err := client.HandleBatchNotification(context.Background(), batch)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to index dependency", "batch must fail on the dependency, before the primary")
+	assert.Contains(t, err.Error(), "bln_1")
+}

--- a/internal/search/search_integration_test.go
+++ b/internal/search/search_integration_test.go
@@ -1,0 +1,327 @@
+/*
+Copyright 2024 Blnk Finance Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package search
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/typesense/typesense-go/typesense/api"
+)
+
+// Typesense is a hard test dependency, like Postgres and Redis: these tests
+// FAIL (not skip) when it is unreachable. Start it with `docker compose up -d
+// typesense` (port 8108 published, API key "blnk-api-key").
+const (
+	testTypesenseHost = "http://localhost:8108"
+	testTypesenseKey  = "blnk-api-key"
+)
+
+func newTestTypesenseClient(t *testing.T) *TypesenseClient {
+	t.Helper()
+	client := NewTypesenseClient(testTypesenseKey, []string{testTypesenseHost})
+	_, err := client.Client.Health(context.Background(), 2*time.Second)
+	require.NoError(t, err, "Typesense must be running on %s for the search test suite (docker compose up -d typesense)", testTypesenseHost)
+	return client
+}
+
+// resetCollections drops and recreates all known collections so each test
+// starts from a clean, schema-correct state.
+func resetCollections(t *testing.T, client *TypesenseClient) {
+	t.Helper()
+	ctx := context.Background()
+	require.NoError(t, client.DropAllCollections(ctx))
+	require.NoError(t, client.EnsureCollectionsExist(ctx))
+}
+
+func TestEnsureCollectionsExist_CreatesAllAndIsIdempotent(t *testing.T) {
+	client := newTestTypesenseClient(t)
+	ctx := context.Background()
+	require.NoError(t, client.DropAllCollections(ctx))
+
+	require.NoError(t, client.EnsureCollectionsExist(ctx))
+
+	// All five collections must exist.
+	for _, name := range []string{CollectionLedgers, CollectionBalances, CollectionTransactions, CollectionReconciliations, CollectionIdentities} {
+		resp, err := client.Client.Collection(name).Retrieve(ctx)
+		require.NoError(t, err, "collection %s should exist", name)
+		assert.Equal(t, name, resp.Name)
+	}
+
+	// The default general ledger document must be present.
+	result, err := client.Search(ctx, CollectionLedgers, &api.SearchCollectionParams{
+		Q:       "general_ledger_id",
+		QueryBy: "ledger_id",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result.Found)
+	assert.GreaterOrEqual(t, *result.Found, 1, "default general ledger should be indexed")
+
+	// Second call is idempotent: collections already exist, no error.
+	require.NoError(t, client.EnsureCollectionsExist(ctx))
+}
+
+func TestCreateCollection_IdempotentOnAlreadyExists(t *testing.T) {
+	client := newTestTypesenseClient(t)
+	ctx := context.Background()
+	resetCollections(t, client)
+
+	// Collection already exists from resetCollections: the "already exists"
+	// error must be suppressed and return nil, nil.
+	resp, err := client.CreateCollection(ctx, getLedgerSchema())
+	require.NoError(t, err)
+	assert.Nil(t, resp)
+}
+
+func TestHandleNotification_UpsertAndSearchRoundTrip(t *testing.T) {
+	client := newTestTypesenseClient(t)
+	ctx := context.Background()
+	resetCollections(t, client)
+
+	ledgerID := "ldg_" + gofakeit.UUID()
+	name := "Search Test Ledger " + gofakeit.LetterN(8)
+	created := time.Date(2024, 3, 1, 12, 0, 0, 0, time.UTC)
+
+	// created_at as an RFC3339 string and a nil meta_data exercise
+	// normalizeTimeFields and processMetadata on the real write path.
+	data := map[string]interface{}{
+		"ledger_id":  ledgerID,
+		"name":       name,
+		"created_at": created.Format(time.RFC3339),
+		"meta_data":  nil,
+	}
+	require.NoError(t, client.HandleNotification(ctx, CollectionLedgers, data))
+
+	result, err := client.Search(ctx, CollectionLedgers, &api.SearchCollectionParams{
+		Q:       ledgerID,
+		QueryBy: "ledger_id",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result.Found)
+	require.Equal(t, 1, *result.Found)
+
+	doc := (*result.Hits)[0].Document
+	require.NotNil(t, doc)
+	assert.Equal(t, name, (*doc)["name"])
+	// RFC3339 string must have been normalized to a Unix timestamp.
+	assert.EqualValues(t, created.Unix(), (*doc)["created_at"])
+
+	// Upserting the same ID with a new name updates, not duplicates.
+	data["name"] = name + " v2"
+	data["created_at"] = created.Format(time.RFC3339)
+	require.NoError(t, client.HandleNotification(ctx, CollectionLedgers, data))
+
+	result, err = client.Search(ctx, CollectionLedgers, &api.SearchCollectionParams{
+		Q:       ledgerID,
+		QueryBy: "ledger_id",
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, *result.Found, "upsert must replace, not duplicate")
+	assert.Equal(t, name+" v2", (*(*result.Hits)[0].Document)["name"])
+}
+
+func TestHandleNotification_UnknownTable(t *testing.T) {
+	client := newTestTypesenseClient(t)
+	err := client.HandleNotification(context.Background(), "no_such_table", map[string]interface{}{"id": "x"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown collection")
+}
+
+func TestHandleBatchNotification_DependenciesBeforePrimary(t *testing.T) {
+	client := newTestTypesenseClient(t)
+	ctx := context.Background()
+	resetCollections(t, client)
+
+	ledgerID := "ldg_" + gofakeit.UUID()
+	balSrc := "bln_" + gofakeit.UUID()
+	balDst := "bln_" + gofakeit.UUID()
+	txnID := "txn_" + gofakeit.UUID()
+	now := time.Now().UTC()
+
+	mkBalance := func(id string) map[string]interface{} {
+		return map[string]interface{}{
+			"balance_id": id,
+			"ledger_id":  "general_ledger_id",
+			"indicator":  "",
+			"currency":   "USD",
+			"balance":    "0",
+			"created_at": now,
+		}
+	}
+
+	batch := NewIndexBatch("batch_" + ledgerID)
+	batch.AddDependency(CollectionBalances, balSrc, mkBalance(balSrc))
+	batch.AddDependency(CollectionBalances, balDst, mkBalance(balDst))
+	// Duplicate dependency must be removed by Deduplicate, not double-indexed.
+	batch.AddDependency(CollectionBalances, balSrc, mkBalance(balSrc))
+	batch.SetPrimary(CollectionTransactions, txnID, map[string]interface{}{
+		"transaction_id": txnID,
+		"source":         balSrc,
+		"destination":    balDst,
+		"reference":      "ref_" + gofakeit.UUID(),
+		"currency":       "USD",
+		"amount":         100.50,
+		"precise_amount": "10050",
+		"status":         "APPLIED",
+		"created_at":     now,
+	})
+
+	require.NoError(t, client.HandleBatchNotification(ctx, batch))
+	assert.Len(t, batch.Dependencies, 2, "duplicate dependency should have been deduplicated")
+
+	// Both balances and the transaction must be retrievable.
+	for id, collection := range map[string]string{balSrc: CollectionBalances, txnID: CollectionTransactions} {
+		queryBy := collectionConfigs[collection].IDField
+		result, err := client.Search(ctx, collection, &api.SearchCollectionParams{Q: id, QueryBy: queryBy})
+		require.NoError(t, err)
+		require.NotNil(t, result.Found)
+		assert.Equal(t, 1, *result.Found, "document %s should exist in %s", id, collection)
+	}
+}
+
+func TestMultiSearch_AcrossCollections(t *testing.T) {
+	client := newTestTypesenseClient(t)
+	ctx := context.Background()
+	resetCollections(t, client)
+
+	ledgerID := "ldg_" + gofakeit.UUID()
+	identityID := "idt_" + gofakeit.UUID()
+	require.NoError(t, client.HandleNotification(ctx, CollectionLedgers, map[string]interface{}{
+		"ledger_id": ledgerID, "name": "multi search ledger", "created_at": time.Now(),
+	}))
+	require.NoError(t, client.HandleNotification(ctx, CollectionIdentities, map[string]interface{}{
+		"identity_id": identityID, "first_name": "Multi", "last_name": "Search", "created_at": time.Now(),
+	}))
+
+	ledgerQ := ledgerID
+	identityQ := identityID
+	ledgerBy := "ledger_id"
+	identityBy := "identity_id"
+	result, err := client.MultiSearch(ctx, api.MultiSearchSearchesParameter{
+		Searches: []api.MultiSearchCollectionParameters{
+			{Collection: CollectionLedgers, Q: &ledgerQ, QueryBy: &ledgerBy},
+			{Collection: CollectionIdentities, Q: &identityQ, QueryBy: &identityBy},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Results, 2)
+	require.NotNil(t, result.Results[0].Found)
+	require.NotNil(t, result.Results[1].Found)
+	assert.Equal(t, 1, *result.Results[0].Found, "ledger should be found via multi-search")
+	assert.Equal(t, 1, *result.Results[1].Found, "identity should be found via multi-search")
+}
+
+func TestMigrateTypeSenseSchema_AddsMissingFields(t *testing.T) {
+	client := newTestTypesenseClient(t)
+	ctx := context.Background()
+	require.NoError(t, client.DropAllCollections(ctx))
+
+	// Create the ledgers collection from a reduced schema missing "name" and
+	// "meta_data" — simulating a collection created by an older Blnk version.
+	// EnableNestedFields must be set at creation time: Typesense rejects
+	// adding object-typed fields (meta_data) to collections without it.
+	facet := true
+	sortBy := "created_at"
+	enableNested := true
+	reduced := &api.CollectionSchema{
+		Name: CollectionLedgers,
+		Fields: []api.Field{
+			{Name: "ledger_id", Type: "string", Facet: &facet},
+			{Name: "created_at", Type: "int64", Facet: &facet},
+		},
+		DefaultSortingField: &sortBy,
+		EnableNestedFields:  &enableNested,
+	}
+	_, err := client.CreateCollection(ctx, reduced)
+	require.NoError(t, err)
+
+	require.NoError(t, client.MigrateTypeSenseSchema(ctx, CollectionLedgers))
+
+	resp, err := client.Client.Collection(CollectionLedgers).Retrieve(ctx)
+	require.NoError(t, err)
+	fields := make(map[string]bool)
+	for _, f := range resp.Fields {
+		fields[f.Name] = true
+	}
+	assert.True(t, fields["name"], "migration should have added the missing 'name' field")
+	assert.True(t, fields["meta_data"], "migration should have added the missing 'meta_data' field")
+}
+
+func TestMigrateTypeSenseSchema_UnknownCollection(t *testing.T) {
+	client := newTestTypesenseClient(t)
+	err := client.MigrateTypeSenseSchema(context.Background(), "no_such_collection")
+	require.Error(t, err)
+}
+
+func TestDropCollection_RemovesAndIgnoresMissing(t *testing.T) {
+	client := newTestTypesenseClient(t)
+	ctx := context.Background()
+	resetCollections(t, client)
+
+	require.NoError(t, client.DropCollection(ctx, CollectionReconciliations))
+	_, err := client.Client.Collection(CollectionReconciliations).Retrieve(ctx)
+	require.Error(t, err, "dropped collection should no longer exist")
+
+	// Dropping a collection that does not exist is not an error.
+	require.NoError(t, client.DropCollection(ctx, CollectionReconciliations))
+	require.NoError(t, client.DropCollection(ctx, "never_existed_"+gofakeit.LetterN(6)))
+}
+
+func TestDropAllCollections_RemovesEverything(t *testing.T) {
+	client := newTestTypesenseClient(t)
+	ctx := context.Background()
+	resetCollections(t, client)
+
+	require.NoError(t, client.DropAllCollections(ctx))
+	for _, name := range []string{CollectionLedgers, CollectionBalances, CollectionTransactions, CollectionReconciliations, CollectionIdentities} {
+		_, err := client.Client.Collection(name).Retrieve(ctx)
+		assert.Error(t, err, "collection %s should be gone", name)
+	}
+}
+
+func TestSearch_DroppedCollectionSurfacesError(t *testing.T) {
+	client := newTestTypesenseClient(t)
+	ctx := context.Background()
+	resetCollections(t, client)
+	require.NoError(t, client.DropCollection(ctx, CollectionIdentities))
+
+	_, err := client.Search(ctx, CollectionIdentities, &api.SearchCollectionParams{Q: "x", QueryBy: "identity_id"})
+	require.Error(t, err, "searching a missing collection must surface the error, not swallow it")
+}
+
+func TestClient_DeadServerReturnsError(t *testing.T) {
+	// Port 1 is reserved/unused: connections fail fast. The client must
+	// return an error within its timeout budget rather than hang.
+	client := NewTypesenseClient("any-key", []string{"http://localhost:1"})
+
+	done := make(chan error, 1)
+	go func() {
+		err := client.EnsureCollectionsExist(context.Background())
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		require.Error(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("operation against dead server did not return within 10s (client timeout is 5s)")
+	}
+}

--- a/internal/traces/otel_sdk_test.go
+++ b/internal/traces/otel_sdk_test.go
@@ -1,0 +1,200 @@
+package trace
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+)
+
+// fakeOTLPCollector records OTLP/HTTP export requests so tests can assert
+// that telemetry genuinely leaves the process.
+type fakeOTLPCollector struct {
+	mu       sync.Mutex
+	requests []*http.Request
+	bodies   [][]byte
+	srv      *httptest.Server
+}
+
+func newFakeOTLPCollector(t *testing.T) *fakeOTLPCollector {
+	t.Helper()
+	c := &fakeOTLPCollector{}
+	c.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := make([]byte, r.ContentLength)
+		_, _ = r.Body.Read(body)
+		c.mu.Lock()
+		c.requests = append(c.requests, r.Clone(context.Background()))
+		c.bodies = append(c.bodies, body)
+		c.mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	t.Cleanup(c.srv.Close)
+	return c
+}
+
+// exportPosts returns recorded OTLP export requests. The URL path depends on
+// which env var configured the endpoint (the OTel spec appends /v1/traces to
+// the generic endpoint but uses signal-specific endpoints as-is), so exports
+// are identified by their protobuf POST signature rather than a fixed path.
+func (c *fakeOTLPCollector) exportPosts() []*http.Request {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var out []*http.Request
+	for _, r := range c.requests {
+		if r.Method == http.MethodPost && strings.Contains(r.Header.Get("Content-Type"), "x-protobuf") {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func TestSetupOTelSDK_BasicLifecycle(t *testing.T) {
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "")
+
+	ctx := context.Background()
+	shutdown, err := SetupOTelSDK(ctx, "blnk-test", "")
+	require.NoError(t, err)
+	require.NotNil(t, shutdown)
+
+	// The W3C composite propagator must be installed globally:
+	// traceparent/tracestate from TraceContext, baggage from Baggage.
+	fields := otel.GetTextMapPropagator().Fields()
+	assert.ElementsMatch(t, []string{"traceparent", "tracestate", "baggage"}, fields)
+
+	// The Prometheus metrics handler must be wired.
+	require.NotNil(t, MetricsHandler())
+
+	// First shutdown flushes cleanly; second is a registered-once no-op.
+	require.NoError(t, shutdown(ctx))
+	require.NoError(t, shutdown(ctx), "second shutdown call must be a no-op, not a double-shutdown error")
+}
+
+func TestSetupOTelSDK_ExportsSpansToCollector(t *testing.T) {
+	collector := newFakeOTLPCollector(t)
+	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", collector.srv.URL)
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "")
+
+	ctx := context.Background()
+	shutdown, err := SetupOTelSDK(ctx, "blnk-span-test", "")
+	require.NoError(t, err)
+
+	_, span := otel.Tracer("blnk-test-tracer").Start(ctx, "test-operation")
+	span.End()
+
+	// Shutdown forces the batch processor to flush pending spans.
+	require.NoError(t, shutdown(ctx))
+
+	posts := collector.exportPosts()
+	require.NotEmpty(t, posts, "the span must have been POSTed to the collector")
+}
+
+func TestSetupOTelSDK_GenericEndpointFallback(t *testing.T) {
+	// Only the generic OTEL_EXPORTER_OTLP_ENDPOINT is set: the trace
+	// exporter must fall back to it (newTraceExporter's second branch).
+	collector := newFakeOTLPCollector(t)
+	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", collector.srv.URL)
+	t.Setenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "")
+
+	ctx := context.Background()
+	shutdown, err := SetupOTelSDK(ctx, "blnk-fallback-test", "")
+	require.NoError(t, err)
+
+	_, span := otel.Tracer("blnk-test-tracer").Start(ctx, "fallback-operation")
+	span.End()
+	require.NoError(t, shutdown(ctx))
+
+	posts := collector.exportPosts()
+	require.NotEmpty(t, posts, "spans must export via the generic endpoint fallback")
+	// The generic endpoint gets /v1/traces appended per the OTel spec.
+	assert.Equal(t, "/v1/traces", posts[0].URL.Path)
+}
+
+func TestSetupOTelSDK_MetricsOTLPBranch(t *testing.T) {
+	// With a metrics endpoint configured, the dual-mode meter provider adds
+	// the OTLP periodic reader on top of the always-on Prometheus exporter.
+	collector := newFakeOTLPCollector(t)
+	t.Setenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", collector.srv.URL)
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "")
+
+	ctx := context.Background()
+	shutdown, err := SetupOTelSDK(ctx, "blnk-metrics-test", "")
+	require.NoError(t, err)
+
+	// Record a metric so the periodic reader has something to push on flush.
+	meter := otel.GetMeterProvider().Meter("blnk-test-meter")
+	counter, err := meter.Int64Counter("blnk_test_counter")
+	require.NoError(t, err)
+	counter.Add(ctx, 1)
+
+	require.NoError(t, shutdown(ctx))
+
+	// Prometheus pull side must still work alongside the push exporter.
+	require.NotNil(t, MetricsHandler())
+}
+
+func TestSetupOTelSDK_InvalidMonitoringDSNIsNonFatal(t *testing.T) {
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "")
+
+	ctx := context.Background()
+	// A garbage DSN must disable the monitoring exporter with a warning,
+	// never fail SDK setup.
+	shutdown, err := SetupOTelSDK(ctx, "blnk-bad-dsn-test", "not-a-valid-dsn")
+	require.NoError(t, err)
+	require.NotNil(t, shutdown)
+	require.NoError(t, shutdown(ctx))
+}
+
+func TestSetupOTelSDK_ShutdownJoinsErrors(t *testing.T) {
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "")
+
+	shutdown, err := SetupOTelSDK(context.Background(), "blnk-shutdown-err-test", "")
+	require.NoError(t, err)
+
+	// Create a span so the batch processor has pending work, then shut down
+	// with an already-canceled context: at least one provider must surface
+	// the cancellation, and the joined error must propagate to the caller.
+	_, span := otel.Tracer("blnk-test-tracer").Start(context.Background(), "doomed-span")
+	span.End()
+
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	err = shutdown(canceled)
+	require.Error(t, err, "shutdown with a canceled context must report the underlying provider errors")
+}
+
+func TestSetupOTelSDK_ValidMonitoringDSNWiresExporter(t *testing.T) {
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "")
+
+	// Point the monitoring DSN at a local fake so exporter construction
+	// succeeds without external services.
+	collector := newFakeOTLPCollector(t)
+	dsn := "https://pk_test@" + collector.srv.Listener.Addr().String() + "/project_test"
+
+	ctx := context.Background()
+	shutdown, err := SetupOTelSDK(ctx, "blnk-dsn-test", dsn)
+	require.NoError(t, err)
+	require.NotNil(t, shutdown)
+
+	// Allow a short grace period for lazy exporter goroutines, then flush.
+	time.Sleep(50 * time.Millisecond)
+	_ = shutdown(ctx)
+}

--- a/makefile
+++ b/makefile
@@ -26,6 +26,18 @@ generate:
 test:
 	go test -short  ./...
 
+# Mutation testing on the money-critical fast packages (model, filter).
+# Plants hundreds of one-line bugs and re-runs the tests against each one;
+# a "LIVED" mutant is a bug the test suite would not catch. Fails when test
+# efficacy (killed/viable mutants) drops below the threshold. Takes ~10 min.
+# Triage survivors by reading the LIVED lines; model/mutation_killers_test.go
+# has examples of boundary tests written to kill them.
+MUTATION_THRESHOLD=85
+mutate:
+	@command -v gremlins >/dev/null 2>&1 || go install github.com/go-gremlins/gremlins/cmd/gremlins@latest
+	cd model && gremlins unleash --workers 2 --timeout-coefficient 8 --threshold-efficacy ${MUTATION_THRESHOLD}
+	cd internal/filter && gremlins unleash --workers 2 --timeout-coefficient 8 --threshold-efficacy ${MUTATION_THRESHOLD}
+
 build:
 	go build -o ${PROJECT} ./cmd/*.go
 

--- a/makefile
+++ b/makefile
@@ -32,11 +32,20 @@ test:
 # efficacy (killed/viable mutants) drops below the threshold. Takes ~10 min.
 # Triage survivors by reading the LIVED lines; model/mutation_killers_test.go
 # has examples of boundary tests written to kill them.
-MUTATION_THRESHOLD=85
+# (The threshold is enforced here by parsing the score: gremlins' own
+# --threshold-efficacy flag does not affect its exit code.)
+MUTATION_THRESHOLD=80
 mutate:
 	@command -v gremlins >/dev/null 2>&1 || go install github.com/go-gremlins/gremlins/cmd/gremlins@latest
-	cd model && gremlins unleash --workers 2 --timeout-coefficient 8 --threshold-efficacy ${MUTATION_THRESHOLD}
-	cd internal/filter && gremlins unleash --workers 2 --timeout-coefficient 8 --threshold-efficacy ${MUTATION_THRESHOLD}
+	@for pkg in model internal/filter; do \
+		echo "==> mutation testing $$pkg (threshold ${MUTATION_THRESHOLD}%)"; \
+		log=/tmp/gremlins-$$(basename $$pkg).log; \
+		(cd $$pkg && gremlins unleash --workers 2 --timeout-coefficient 8) | tee $$log; \
+		eff=$$(grep -o 'Test efficacy: [0-9.]*' $$log | grep -o '[0-9.]*'); \
+		awk -v e="$$eff" -v t="${MUTATION_THRESHOLD}" 'BEGIN { exit (e+0 < t+0) ? 1 : 0 }' \
+			|| { echo "MUTATION GATE FAILED: $$pkg efficacy $$eff% is below ${MUTATION_THRESHOLD}% — see LIVED lines in $$log"; exit 1; }; \
+		echo "PASS: $$pkg efficacy $$eff%"; \
+	done
 
 build:
 	go build -o ${PROJECT} ./cmd/*.go

--- a/model/model.go
+++ b/model/model.go
@@ -41,8 +41,7 @@ func Int64ToBigInt(value int64) *big.Int {
 // HashTxn generates a SHA-256 hash of a transaction's relevant fields.
 // This ensures the integrity of the transaction by creating a unique hash from its details.
 func (transaction *Transaction) HashTxn() string {
-	// Concatenate the transaction's fields into a single string.
-	data := fmt.Sprintf("%f%s%s%s%s", transaction.Amount, transaction.Reference, transaction.Currency, transaction.Source, transaction.Destination)
+	data := fmt.Sprintf("%s%s%s%s%s", strconv.FormatFloat(transaction.Amount, 'f', -1, 64), transaction.Reference, transaction.Currency, transaction.Source, transaction.Destination)
 	hash := sha256.Sum256([]byte(data)) // Hash the concatenated data.
 	return hex.EncodeToString(hash[:])  // Return the hex-encoded hash.
 }
@@ -161,8 +160,12 @@ func canProcessTransaction(transaction *Transaction, sourceBalance *Balance) err
 		// Calculate the resulting balance after transaction, considering inflight and queued debits
 		resultingBalance := new(big.Int).Sub(availableBalance, transactionAmount)
 
-		// Convert overdraft limit to big.Int with precision applied
-		overdraftLimitPrecise := int64(transaction.OverdraftLimit * transaction.Precision)
+		// Convert overdraft limit to big.Int with precision applied using
+		// decimal arithmetic: int64(limit*precision) truncates binary-float
+		// products (0.29*100 -> 28), rejecting transactions exactly at the
+		// configured limit.
+		overdraftLimitPrecise := decimal.NewFromFloat(transaction.OverdraftLimit).
+			Mul(decimal.NewFromFloat(transaction.Precision)).Round(0).IntPart()
 		overdraftLimitBigInt := new(big.Int).SetInt64(overdraftLimitPrecise)
 
 		// Negative of overdraft limit (as balance will be negative)
@@ -376,7 +379,10 @@ func convertDecimalToPrecise(transaction *Transaction) *big.Int {
 	amountDec, _ := decimal.NewFromString(amountStr)
 	precisionDec, _ := decimal.NewFromString(precisionStr)
 
-	preciseAmount := amountDec.Mul(precisionDec)
+	// Round to the nearest minor unit: an amount finer than the precision
+	// (e.g. 1.005 at precision 100) would otherwise produce a non-integer
+	// string that big.Int.SetString silently rejects, yielding zero.
+	preciseAmount := amountDec.Mul(precisionDec).Round(0)
 
 	// Convert to big.Int
 	result := new(big.Int)
@@ -392,20 +398,13 @@ func ApplyRate(preciseAmount *big.Int, rate float64) *big.Int {
 		rate = 1
 	}
 
-	// Create a new big.Float from the precise amount
-	preciseAmountFloat := new(big.Float).SetInt(preciseAmount)
-
-	// Create a big.Float for the rate
-	rateFloat := new(big.Float).SetFloat64(rate)
-
-	// Multiply the amount by the rate
-	result := new(big.Float).Mul(preciseAmountFloat, rateFloat)
-
-	// Convert back to big.Int (rounding if necessary)
-	resultBigInt := new(big.Int)
-	result.Int(resultBigInt)
-
-	return resultBigInt
+	// Multiply with decimal arithmetic and round to the nearest minor unit.
+	// The previous big.Float path truncated toward zero, so a rate like
+	// 1.0001 on 10000 units yielded 10000 instead of 10001 — silently
+	// losing a minor unit on every FX leg.
+	amountDec := decimal.NewFromBigInt(preciseAmount, 0)
+	rateDec := decimal.NewFromFloat(rate)
+	return amountDec.Mul(rateDec).Round(0).BigInt()
 }
 
 // validate checks if the transaction is valid (e.g., ensuring positive amount).

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -32,7 +32,9 @@ func TestTransaction_HashTxn(t *testing.T) {
 		Source:      "source_account",
 		Destination: "dest_account",
 	}
-	data := "100.000000ref123USDsource_accountdest_account"
+	// Amount is formatted at full precision (shortest round-trip form), so
+	// amounts differing beyond 6 decimals no longer collide.
+	data := "100ref123USDsource_accountdest_account"
 	expectedHash := sha256.Sum256([]byte(data))
 	expectedHashStr := hex.EncodeToString(expectedHash[:])
 

--- a/model/mutation_killers_test.go
+++ b/model/mutation_killers_test.go
@@ -1,0 +1,160 @@
+package model
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests were written to kill mutants that survived a gremlins run:
+// each one pins an exact comparison boundary in money-handling code where a
+// one-character operator change (> vs >=, <= vs <) previously went unnoticed.
+
+func TestCompare_ExactBoundaries(t *testing.T) {
+	ten := big.NewInt(10)
+	tests := []struct {
+		name      string
+		value     int64
+		condition string
+		want      bool
+	}{
+		// strict > : equal must NOT satisfy
+		{"gt above", 11, ">", true},
+		{"gt equal", 10, ">", false},
+		{"gt below", 9, ">", false},
+		// strict < : equal must NOT satisfy
+		{"lt below", 9, "<", true},
+		{"lt equal", 10, "<", false},
+		{"lt above", 11, "<", false},
+		// >= : equal MUST satisfy
+		{"gte equal", 10, ">=", true},
+		{"gte below", 9, ">=", false},
+		// <= : equal MUST satisfy
+		{"lte equal", 10, "<=", true},
+		{"lte above", 11, "<=", false},
+		// equality operators
+		{"eq equal", 10, "==", true},
+		{"eq differs", 9, "==", false},
+		{"ne differs", 9, "!=", true},
+		{"ne equal", 10, "!=", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, compare(big.NewInt(tt.value), tt.condition, ten))
+		})
+	}
+}
+
+func TestMonitorCheckCondition_FiresOnlyPastThreshold(t *testing.T) {
+	monitor := &BalanceMonitor{
+		Condition: AlertCondition{Field: "balance", Operator: ">", PreciseValue: big.NewInt(1000)},
+	}
+
+	atThreshold := &Balance{Balance: big.NewInt(1000)}
+	pastThreshold := &Balance{Balance: big.NewInt(1001)}
+	atThreshold.InitializeBalanceFields()
+	pastThreshold.InitializeBalanceFields()
+
+	assert.False(t, monitor.CheckCondition(atThreshold), "a strict > monitor must not fire at exactly the threshold")
+	assert.True(t, monitor.CheckCondition(pastThreshold))
+}
+
+func TestCommitInflight_ExactFullAmountSettles(t *testing.T) {
+	txn := &Transaction{Amount: 100, Precision: 100}
+
+	t.Run("debit", func(t *testing.T) {
+		b := &Balance{InflightDebitBalance: big.NewInt(10000)}
+		b.InitializeBalanceFields()
+		b.CommitInflightDebit(txn)
+		assert.Equal(t, "0", b.InflightDebitBalance.String(), "committing exactly the inflight amount must drain it")
+		assert.Equal(t, "10000", b.DebitBalance.String(), "the full amount must land in the committed debit balance")
+	})
+
+	t.Run("credit", func(t *testing.T) {
+		b := &Balance{InflightCreditBalance: big.NewInt(10000)}
+		b.InitializeBalanceFields()
+		b.CommitInflightCredit(txn)
+		assert.Equal(t, "0", b.InflightCreditBalance.String())
+		assert.Equal(t, "10000", b.CreditBalance.String())
+	})
+
+	t.Run("over-commit is a no-op", func(t *testing.T) {
+		over := &Transaction{Amount: 100.01, Precision: 100}
+		b := &Balance{InflightDebitBalance: big.NewInt(10000)}
+		b.InitializeBalanceFields()
+		b.CommitInflightDebit(over)
+		assert.Equal(t, "10000", b.InflightDebitBalance.String(), "committing more than inflight must not move anything")
+		assert.Equal(t, "0", b.DebitBalance.String())
+	})
+}
+
+func TestRollbackInflight_ExactFullAmount(t *testing.T) {
+	t.Run("credit", func(t *testing.T) {
+		b := &Balance{InflightCreditBalance: big.NewInt(500)}
+		b.InitializeBalanceFields()
+		b.RollbackInflightCredit(big.NewInt(500))
+		assert.Equal(t, "0", b.InflightCreditBalance.String(), "rolling back exactly the inflight amount must drain it")
+	})
+
+	t.Run("debit", func(t *testing.T) {
+		b := &Balance{InflightDebitBalance: big.NewInt(500)}
+		b.InitializeBalanceFields()
+		b.RollbackInflightDebit(big.NewInt(500))
+		assert.Equal(t, "0", b.InflightDebitBalance.String())
+	})
+
+	t.Run("over-rollback is a no-op", func(t *testing.T) {
+		b := &Balance{InflightCreditBalance: big.NewInt(500)}
+		b.InitializeBalanceFields()
+		b.RollbackInflightCredit(big.NewInt(501))
+		assert.Equal(t, "500", b.InflightCreditBalance.String())
+	})
+}
+
+func TestApplyPrecision_ZeroPreciseAmountFallsThroughToAmount(t *testing.T) {
+	// A zero PreciseAmount must not be treated as authoritative: the amount
+	// is recomputed from Amount, otherwise a positive transaction would be
+	// recorded as zero minor units.
+	txn := &Transaction{PreciseAmount: big.NewInt(0), Amount: 5, Precision: 100}
+	got := ApplyPrecision(txn)
+	assert.Equal(t, "500", got.String())
+}
+
+func TestValidate_ZeroAmountRejected(t *testing.T) {
+	txn := &Transaction{Amount: 0, PreciseAmount: nil}
+	err := txn.validate()
+	require.Error(t, err, "a zero amount with no precise amount must be rejected, not just negative ones")
+
+	positive := &Transaction{Amount: 0.01}
+	assert.NoError(t, positive.validate())
+}
+
+func TestSplit_ExactlyHundredPercentAllowed(t *testing.T) {
+	txn := &Transaction{
+		Amount:        100,
+		Precision:     100,
+		PreciseAmount: big.NewInt(10000),
+		Sources: []Distribution{
+			{Identifier: "a", Distribution: "60%"},
+			{Identifier: "b", Distribution: "40%"},
+		},
+	}
+	_, err := txn.SplitTransactionPrecise(context.Background())
+	require.NoError(t, err, "distributions summing to exactly 100%% must be accepted")
+}
+
+func TestSplit_FixedAmountEqualToRemainingAllowed(t *testing.T) {
+	txn := &Transaction{
+		Amount:        100,
+		Precision:     100,
+		PreciseAmount: big.NewInt(10000),
+		Sources: []Distribution{
+			{Identifier: "a", Distribution: "100"},
+		},
+	}
+	_, err := txn.SplitTransactionPrecise(context.Background())
+	require.NoError(t, err, "a fixed distribution exactly equal to the full amount must be accepted")
+}

--- a/reconciliation.go
+++ b/reconciliation.go
@@ -773,6 +773,18 @@ func (s *Blnk) manyToOne(ctx context.Context, internalTxns []*model.Transaction,
 	ctx, span := otel.Tracer("blnk.reconciliation").Start(ctx, "ProcessManyToOne")
 	defer span.End()
 
+	processedAny := false
+	// Every input transaction must end up matched or unmatched; if the loop
+	// exits before any group batch was processed, report them all unmatched
+	// instead of silently dropping them from the reconciliation results.
+	defer func() {
+		if !processedAny {
+			for _, txn := range internalTxns {
+				unMatchChan <- txn.TransactionID
+			}
+		}
+	}()
+
 	// Loop to process transactions in batches.
 	for {
 		groupedExternalTxns, err := s.groupExternalTransactions(ctx, uploadID, groupingCriteria, batchSize, offset)
@@ -784,6 +796,7 @@ func (s *Blnk) manyToOne(ctx context.Context, internalTxns []*model.Transaction,
 			span.AddEvent("No more grouped transactions to process")
 			break
 		}
+		processedAny = true
 		groupMap := s.buildGroupMap(groupedExternalTxns)
 		err = s.processGroupedTransactions(internalTxns, groupedExternalTxns, groupMap, matchingRules, isExternalGrouped, wg, matchChan, unMatchChan)
 		if err != nil {
@@ -899,6 +912,17 @@ func (s *Blnk) oneToMany(ctx context.Context, singleTxn []*model.Transaction, ma
 	ctx, span := otel.Tracer("blnk.reconciliation").Start(ctx, "ProcessOneToMany")
 	defer span.End()
 
+	processedAny := false
+	// Mirror manyToOne: inputs must never silently vanish when no group
+	// batch was processed.
+	defer func() {
+		if !processedAny {
+			for _, txn := range singleTxn {
+				unMatchChan <- txn.TransactionID
+			}
+		}
+	}()
+
 	for {
 		txns, err := s.groupInternalTransactions(ctx, groupingCriteria, batchSize, offset)
 		if err != nil {
@@ -909,6 +933,7 @@ func (s *Blnk) oneToMany(ctx context.Context, singleTxn []*model.Transaction, ma
 			span.AddEvent("No more grouped transactions to process")
 			break
 		}
+		processedAny = true
 		groupMap := s.buildGroupMap(txns)
 		err = s.processGroupedTransactions(singleTxn, txns, groupMap, matchingRules, isExternalGrouped, wg, matchChan, unMatchChan)
 		if err != nil {
@@ -1279,8 +1304,10 @@ func (s *Blnk) validateDrift(criteria model.MatchingCriteria) error {
 	if criteria.Operator == "equals" {
 		switch criteria.Field {
 		case "amount":
-			if criteria.AllowableDrift < 0 || criteria.AllowableDrift > 100 {
-				return errors.New("drift for amount must be between 0 and 100 (percentage)")
+			// Amount drift is a fraction of the amount: 0.01 allows 1%
+			// deviation, 1 allows 100%.
+			if criteria.AllowableDrift < 0 || criteria.AllowableDrift > 1 {
+				return errors.New("drift for amount must be between 0 and 1 (fraction, e.g. 0.01 = 1%)")
 			}
 		case "date":
 			if criteria.AllowableDrift < 0 {
@@ -1384,7 +1411,7 @@ func (s *Blnk) matchesCurrency(externalValue, internalValue string, criteria mod
 func (s *Blnk) matchesGroupAmount(externalAmount, groupAmount float64, criteria model.MatchingCriteria) bool {
 	switch criteria.Operator {
 	case "equals":
-		allowableDrift := groupAmount * criteria.AllowableDrift
+		allowableDrift := math.Abs(groupAmount) * criteria.AllowableDrift
 		return math.Abs(externalAmount-groupAmount) <= allowableDrift
 	case "greater_than":
 		return externalAmount > groupAmount
@@ -1404,10 +1431,10 @@ func (s *Blnk) matchesGroupDate(externalDate, groupEarliestDate time.Time, crite
 	switch criteria.Operator {
 	case "equals":
 		difference := externalDate.Sub(groupEarliestDate)
-		return math.Abs(float64(difference/time.Second)) <= criteria.AllowableDrift
-	case "after":
+		return math.Abs(difference.Seconds()) <= criteria.AllowableDrift
+	case "after", "greater_than":
 		return externalDate.After(groupEarliestDate)
-	case "before":
+	case "before", "less_than":
 		return externalDate.Before(groupEarliestDate)
 	}
 	return false
@@ -1434,9 +1461,9 @@ func (s *Blnk) calculateMatchingBounds(externalTxn *model.Transaction, matchingR
 	for _, rule := range matchingRules {
 		for _, criteria := range rule.Criteria {
 			if criteria.Field == "amount" && criteria.Operator == "equals" {
-				drift := criteria.AllowableDrift // percentage
+				drift := criteria.AllowableDrift // fraction: 0.01 = 1%
 				amt := externalTxn.Amount
-				delta := amt * (drift / 100.0)
+				delta := math.Abs(amt) * drift
 				low := amt - delta
 				high := amt + delta
 

--- a/reconciliation_matching_test.go
+++ b/reconciliation_matching_test.go
@@ -36,10 +36,9 @@ var reconBaseTime = time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
 func TestRecon_MatchesGroupAmount_EqualsBoundaries(t *testing.T) {
 	b := &Blnk{}
 
-	// NOTE: matchesGroupAmount currently treats AllowableDrift as a FRACTION of the
-	// internal amount (0.25 => 25%). These cases pin the exact <= boundary under
-	// that interpretation; the unit inconsistency with validateDrift and
-	// calculateMatchingBounds is covered by TestRecon_SuspectedBug_AmountDriftUnitsInconsistent.
+	// AllowableDrift is a FRACTION of the internal amount (0.25 => 25%); the
+	// validator and SQL prefilter use the same unit. These cases pin the
+	// exact <= boundary.
 	tests := []struct {
 		name     string
 		external float64
@@ -90,20 +89,28 @@ func TestRecon_MatchesGroupAmount_UnknownOperatorNeverMatches(t *testing.T) {
 	assert.False(t, b.matchesGroupAmount(100, 100, model.MatchingCriteria{Field: "amount", Operator: "bogus"}))
 }
 
-func TestRecon_SuspectedBug_AmountDriftUnitsInconsistent(t *testing.T) {
-	t.Skip("SUSPECTED BUG: drift units are inconsistent. validateDrift (reconciliation.go:1282) validates amount drift as a PERCENTAGE in [0,100] and calculateMatchingBounds (reconciliation.go:1439) computes query bounds as amt*(drift/100), but matchesGroupAmount (reconciliation.go:1387) computes allowableDrift = groupAmount*AllowableDrift, i.e. treats it as a FRACTION. A validated rule with drift=1 (1%) therefore tolerates a 100% amount deviation in the matcher, while the SQL prefilter only fetches candidates within 1% — the matcher and the prefilter disagree by a factor of 100. Pick one unit (percentage) and apply it in both places.")
+func TestRecon_AmountDriftFractionSemantics(t *testing.T) {
+	// Regression: drift units used to disagree — the validator/SQL prefilter
+	// treated AllowableDrift as a percentage while the matcher treated it as
+	// a fraction, a 100x mismatch. The canonical unit is now a FRACTION
+	// (0.01 = 1%) in all three places.
 	b := &Blnk{}
-	criteria := model.MatchingCriteria{Field: "amount", Operator: "equals", AllowableDrift: 1} // 1% under validated semantics
+	criteria := model.MatchingCriteria{Field: "amount", Operator: "equals", AllowableDrift: 0.01} // 1%
 	assert.False(t, b.matchesGroupAmount(150, 100, criteria), "a 50%% deviation must not satisfy a 1%% drift rule")
 	assert.True(t, b.matchesGroupAmount(100.5, 100, criteria), "a 0.5%% deviation must satisfy a 1%% drift rule")
+	assert.True(t, b.matchesGroupAmount(101, 100, criteria), "exactly 1%% deviation must satisfy a 1%% drift rule")
+	assert.False(t, b.matchesGroupAmount(101.001, 100, criteria), "just past 1%% must not match")
 }
 
-func TestRecon_SuspectedBug_NegativeAmountsNeverMatch(t *testing.T) {
-	t.Skip("SUSPECTED BUG: matchesGroupAmount (reconciliation.go:1387) computes allowableDrift = groupAmount*AllowableDrift without taking the absolute value. For negative internal amounts (refunds, debits) the allowable drift is negative, so math.Abs(diff) <= allowableDrift is false even when the amounts are identical — negative-amount transactions can never be reconciled with a non-zero drift. Use math.Abs(groupAmount).")
+func TestRecon_NegativeAmountsMatchWithinDrift(t *testing.T) {
+	// Regression: the matcher used to compute groupAmount*AllowableDrift
+	// without abs(), so negative internal amounts (refunds, debits) produced
+	// a negative tolerance and could never reconcile.
 	b := &Blnk{}
 	criteria := model.MatchingCriteria{Field: "amount", Operator: "equals", AllowableDrift: 0.01}
 	assert.True(t, b.matchesGroupAmount(-100, -100, criteria), "identical negative amounts must match")
 	assert.True(t, b.matchesGroupAmount(-100.5, -100, criteria), "negative amounts within drift must match")
+	assert.False(t, b.matchesGroupAmount(-150, -100, criteria), "negative amounts past drift must not match")
 }
 
 // --- date matching ---
@@ -151,8 +158,9 @@ func TestRecon_MatchesGroupDate_AfterBefore(t *testing.T) {
 	assert.False(t, b.matchesGroupDate(reconBaseTime, reconBaseTime, model.MatchingCriteria{Field: "date", Operator: "bogus"}))
 }
 
-func TestRecon_SuspectedBug_DateDriftTruncatesSubSecond(t *testing.T) {
-	t.Skip("SUSPECTED BUG: matchesGroupDate (reconciliation.go:1407) computes math.Abs(float64(difference/time.Second)), an INTEGER division that truncates the sub-second remainder before comparison. A 60.9s difference passes a 60s drift rule and a 0.99s difference passes a 0s (exact-match) rule. Use difference.Seconds() to compare fractional seconds.")
+func TestRecon_DateDriftComparesFractionalSeconds(t *testing.T) {
+	// Regression: integer Duration division used to truncate the sub-second
+	// remainder, so a 60.9s difference passed a 60s drift rule.
 	b := &Blnk{}
 
 	drift60 := model.MatchingCriteria{Field: "date", Operator: "equals", AllowableDrift: 60}
@@ -164,8 +172,11 @@ func TestRecon_SuspectedBug_DateDriftTruncatesSubSecond(t *testing.T) {
 		"0.99s difference must not satisfy an exact (0s drift) rule")
 }
 
-func TestRecon_SuspectedBug_DateOperatorsUnreachable(t *testing.T) {
-	t.Skip("SUSPECTED BUG: operator sets disagree. validateOperator (reconciliation.go:1254) accepts equals/greater_than/less_than/contains, but matchesGroupDate (reconciliation.go:1403) implements equals/after/before. A validated date rule using greater_than or less_than always evaluates to false (silently failing every comparison), while after/before rules can never be created through the validated API. Align the two operator sets.")
+func TestRecon_DateOperatorsAlignedWithValidation(t *testing.T) {
+	// Regression: the validator accepts greater_than/less_than but the
+	// matcher only implemented after/before, so every validated date
+	// comparison rule silently evaluated to false. greater_than/less_than
+	// now alias after/before.
 	b := &Blnk{}
 
 	// greater_than is accepted by validation for the date field...
@@ -369,9 +380,9 @@ func TestRecon_CalculateMatchingBounds(t *testing.T) {
 		assert.Equal(t, "USD", *currency)
 	})
 
-	t.Run("amount equals drift is a percentage of the external amount", func(t *testing.T) {
+	t.Run("amount equals drift is a fraction of the external amount", func(t *testing.T) {
 		minA, maxA, _, _, _ := b.calculateMatchingBounds(external, []model.MatchingRule{
-			rule(model.MatchingCriteria{Field: "amount", Operator: "equals", AllowableDrift: 10}),
+			rule(model.MatchingCriteria{Field: "amount", Operator: "equals", AllowableDrift: 0.1}),
 		})
 		require.NotNil(t, minA)
 		require.NotNil(t, maxA)
@@ -391,8 +402,8 @@ func TestRecon_CalculateMatchingBounds(t *testing.T) {
 
 	t.Run("multiple rules take the widest amount range", func(t *testing.T) {
 		minA, maxA, _, _, _ := b.calculateMatchingBounds(external, []model.MatchingRule{
-			rule(model.MatchingCriteria{Field: "amount", Operator: "equals", AllowableDrift: 10}),
-			rule(model.MatchingCriteria{Field: "amount", Operator: "equals", AllowableDrift: 50}),
+			rule(model.MatchingCriteria{Field: "amount", Operator: "equals", AllowableDrift: 0.1}),
+			rule(model.MatchingCriteria{Field: "amount", Operator: "equals", AllowableDrift: 0.5}),
 		})
 		require.NotNil(t, minA)
 		require.NotNil(t, maxA)
@@ -608,8 +619,11 @@ func TestRecon_MatchSingleTransaction_ConsumesGroupAndOrientsIDs(t *testing.T) {
 	})
 }
 
-func TestRecon_SuspectedBug_OneToManyDropsTxnsWhenNoGroupsExist(t *testing.T) {
-	t.Skip("SUSPECTED BUG: oneToMany (reconciliation.go:897) and manyToOne (reconciliation.go:771) break out of the pagination loop when grouping returns zero groups (or when the grouping query errors -- the error is logged and swallowed, returning nil). In that case processGroupedTransactions is never invoked, so the input transactions are neither matched nor reported as unmatched: they silently vanish from the reconciliation results and the run completes as 0 matched / 0 unmatched. Financially, every unprocessed transaction must be reported unmatched (or the run must fail). The existing test 'One-to-many with no matching group' even says 'Expected 1 unmatched transaction' in its assertion message while asserting 0.")
+func TestRecon_OneToManyReportsUnmatchedWhenNoGroupsExist(t *testing.T) {
+	// Regression: oneToMany/manyToOne used to break out of the pagination
+	// loop when grouping returned zero groups, so the input transactions
+	// were neither matched nor reported unmatched — they silently vanished
+	// from the reconciliation results.
 	storeReconEngineConfig()
 	mockDS := new(mocks.MockDataSource)
 	b := &Blnk{datasource: mockDS}

--- a/reconciliation_rules_test.go
+++ b/reconciliation_rules_test.go
@@ -130,13 +130,13 @@ func TestRecon_ValidateDrift(t *testing.T) {
 		criteria model.MatchingCriteria
 		wantErr  string
 	}{
-		// amount + equals: drift is a percentage, bounded [0, 100]
+		// amount + equals: drift is a fraction, bounded [0, 1] (0.01 = 1%)
 		{"amount drift 0 (boundary low)", model.MatchingCriteria{Field: "amount", Operator: "equals", AllowableDrift: 0}, ""},
-		{"amount drift 100 (boundary high)", model.MatchingCriteria{Field: "amount", Operator: "equals", AllowableDrift: 100}, ""},
-		{"amount drift 50 (interior)", model.MatchingCriteria{Field: "amount", Operator: "equals", AllowableDrift: 50}, ""},
-		{"amount drift just below 0", model.MatchingCriteria{Field: "amount", Operator: "equals", AllowableDrift: -0.000001}, "drift for amount must be between 0 and 100 (percentage)"},
-		{"amount drift just above 100", model.MatchingCriteria{Field: "amount", Operator: "equals", AllowableDrift: 100.000001}, "drift for amount must be between 0 and 100 (percentage)"},
-		{"amount drift -1", model.MatchingCriteria{Field: "amount", Operator: "equals", AllowableDrift: -1}, "drift for amount must be between 0 and 100 (percentage)"},
+		{"amount drift 1 (boundary high)", model.MatchingCriteria{Field: "amount", Operator: "equals", AllowableDrift: 1}, ""},
+		{"amount drift 0.5 (interior)", model.MatchingCriteria{Field: "amount", Operator: "equals", AllowableDrift: 0.5}, ""},
+		{"amount drift just below 0", model.MatchingCriteria{Field: "amount", Operator: "equals", AllowableDrift: -0.000001}, "drift for amount must be between 0 and 1 (fraction, e.g. 0.01 = 1%)"},
+		{"amount drift just above 1", model.MatchingCriteria{Field: "amount", Operator: "equals", AllowableDrift: 1.000001}, "drift for amount must be between 0 and 1 (fraction, e.g. 0.01 = 1%)"},
+		{"amount drift -1", model.MatchingCriteria{Field: "amount", Operator: "equals", AllowableDrift: -1}, "drift for amount must be between 0 and 1 (fraction, e.g. 0.01 = 1%)"},
 
 		// date + equals: drift is seconds, must be non-negative, unbounded above
 		{"date drift 0 (boundary)", model.MatchingCriteria{Field: "date", Operator: "equals", AllowableDrift: 0}, ""},

--- a/reconciliation_test.go
+++ b/reconciliation_test.go
@@ -201,10 +201,15 @@ func TestManyToOneReconciliationUsesUploadID(t *testing.T) {
 func TestMatchingRules(t *testing.T) {
 	blnk := &Blnk{}
 
+	// A single captured timestamp keeps the date-drift case exactly at the
+	// 3600s boundary; two time.Now() calls would add nanoseconds and
+	// (correctly) fail the fractional-seconds comparison.
+	now := time.Now()
+
 	externalTxn := &model.Transaction{
 		TransactionID: "ext1",
 		Amount:        100,
-		CreatedAt:     time.Now(),
+		CreatedAt:     now,
 		Description:   "Test transaction",
 		Reference:     "REF123",
 		Currency:      "USD",
@@ -213,7 +218,7 @@ func TestMatchingRules(t *testing.T) {
 	internalTxn := model.Transaction{
 		TransactionID: "int1",
 		Amount:        101,
-		CreatedAt:     time.Now().Add(1 * time.Hour),
+		CreatedAt:     now.Add(1 * time.Hour),
 		Description:   "Internal test transaction",
 		Reference:     "INT-REF123",
 		Currency:      "USD",
@@ -418,7 +423,9 @@ func TestReconciliationEdgeCases(t *testing.T) {
 		matches, unmatched := blnk.oneToManyReconciliation(ctx, externalTxns, "", matchingRules, false)
 
 		assert.Equal(t, 0, len(matches), "Expected 0 matches")
-		assert.Equal(t, 0, len(unmatched), "Expected 1 unmatched transaction")
+		// Inputs that never get a group batch must be reported unmatched,
+		// not silently dropped from the reconciliation results.
+		assert.Equal(t, 1, len(unmatched), "Expected 1 unmatched transaction")
 
 		mockDS.AssertExpectations(t)
 	})

--- a/transaction_core_coverage_test.go
+++ b/transaction_core_coverage_test.go
@@ -1,0 +1,360 @@
+/*
+Copyright 2024 Blnk Finance Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package blnk
+
+import (
+	"context"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/blnkfinance/blnk/config"
+	"github.com/blnkfinance/blnk/database"
+	"github.com/blnkfinance/blnk/model"
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newCoreTestBlnk builds a Blnk instance against the real local Postgres and
+// Redis, mirroring the integration setup used in transaction_test.go.
+func newCoreTestBlnk(t *testing.T) (*Blnk, database.IDataSource) {
+	t.Helper()
+
+	cnf := &config.Configuration{
+		Redis: config.RedisConfig{Dns: "localhost:6379"},
+		DataSource: config.DataSourceConfig{
+			Dns: "postgres://postgres:@localhost:5432/blnk?sslmode=disable",
+		},
+		Queue: config.QueueConfig{
+			WebhookQueue:     "webhook_queue_core_cov",
+			IndexQueue:       "index_queue_core_cov",
+			TransactionQueue: "transaction_queue_core_cov",
+			NumberOfQueues:   1,
+		},
+		Transaction: config.TransactionConfig{
+			BatchSize:    100,
+			MaxQueueSize: 1000,
+			MaxWorkers:   2,
+			LockDuration: 30 * time.Second,
+		},
+	}
+	config.ConfigStore.Store(cnf)
+
+	ds, err := database.NewDataSource(cnf)
+	require.NoError(t, err, "failed to create datasource")
+	b, err := NewBlnk(ds)
+	require.NoError(t, err, "failed to create blnk instance")
+	return b, ds
+}
+
+// fundedPair creates two USD balances and returns them. allowOverdraft on the
+// recorded transactions funds the source implicitly where needed.
+func newBalancePair(t *testing.T, ds database.IDataSource) (*model.Balance, *model.Balance) {
+	t.Helper()
+	src, err := ds.CreateBalance(model.Balance{Currency: "USD", LedgerID: "general_ledger_id"})
+	require.NoError(t, err)
+	dst, err := ds.CreateBalance(model.Balance{Currency: "USD", LedgerID: "general_ledger_id"})
+	require.NoError(t, err)
+	return &src, &dst
+}
+
+func recordAppliedTxn(t *testing.T, b *Blnk, src, dst string, amount float64) *model.Transaction {
+	t.Helper()
+	draft := &model.Transaction{
+		TransactionID:  model.GenerateUUIDWithSuffix("txn"),
+		Reference:      "ref_" + gofakeit.UUID(),
+		Source:         src,
+		Destination:    dst,
+		Amount:         amount,
+		Precision:      100,
+		Currency:       "USD",
+		AllowOverdraft: true,
+		SkipQueue:      true,
+		Status:         StatusApplied,
+	}
+	// Direct RecordTransaction (unlike the queue flow) neither assigns a
+	// TransactionID nor applies precision twice: the ID must be preset, and
+	// priming PreciseAmount makes the in-flow ApplyPrecision take the
+	// precise->decimal branch that fills AmountString.
+	model.ApplyPrecision(draft)
+	txn, err := b.RecordTransaction(context.Background(), draft)
+	require.NoError(t, err)
+	require.Equal(t, StatusApplied, txn.Status)
+	return txn
+}
+
+// --- refunds -----------------------------------------------------------------
+
+func TestRefundTransaction_RestoresSourceBalance(t *testing.T) {
+	b, ds := newCoreTestBlnk(t)
+	src, dst := newBalancePair(t, ds)
+
+	txn := recordAppliedTxn(t, b, src.BalanceID, dst.BalanceID, 100)
+
+	refund, err := b.RefundTransaction(context.Background(), txn.TransactionID, true)
+	require.NoError(t, err)
+	assert.Equal(t, txn.TransactionID, refund.ParentTransaction, "refund must reference the original")
+	assert.Equal(t, StatusApplied, refund.Status)
+
+	// Money conservation: after refund the source must be back to zero and
+	// the destination back to zero — verify actual numbers, not statuses.
+	srcAfter, err := ds.GetBalanceByIDLite(src.BalanceID)
+	require.NoError(t, err)
+	dstAfter, err := ds.GetBalanceByIDLite(dst.BalanceID)
+	require.NoError(t, err)
+	assert.Equal(t, "0", srcAfter.Balance.String(), "source balance must be restored after refund")
+	assert.Equal(t, "0", dstAfter.Balance.String(), "destination balance must be drained after refund")
+}
+
+func TestRefundTransaction_NonexistentFails(t *testing.T) {
+	b, _ := newCoreTestBlnk(t)
+	_, err := b.RefundTransaction(context.Background(), "txn_does_not_exist_"+gofakeit.UUID(), true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestRefundTransaction_DoubleRefund(t *testing.T) {
+	b, ds := newCoreTestBlnk(t)
+	src, dst := newBalancePair(t, ds)
+	txn := recordAppliedTxn(t, b, src.BalanceID, dst.BalanceID, 50)
+
+	_, err := b.RefundTransaction(context.Background(), txn.TransactionID, true)
+	require.NoError(t, err)
+
+	// A second refund of the same transaction must not move money again.
+	_, err = b.RefundTransaction(context.Background(), txn.TransactionID, true)
+	require.Error(t, err, "double refund must be rejected")
+
+	srcAfter, err := ds.GetBalanceByIDLite(src.BalanceID)
+	require.NoError(t, err)
+	assert.Equal(t, "0", srcAfter.Balance.String(),
+		"source must hold exactly the original amount after one refund; a double refund must not double-credit")
+}
+
+func TestRefundTransaction_RejectedTransactionFails(t *testing.T) {
+	b, ds := newCoreTestBlnk(t)
+	src, dst := newBalancePair(t, ds)
+
+	rejected, err := b.RecordTransaction(context.Background(), &model.Transaction{
+		TransactionID: model.GenerateUUIDWithSuffix("txn"),
+		Reference:     "ref_" + gofakeit.UUID(),
+		Source:        src.BalanceID,
+		Destination:   dst.BalanceID,
+		Amount:        10,
+		Precision:     100,
+		Currency:      "USD",
+		SkipQueue:     true,
+	})
+	// Without overdraft and with a zero source balance this is rejected.
+	if err == nil {
+		t.Skipf("expected insufficient-funds rejection, got status %s", rejected.Status)
+	}
+
+	// Record a rejection row explicitly and try to refund it.
+	queued := &model.Transaction{
+		TransactionID: model.GenerateUUIDWithSuffix("txn"),
+		Reference:     "ref_" + gofakeit.UUID(),
+		Source:        src.BalanceID,
+		Destination:   dst.BalanceID,
+		Amount:        10,
+		Precision:     100,
+		Currency:      "USD",
+		CreatedAt:     time.Now(),
+	}
+	// Two passes: the first fills PreciseAmount, the second takes the
+	// precise->decimal branch that fills AmountString (RejectTransaction
+	// persists directly without the queue flow's metadata preparation).
+	model.ApplyPrecision(queued)
+	model.ApplyPrecision(queued)
+	rej, err := b.RejectTransaction(context.Background(), queued, "insufficient funds")
+	require.NoError(t, err)
+
+	_, err = b.RefundTransaction(context.Background(), rej.TransactionID, true)
+	require.Error(t, err, "refunding a REJECTED transaction must fail")
+}
+
+// --- inflight void / commit balance integrity ---------------------------------
+
+func TestVoidInflight_ReleasesInflightBalance(t *testing.T) {
+	b, ds := newCoreTestBlnk(t)
+	src, dst := newBalancePair(t, ds)
+
+	inflightDraft := &model.Transaction{
+		TransactionID:  model.GenerateUUIDWithSuffix("txn"),
+		Reference:      "ref_" + gofakeit.UUID(),
+		Source:         src.BalanceID,
+		Destination:    dst.BalanceID,
+		Amount:         75,
+		Precision:      100,
+		Currency:       "USD",
+		AllowOverdraft: true,
+		SkipQueue:      true,
+		Inflight:       true,
+		Status:         StatusInflight,
+	}
+	model.ApplyPrecision(inflightDraft)
+	inflight, err := b.RecordTransaction(context.Background(), inflightDraft)
+	require.NoError(t, err)
+	require.Equal(t, StatusInflight, inflight.Status)
+
+	voided, err := b.VoidInflightTransaction(context.Background(), inflight.TransactionID)
+	require.NoError(t, err)
+	assert.Equal(t, StatusVoid, voided.Status)
+
+	srcAfter, err := ds.GetBalanceByIDLite(src.BalanceID)
+	require.NoError(t, err)
+	assert.Equal(t, "0", srcAfter.InflightDebitBalance.String(), "void must release the inflight debit")
+	assert.Equal(t, "0", srcAfter.Balance.String(), "void must not touch the committed balance")
+}
+
+func TestCommitInflight_PartialOverCommitRejected(t *testing.T) {
+	b, ds := newCoreTestBlnk(t)
+	src, dst := newBalancePair(t, ds)
+
+	commitDraft := &model.Transaction{
+		TransactionID:  model.GenerateUUIDWithSuffix("txn"),
+		Reference:      "ref_" + gofakeit.UUID(),
+		Source:         src.BalanceID,
+		Destination:    dst.BalanceID,
+		Amount:         100,
+		Precision:      100,
+		Currency:       "USD",
+		AllowOverdraft: true,
+		SkipQueue:      true,
+		Inflight:       true,
+		Status:         StatusInflight,
+	}
+	model.ApplyPrecision(commitDraft)
+	inflight, err := b.RecordTransaction(context.Background(), commitDraft)
+	require.NoError(t, err)
+
+	// Committing more than the inflight amount must fail.
+	_, err = b.CommitInflightTransaction(context.Background(), inflight.TransactionID, big.NewInt(20000))
+	require.Error(t, err, "over-commit beyond the original amount must be rejected")
+
+	// Commit exactly half, then the rest; a further commit must fail.
+	_, err = b.CommitInflightTransaction(context.Background(), inflight.TransactionID, big.NewInt(5000))
+	require.NoError(t, err)
+	_, err = b.CommitInflightTransaction(context.Background(), inflight.TransactionID, big.NewInt(5000))
+	require.NoError(t, err)
+	_, err = b.CommitInflightTransaction(context.Background(), inflight.TransactionID, big.NewInt(1))
+	require.Error(t, err, "commit after the full amount is settled must be rejected")
+}
+
+// --- bulk rollback paths -------------------------------------------------------
+
+func TestRollbackBatch_RefundsNonInflightBatch(t *testing.T) {
+	b, ds := newCoreTestBlnk(t)
+	src, dst := newBalancePair(t, ds)
+	batchID := model.GenerateUUIDWithSuffix("bulk")
+
+	txns := []*model.Transaction{
+		{Reference: "ref_" + gofakeit.UUID(), Source: src.BalanceID, Destination: dst.BalanceID, Amount: 40, Precision: 100, Currency: "USD", AllowOverdraft: true},
+		{Reference: "ref_" + gofakeit.UUID(), Source: src.BalanceID, Destination: dst.BalanceID, Amount: 60, Precision: 100, Currency: "USD", AllowOverdraft: true},
+	}
+	require.NoError(t, b.processBulkTransactions(context.Background(), txns, batchID, false, true))
+
+	action, err := b.rollbackBatchTransactions(context.Background(), batchID, false)
+	require.NoError(t, err)
+	assert.Equal(t, "refunded", action)
+
+	// Batch refunds are enqueued (SkipQueue is not persisted, so the worker
+	// path settles them). Every original transaction must gain a queued
+	// refund child with source/destination swapped; the queued row is
+	// persisted asynchronously, so poll briefly.
+	for _, original := range txns {
+		var children []*model.Transaction
+		deadline := time.Now().Add(10 * time.Second)
+		for {
+			var err error
+			children, err = ds.GetTransactionsByParent(context.Background(), original.TransactionID, 10, 0)
+			require.NoError(t, err)
+			if len(children) > 0 || time.Now().After(deadline) {
+				break
+			}
+			time.Sleep(200 * time.Millisecond)
+		}
+		require.Len(t, children, 1, "each batch transaction must get exactly one refund child")
+		refund := children[0]
+		assert.Equal(t, StatusQueued, refund.Status, "rollback refunds are queued for the worker")
+		assert.Equal(t, original.Destination, refund.Source, "refund must swap source and destination")
+		assert.Equal(t, original.Source, refund.Destination, "refund must swap source and destination")
+	}
+}
+
+func TestRollbackBatch_VoidsInflightBatch(t *testing.T) {
+	b, ds := newCoreTestBlnk(t)
+	src, dst := newBalancePair(t, ds)
+	batchID := model.GenerateUUIDWithSuffix("bulk")
+
+	txns := []*model.Transaction{
+		{Reference: "ref_" + gofakeit.UUID(), Source: src.BalanceID, Destination: dst.BalanceID, Amount: 25, Precision: 100, Currency: "USD", AllowOverdraft: true},
+		{Reference: "ref_" + gofakeit.UUID(), Source: src.BalanceID, Destination: dst.BalanceID, Amount: 35, Precision: 100, Currency: "USD", AllowOverdraft: true},
+	}
+	require.NoError(t, b.processBulkTransactions(context.Background(), txns, batchID, true, true))
+
+	action, err := b.rollbackBatchTransactions(context.Background(), batchID, true)
+	require.NoError(t, err)
+	assert.Equal(t, "voided", action)
+
+	srcAfter, err := ds.GetBalanceByIDLite(src.BalanceID)
+	require.NoError(t, err)
+	assert.Equal(t, "0", srcAfter.InflightDebitBalance.String(), "all inflight debits must be released by the void rollback")
+	assert.Equal(t, "0", srcAfter.Balance.String(), "committed balance must be untouched by an inflight batch rollback")
+}
+
+// --- queued execution path -----------------------------------------------------
+
+func TestProcessQueuedTransaction_AppliesAndIsIdempotent(t *testing.T) {
+	b, ds := newCoreTestBlnk(t)
+	src, dst := newBalancePair(t, ds)
+
+	ref := "ref_" + gofakeit.UUID()
+	queueCopy := &model.Transaction{
+		TransactionID:  model.GenerateUUIDWithSuffix("txn"),
+		Reference:      ref,
+		Source:         src.BalanceID,
+		Destination:    dst.BalanceID,
+		Amount:         80,
+		Precision:      100,
+		Currency:       "USD",
+		AllowOverdraft: true,
+		Status:         StatusQueued,
+		CreatedAt:      time.Now(),
+	}
+	model.ApplyPrecision(queueCopy)
+
+	applied, err := b.ProcessQueuedTransaction(context.Background(), queueCopy, false)
+	require.NoError(t, err)
+	assert.Equal(t, StatusApplied, applied.Status)
+
+	dstAfter, err := ds.GetBalanceByIDLite(dst.BalanceID)
+	require.NoError(t, err)
+	assert.Equal(t, "8000", dstAfter.Balance.String())
+
+	// Replaying the same queue copy (same reference) must not double-apply.
+	replay := *queueCopy
+	replay.TransactionID = model.GenerateUUIDWithSuffix("txn")
+	_, err = b.ProcessQueuedTransaction(context.Background(), &replay, false)
+	require.Error(t, err, "replaying the same reference must be rejected")
+	assert.True(t, IsDuplicateReferenceError(err), "replay rejection must be a duplicate-reference error, got: %v", err)
+
+	dstFinal, err := ds.GetBalanceByIDLite(dst.BalanceID)
+	require.NoError(t, err)
+	assert.Equal(t, "8000", dstFinal.Balance.String(), "balance must be unchanged after a duplicate replay")
+}

--- a/webhooks.go
+++ b/webhooks.go
@@ -86,13 +86,6 @@ func processHTTP(data NewWebhook, client *http.Client) error {
 
 	secret := conf.Server.SecretKey
 
-	timestamp := strconv.FormatInt(time.Now().Unix(), 10)
-
-	signatureData := timestamp + "." + string(payloadBytes)
-	mac := hmac.New(sha256.New, []byte(secret))
-	mac.Write([]byte(signatureData))
-	signature := hex.EncodeToString(mac.Sum(nil))
-
 	req, err := http.NewRequest(
 		"POST",
 		conf.Notification.Webhook.Url,
@@ -103,8 +96,18 @@ func processHTTP(data NewWebhook, client *http.Client) error {
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-Blnk-Signature", signature)
-	req.Header.Set("X-Blnk-Timestamp", timestamp)
+
+	if secret != "" {
+		timestamp := strconv.FormatInt(time.Now().Unix(), 10)
+		signatureData := timestamp + "." + string(payloadBytes)
+		mac := hmac.New(sha256.New, []byte(secret))
+		mac.Write([]byte(signatureData))
+		signature := hex.EncodeToString(mac.Sum(nil))
+		req.Header.Set("X-Blnk-Signature", signature)
+		req.Header.Set("X-Blnk-Timestamp", timestamp)
+	} else {
+		logrus.Warn("webhook sent unsigned: server.secret_key is not configured")
+	}
 
 	for key, value := range conf.Notification.Webhook.Headers {
 		req.Header.Set(key, value)

--- a/webhooks_process_test.go
+++ b/webhooks_process_test.go
@@ -314,10 +314,11 @@ func TestSendWebhook_UnmarshalablePayloadReturnsError(t *testing.T) {
 	}
 }
 
-func TestProcessWebhook_SignaturePresentEvenWithEmptySecret(t *testing.T) {
-	// An empty Server.SecretKey still produces a deterministic HMAC over a
-	// well-known (empty) key, which any third party can forge. The headers are
-	// still sent; receivers must not treat them as authentication in that case.
+func TestProcessWebhook_NoSignatureHeadersWithEmptySecret(t *testing.T) {
+	// Regression: an empty Server.SecretKey used to produce an HMAC over the
+	// empty key — computable (and forgeable) by anyone. The delivery is now
+	// sent unsigned so receivers cannot mistake a forgeable header for
+	// authentication.
 	server, received := newWebhookReceiver(http.StatusOK)
 	defer server.Close()
 	storeWebhookTestConfig(server.URL, "", nil)
@@ -332,13 +333,6 @@ func TestProcessWebhook_SignaturePresentEvenWithEmptySecret(t *testing.T) {
 
 	reqs := received()
 	require.Len(t, reqs, 1)
-	sig := reqs[0].headers.Get("X-Blnk-Signature")
-	ts := reqs[0].headers.Get("X-Blnk-Timestamp")
-	require.NotEmpty(t, sig)
-	require.NotEmpty(t, ts)
-
-	mac := hmac.New(sha256.New, []byte(""))
-	mac.Write([]byte(ts + "." + string(reqs[0].body)))
-	assert.Equal(t, hex.EncodeToString(mac.Sum(nil)), sig,
-		"with no secret configured the signature is HMAC over the empty key (forgeable; documented behavior)")
+	assert.Empty(t, reqs[0].headers.Get("X-Blnk-Signature"), "no signature header may be sent without a configured secret")
+	assert.Empty(t, reqs[0].headers.Get("X-Blnk-Timestamp"), "no timestamp header may be sent without a configured secret")
 }


### PR DESCRIPTION
 Every API error response now carries a structured `error_detail` object with a stable, domain-prefixed code (TXN_NOT_FOUND, GEN_VALIDATION_ERROR,...) alongside the legacy `error`/`errors` fields, which are preserved byte-for-byte and deprecated for removal in the next major release.Unclassified failures return a sanitized 500 instead of echoing internal errors. Catalog and transition contract documented in docs/errors.md.
## Error-code catalog

Codes are domain-prefixed. Each code has exactly one default HTTP status.

### GEN: generic / cross-cutting

| Code | HTTP | Meaning |
|---|---|---|
| `GEN_MALFORMED_REQUEST` | 400 | Request body could not be parsed (invalid JSON, wrong types) |
| `GEN_VALIDATION_ERROR` | 400 | Request failed validation (invalid params, filters, fields) |
| `GEN_MISSING_PARAMETER` | 400 | A required route or query parameter is missing |
| `GEN_BAD_REQUEST` | 400 | Request rejected; no more specific code applies |
| `GEN_NOT_FOUND` | 404 | Resource not found; no domain-specific code applies |
| `GEN_CONFLICT` | 409 | Request conflicts with current resource state |
| `GEN_RESOURCE_LOCKED` | 423 | A concurrent operation holds the lock; retry shortly |
| `GEN_RATE_LIMITED` | 429 | Too many requests |
| `GEN_INTERNAL` | 500 | Unexpected server failure; message is sanitized |

### AUTH: authentication & authorization

| Code | HTTP | Meaning |
|---|---|---|
| `AUTH_MISSING_API_KEY` | 401 | No `X-Blnk-Key` header supplied |
| `AUTH_INVALID_API_KEY` | 401 | API key is unknown |
| `AUTH_EXPIRED_API_KEY` | 401 | API key is expired or revoked |
| `AUTH_MISSING_PRINCIPAL` | 401 | Authenticated API key principal missing from request context |
| `AUTH_INSUFFICIENT_PERMISSIONS` | 403 | API key lacks the required `resource:action` scope |
| `AUTH_UNKNOWN_RESOURCE` | 403 | Request path maps to no known resource |
| `AUTH_MASTER_KEY_REQUIRED` | 403 | Endpoint (hooks management) requires the master key |
| `AUTH_CROSS_OWNER_ACCESS` | 403 | Attempt to manage another owner's API keys |
| `AUTH_SCOPE_ESCALATION` | 403 | Attempt to grant scopes broader than the caller's |
| `AUTH_METRICS_TOKEN_REQUIRED` | 401 | `/metrics` requires `Authorization: Bearer <token>` |
| `AUTH_INVALID_BEARER_TOKEN` | 401 | `/metrics` bearer token mismatch |
| `AUTH_METRICS_DISABLED` | 403 | Secure mode on but no metrics bearer token configured |

### APIKEY:  API-key management

| Code | HTTP | Meaning |
|---|---|---|
| `APIKEY_NOT_FOUND` | 404 | API key does not exist |
| `APIKEY_OWNER_REQUIRED` | 400 | `owner` is required when creating/listing with the master key |
| `APIKEY_INVALID` | 400 | API-key payload validation failure |

### TXN:  transactions

| Code | HTTP | Meaning |
|---|---|---|
| `TXN_NOT_FOUND` | 404 | Transaction (or refundable/queued source) does not exist |
| `TXN_INSUFFICIENT_FUNDS` | 400 | Source balance cannot cover the transaction |
| `TXN_INVALID_AMOUNT` | 400 | Transaction amount must be positive |
| `TXN_PRECISION_NOT_INTEGER` | 400 | `precision` must be an integer value |
| `TXN_INVALID_DISTRIBUTION` | 400 | Multi-source/destination distribution is invalid |
| `TXN_DUPLICATE_REFERENCE` | 409 | The `reference` has already been used |
| `TXN_NOT_INFLIGHT` | 400 | Transaction is not in INFLIGHT status |
| `TXN_ALREADY_COMMITTED` | 409 | Inflight transaction was already committed |
| `TXN_ALREADY_VOIDED` | 409 | Inflight transaction was already voided |
| `TXN_COMMIT_AMOUNT_EXCEEDED` | 400 | Commit exceeds the original/remaining inflight amount |
| `TXN_INVALID_STATUS_ACTION` | 400 | Inflight update status must be `commit` or `void` |
| `TXN_BULK_EMPTY` | 400 | Bulk payload contains no transactions/IDs |
| `TXN_BULK_LIMIT_EXCEEDED` | 400 | Bulk payload exceeds the per-request item limit |
| `TXN_VALIDATION_ERROR` | 400 | Transaction payload failed validation |

### BAL: balances & monitors

| Code | HTTP | Meaning |
|---|---|---|
| `BAL_NOT_FOUND` | 404 | Balance does not exist |
| `BAL_HISTORY_NOT_FOUND` | 404 | No balance snapshot/history at the requested time |
| `BAL_INVALID_TIMESTAMP` | 400 | Timestamp must be ISO 8601 |
| `BAL_VALIDATION_ERROR` | 400 | Balance (or linked identity) validation failure |
| `BAL_MONITOR_NOT_FOUND` | 404 | Balance monitor does not exist |

### LGR / ACC :  ledgers & accounts

| Code | HTTP | Meaning |
|---|---|---|
| `LGR_NOT_FOUND` | 404 | Ledger does not exist |
| `LGR_DUPLICATE` | 409 | Ledger with this name or ID already exists |
| `ACC_NOT_FOUND` | 404 | Account does not exist |
| `ACC_DUPLICATE` | 409 | Account already exists |
| `ACC_GENERATION_FAILED` | 500 | Mock account generation failed |

### IDT :  identities & tokenization

| Code | HTTP | Meaning |
|---|---|---|
| `IDT_NOT_FOUND` | 404 | Identity does not exist |
| `IDT_VALIDATION_ERROR` | 400 | Identity payload validation failure |
| `IDT_FIELD_NOT_TOKENIZABLE` | 400 | Field is not in the tokenizable set |
| `IDT_FIELD_ALREADY_TOKENIZED` | 409 | Field is already tokenized |
| `IDT_FIELD_NOT_TOKENIZED` | 400 | Field is not tokenized (cannot detokenize) |
| `IDT_FIELD_NOT_FOUND` | 400 | Field does not exist on the identity |
| `IDT_TOKENIZATION_DISABLED` | 403 | Tokenization is not configured on this server |

### RECON :  reconciliation

| Code | HTTP | Meaning |
|---|---|---|
| `RECON_NOT_FOUND` | 404 | Reconciliation run does not exist |
| `RECON_RULE_NOT_FOUND` | 404 | Matching rule does not exist |
| `RECON_UPLOAD_FAILED` | 400 | External data file upload failed (client-side) |
| `RECON_UPLOAD_PROCESSING_FAILED` | 500 | Server failed to process the uploaded file |
| `RECON_RULE_INVALID` | 400 | Matching rule validation failure (name, criteria, operator, field, drift) |
| `RECON_MATCHING_RULES_REQUIRED` | 400 | `matching_rule_ids` is required |
| `RECON_EXTERNAL_TXNS_REQUIRED` | 400 | `external_transactions` is required |
| `RECON_START_FAILED` | 500 | Reconciliation could not be started |

### META / HOOK / SRCH / ADMIN

| Code | HTTP | Meaning |
|---|---|---|
| `META_ENTITY_NOT_FOUND` | 404 | Entity for metadata update does not exist |
| `META_UNSUPPORTED_ENTITY` | 400 | Entity type does not support metadata |
| `META_INVALID_ENTITY_ID` | 400 | Entity ID is missing or malformed |
| `HOOK_NOT_FOUND` | 404 | Hook does not exist |
| `HOOK_INVALID` | 400 | Hook payload validation failure |
| `HOOK_OPERATION_FAILED` | 500 | Hook registration/update/list/delete infrastructure failure |
| `SRCH_QUERY_INVALID` | 400 | Search payload is invalid |
| `SRCH_FAILED` | 500 | Search backend failure |
| `SRCH_REINDEX_IN_PROGRESS` | 409 | A reindex is already running (`details` carries progress) |
| `SRCH_REINDEX_NOT_STARTED` | 404 | No reindex has been started |
| `ADMIN_BACKUP_FAILED` | 500 | Database backup failed |

## Legacy codes

Internal layers may still construct errors with the original generic codes.
They are normalized at the response boundary and never appear in
`error_detail.code`:

| Legacy | Canonical |
|---|---|
| `NOT_FOUND` | `GEN_NOT_FOUND` |
| `CONFLICT` | `GEN_CONFLICT` |
| `BAD_REQUEST` | `GEN_BAD_REQUEST` |
| `INVALID_INPUT` | `GEN_VALIDATION_ERROR` |
| `INTERNAL_SERVER_ERROR` | `GEN_INTERNAL` |
| `RATE_LIMITED` | `GEN_RATE_LIMITED` |


  Bugs fixed:
  - ApplyPrecision silently recorded 0 for amounts finer than precision
  - ApplyRate truncated instead of rounding (lost minor units on FX)
  - Overdraft limit float truncation rejected at-limit transactions
  - Reconciliation drift: matcher/prefilter disagreed 100x; canonical unit is now a fraction (0.01 = 1%), validated in [0,1]
  - Negative amounts could never reconcile (negative drift tolerance)
  - Date drift truncated sub-seconds; validated date operators (greater_than/less_than) were unimplemented and always false
  - Reconciliation inputs vanished (neither matched nor unmatched) when grouping returned no groups
  - HashTxn collided beyond 6 decimals (high-precision assets)
  - Webhooks permanently lost on receiver non-2xx (asynq never retried)
  - Lineage outbox entries stranded in 'processing' after a crash; lock window now computed on the DB clock; claims now FIFO-ordered
  - Slack notifications dropped (and JSON-injectable) on error text with quotes; payload now built with json.Marshal
  - request.Call had no HTTP timeout (goroutine leak on hung endpoints)
  - Rate limiter nil-pointer panic on nil CleanupIntervalSec
  - Webhooks signed with an empty-key HMAC when secret_key unset are forgeable; now sent unsigned with a warning in
  - Filter between/in/balance_id misuse silently dropped conditions and ran queries UNFILTERED; now rejected at validation
  - GetSourceDestination scanned 9 fields from a composite column (broken for any caller); rewritten as a direct select
  - DELETE /balance-monitors/:id and DELETE /identities/:id had handlers but no routes; GET /balance-monitors/balances/:balance_id looked up by monitor ID; metadata 404 branch was unreachable (errors.Is misuse)
  - Reindex always failed on fresh Typesense (404 message not tolerated)
  - Detokenize-all returned empty after DB round-trip (metadata type)
  - Transaction created_at now stored in UTC at all insert sites; stuck- transaction recovery no longer blind by the server TZ offset
  - Removed dead unrouted api.RecordTransaction handler (superseded by skip_queue)