### PR TITLE
Remove unused rate, currency_multiplier, and modification_ref columns

### DIFF
--- a/account_test.go
+++ b/account_test.go
@@ -53,7 +53,7 @@ func TestCreateAccount(t *testing.T) {
 	}
 	metaDataJSON, _ := json.Marshal(account.MetaData)
 
-	rows := sqlmock.NewRows([]string{"balance_id", "indicator", "currency", "currency_multiplier", "ledger_id", "balance", "credit_balance", "debit_balance", "inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id"}).
+	rows := sqlmock.NewRows([]string{"balance_id", "indicator", "currency", "ledger_id", "balance", "credit_balance", "debit_balance", "inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id"}).
 		AddRow(account.BalanceID, "", "NGN", 1, account.LedgerID, 100, 50, 50, 0, 0, 0, time.Now(), 0, false, "FIFO", "")
 
 	mock.ExpectQuery("SELECT .* FROM blnk.balances WHERE balance_id =").
@@ -104,7 +104,7 @@ func TestCreateAccountWithExternalGenerator(t *testing.T) {
 	}
 	metaDataJSON, _ := json.Marshal(account.MetaData)
 
-	rows := sqlmock.NewRows([]string{"balance_id", "indicator", "currency", "currency_multiplier", "ledger_id", "balance", "credit_balance", "debit_balance", "inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id"}).
+	rows := sqlmock.NewRows([]string{"balance_id", "indicator", "currency", "ledger_id", "balance", "credit_balance", "debit_balance", "inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id"}).
 		AddRow(account.BalanceID, "", "NGN", 1, account.LedgerID, 100, 50, 50, 0, 0, 0, time.Now(), 0, false, "FIFO", "")
 
 	mock.ExpectQuery("SELECT .* FROM blnk.balances WHERE balance_id =").

--- a/api/model/model.go
+++ b/api/model/model.go
@@ -215,7 +215,7 @@ func (b *CreateBalance) ToBalance() model.Balance {
 	if allocationStrategy == "" {
 		allocationStrategy = "FIFO"
 	}
-	return model.Balance{LedgerID: b.LedgerId, IdentityID: b.IdentityId, Currency: b.Currency, MetaData: b.MetaData, CurrencyMultiplier: b.Precision, TrackFundLineage: b.TrackFundLineage, AllocationStrategy: allocationStrategy}
+	return model.Balance{LedgerID: b.LedgerId, IdentityID: b.IdentityId, Currency: b.Currency, MetaData: b.MetaData, TrackFundLineage: b.TrackFundLineage, AllocationStrategy: allocationStrategy}
 }
 
 func (b *CreateBalanceMonitor) ToBalanceMonitor() model.BalanceMonitor {
@@ -265,5 +265,5 @@ func (t *RecordTransaction) ToTransaction() *model.Transaction {
 		inflightCommitDate = inflightCommit
 	}
 
-	return &model.Transaction{Currency: t.Currency, Source: t.Source, Description: t.Description, Reference: t.Reference, ScheduledFor: scheduledFor, Destination: t.Destination, Amount: t.Amount, AllowOverdraft: t.AllowOverDraft, MetaData: t.MetaData, Sources: t.Sources, Destinations: t.Destinations, Inflight: t.Inflight, Precision: t.Precision, InflightExpiryDate: inflightExpiryDate, InflightCommitDate: inflightCommitDate, Rate: t.Rate, SkipQueue: t.SkipQueue, EffectiveDate: t.EffectiveDate, OverdraftLimit: t.OverdraftLimit, PreciseAmount: t.PreciseAmount, Atomic: t.Atomic}
+	return &model.Transaction{Currency: t.Currency, Source: t.Source, Description: t.Description, Reference: t.Reference, ScheduledFor: scheduledFor, Destination: t.Destination, Amount: t.Amount, AllowOverdraft: t.AllowOverDraft, MetaData: t.MetaData, Sources: t.Sources, Destinations: t.Destinations, Inflight: t.Inflight, Precision: t.Precision, InflightExpiryDate: inflightExpiryDate, InflightCommitDate: inflightCommitDate, SkipQueue: t.SkipQueue, EffectiveDate: t.EffectiveDate, OverdraftLimit: t.OverdraftLimit, PreciseAmount: t.PreciseAmount, Atomic: t.Atomic}
 }

--- a/api/model/model_test.go
+++ b/api/model/model_test.go
@@ -358,7 +358,6 @@ func TestToBalance(t *testing.T) {
 	assert.Equal(t, createBalance.IdentityId, balance.IdentityID)
 	assert.Equal(t, createBalance.Currency, balance.Currency)
 	assert.Equal(t, createBalance.MetaData, balance.MetaData)
-	assert.Equal(t, createBalance.Precision, balance.CurrencyMultiplier)
 }
 
 func TestToAccount(t *testing.T) {
@@ -405,7 +404,6 @@ func TestToTransaction(t *testing.T) {
 		Precision:          2,
 		InflightExpiryDate: inflightExpiryDate.Format(time.RFC3339),
 		InflightCommitDate: inflightCommitDate.Format(time.RFC3339),
-		Rate:               1.5,
 		SkipQueue:          true,
 	}
 
@@ -423,7 +421,6 @@ func TestToTransaction(t *testing.T) {
 	assert.Equal(t, recordTransaction.Destinations, transaction.Destinations)
 	assert.Equal(t, recordTransaction.Inflight, transaction.Inflight)
 	assert.Equal(t, recordTransaction.Precision, transaction.Precision)
-	assert.Equal(t, recordTransaction.Rate, transaction.Rate)
 	assert.Equal(t, recordTransaction.SkipQueue, transaction.SkipQueue)
 	assert.False(t, transaction.InflightCommitDate.IsZero(), "InflightCommitDate should be parsed and set")
 	assert.WithinDuration(t, inflightCommitDate, transaction.InflightCommitDate, time.Second)

--- a/api/model/transaction.go
+++ b/api/model/transaction.go
@@ -24,7 +24,6 @@ import (
 
 type RecordTransaction struct {
 	Amount             float64                `json:"amount"`
-	Rate               float64                `json:"rate"`
 	Precision          float64                `json:"precision"`
 	OverdraftLimit     float64                `json:"overdraft_limit"`
 	PreciseAmount      *big.Int               `json:"precise_amount"`

--- a/balance_test.go
+++ b/balance_test.go
@@ -163,7 +163,7 @@ func TestCreateBalance(t *testing.T) {
 	// Convert metadata to JSON for mocking
 	metaDataJSON, _ := json.Marshal(balance.MetaData)
 	mock.ExpectExec("INSERT INTO blnk.balances").
-		WithArgs(sqlmock.AnyArg(), balance.Balance.String(), balance.CreditBalance.String(), balance.DebitBalance.String(), balance.Currency, balance.CurrencyMultiplier, balance.LedgerID, balance.IdentityID, sqlmock.AnyArg(), sqlmock.AnyArg(), metaDataJSON, false, "FIFO").
+		WithArgs(sqlmock.AnyArg(), balance.Balance.String(), balance.CreditBalance.String(), balance.DebitBalance.String(), balance.Currency, balance.LedgerID, balance.IdentityID, sqlmock.AnyArg(), sqlmock.AnyArg(), metaDataJSON, false, "FIFO").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	result, err := d.CreateBalance(context.Background(), balance)
@@ -188,8 +188,8 @@ func TestGetBalanceByID(t *testing.T) {
 	balanceID := gofakeit.UUID()
 
 	// Adjust the expected SQL to match the actual SQL output.
-	expectedSQL := `SELECT b\.balance_id, b\.balance, b\.credit_balance, b\.debit_balance, b\.currency, b\.currency_multiplier, b\.ledger_id, COALESCE\(b\.identity_id, ''\) as identity_id, b\.created_at, b\.meta_data, b\.inflight_balance, b\.inflight_credit_balance, b\.inflight_debit_balance, b\.version, b\.indicator, b\.track_fund_lineage, COALESCE\(b\.allocation_strategy, 'FIFO'\) as allocation_strategy FROM \( SELECT \* FROM blnk\.balances WHERE balance_id = \$1 \) AS b`
-	rows := sqlmock.NewRows([]string{"balance_id", "balance", "credit_balance", "debit_balance", "currency", "currency_multiplier", "ledger_id", "identity_id", "created_at", "meta_data", "inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "version", "indicator", "track_fund_lineage", "allocation_strategy"}).
+	expectedSQL := `SELECT b\.balance_id, b\.balance, b\.credit_balance, b\.debit_balance, b\.currency, b\.ledger_id, COALESCE\(b\.identity_id, ''\) as identity_id, b\.created_at, b\.meta_data, b\.inflight_balance, b\.inflight_credit_balance, b\.inflight_debit_balance, b\.version, b\.indicator, b\.track_fund_lineage, COALESCE\(b\.allocation_strategy, 'FIFO'\) as allocation_strategy FROM \( SELECT \* FROM blnk\.balances WHERE balance_id = \$1 \) AS b`
+	rows := sqlmock.NewRows([]string{"balance_id", "balance", "credit_balance", "debit_balance", "currency", "ledger_id", "identity_id", "created_at", "meta_data", "inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "version", "indicator", "track_fund_lineage", "allocation_strategy"}).
 		AddRow(balanceID,
 			BigIntString{big.NewInt(100)},
 			BigIntString{big.NewInt(50)},
@@ -236,14 +236,14 @@ func TestGetAllBalances(t *testing.T) {
 	// The column order must match the actual SQL generated.
 	rows := sqlmock.NewRows([]string{
 		"balance_id", "indicator", "balance", "credit_balance", "debit_balance",
-		"inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "currency", "currency_multiplier", "ledger_id", "identity_id", "created_at", "meta_data",
+		"inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "currency", "ledger_id", "identity_id", "created_at", "meta_data",
 	}).
 		AddRow(
 			"test-balance", "test-indicator", 100, 50, 50, 0, 0, 0, "USD", 1.0, "test-ledger", "",
 			time.Now(), `{"key":"value"}`,
 		)
 
-	mock.ExpectQuery(`SELECT balance_id, indicator, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, currency, currency_multiplier, ledger_id, COALESCE\(identity_id, ''\) as identity_id, created_at, meta_data FROM blnk.balances ORDER BY created_at DESC LIMIT \$1 OFFSET \$2`).
+	mock.ExpectQuery(`SELECT balance_id, indicator, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, currency, ledger_id, COALESCE\(identity_id, ''\) as identity_id, created_at, meta_data FROM blnk.balances ORDER BY created_at DESC LIMIT \$1 OFFSET \$2`).
 		WithArgs(1, 1).
 		WillReturnRows(rows)
 
@@ -273,7 +273,6 @@ func TestUpdateBalance(t *testing.T) {
 		CreditBalance:      big.NewInt(50),
 		DebitBalance:       big.NewInt(50),
 		Currency:           "USD",
-		CurrencyMultiplier: 1,
 		LedgerID:           gofakeit.UUID(),
 		CreatedAt:          time.Time{},              // Assuming CreatedAt is properly initialized elsewhere
 		MetaData:           map[string]interface{}{}, // Assuming MetaData is initialized, even if empty
@@ -284,8 +283,8 @@ func TestUpdateBalance(t *testing.T) {
 
 	mock.ExpectExec(regexp.QuoteMeta(`
         UPDATE blnk.balances
-        SET balance = $2, credit_balance = $3, debit_balance = $4, currency = $5, currency_multiplier = $6, ledger_id = $7, created_at = $8, meta_data = $9
-        WHERE balance_id = $1`)).WithArgs(balance.BalanceID, balance.Balance.String(), balance.CreditBalance.String(), balance.DebitBalance.String(), balance.Currency, balance.CurrencyMultiplier, balance.LedgerID, balance.CreatedAt, metaDataJSON).WillReturnResult(sqlmock.NewResult(1, 1))
+        SET balance = $2, credit_balance = $3, debit_balance = $4, currency = $5, ledger_id = $6, created_at = $7, meta_data = $8
+        WHERE balance_id = $1`)).WithArgs(balance.BalanceID, balance.Balance.String(), balance.CreditBalance.String(), balance.DebitBalance.String(), balance.Currency, balance.LedgerID, balance.CreatedAt, metaDataJSON).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	err = d.datasource.UpdateBalance(balance)
 	assert.NoError(t, err)
@@ -313,12 +312,12 @@ func TestUpdateBalances(t *testing.T) {
 
 	// Expect the first update (for sourceBalance)
 	mock.ExpectExec("UPDATE blnk.balances").WithArgs(
-		sourceBalance.BalanceID, sourceBalance.Balance.String(), sourceBalance.CreditBalance.String(), sourceBalance.DebitBalance.String(), sourceBalance.InflightBalance.String(), sourceBalance.InflightCreditBalance.String(), sourceBalance.InflightDebitBalance.String(), sourceBalance.Currency, sourceBalance.CurrencyMultiplier, sourceBalance.LedgerID, sourceBalance.CreatedAt, sourceBalance.Version,
+		sourceBalance.BalanceID, sourceBalance.Balance.String(), sourceBalance.CreditBalance.String(), sourceBalance.DebitBalance.String(), sourceBalance.InflightBalance.String(), sourceBalance.InflightCreditBalance.String(), sourceBalance.InflightDebitBalance.String(), sourceBalance.Currency, sourceBalance.LedgerID, sourceBalance.CreatedAt, sourceBalance.Version,
 	).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	// Expect the second update (for destinationBalance)
 	mock.ExpectExec("UPDATE blnk.balances").WithArgs(
-		destinationBalance.BalanceID, destinationBalance.Balance.String(), destinationBalance.CreditBalance.String(), destinationBalance.DebitBalance.String(), destinationBalance.InflightBalance.String(), destinationBalance.InflightCreditBalance.String(), destinationBalance.InflightDebitBalance.String(), destinationBalance.Currency, destinationBalance.CurrencyMultiplier, destinationBalance.LedgerID, destinationBalance.CreatedAt, destinationBalance.Version,
+		destinationBalance.BalanceID, destinationBalance.Balance.String(), destinationBalance.CreditBalance.String(), destinationBalance.DebitBalance.String(), destinationBalance.InflightBalance.String(), destinationBalance.InflightCreditBalance.String(), destinationBalance.InflightDebitBalance.String(), destinationBalance.Currency, destinationBalance.LedgerID, destinationBalance.CreatedAt, destinationBalance.Version,
 	).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	// Expect transaction commit

--- a/database/account.go
+++ b/database/account.go
@@ -122,7 +122,7 @@ func prepareAccountQueries(queryBuilder strings.Builder, include []string) strin
 	if contains(include, "balance") {
 		selectFields = append(selectFields,
 			"b.balance_id", "b.balance", "b.credit_balance", "b.debit_balance",
-			"b.currency", "b.currency_multiplier", "b.ledger_id",
+			"b.currency", "b.ledger_id",
 			"COALESCE(b.identity_id, '') as identity_id", "b.created_at", "b.meta_data")
 	}
 
@@ -199,8 +199,7 @@ func scanAccountRow(row *sql.Row, tx *sql.Tx, include []string) (*model.Account,
 	// Add fields for balance if included
 	if contains(include, "balance") {
 		scanArgs = append(scanArgs, &balance.BalanceID, &balance.Balance, &balance.CreditBalance,
-			&balance.DebitBalance, &balance.Currency, &balance.CurrencyMultiplier,
-			&balance.LedgerID, &balance.IdentityID, &balance.CreatedAt, &metaDataJSON)
+			&balance.DebitBalance, &balance.Currency,			&balance.LedgerID, &balance.IdentityID, &balance.CreatedAt, &metaDataJSON)
 	}
 
 	// Add fields for identity if included

--- a/database/balance.go
+++ b/database/balance.go
@@ -63,7 +63,7 @@ func prepareQueries(queryBuilder strings.Builder, include []string) string {
 	// Default fields for balances
 	selectFields = append(selectFields,
 		"b.balance_id", "b.balance", "b.credit_balance", "b.debit_balance",
-		"b.currency", "b.currency_multiplier", "b.ledger_id",
+		"b.currency", "b.ledger_id",
 		"COALESCE(b.identity_id, '') as identity_id", "b.created_at", "b.meta_data", "b.inflight_balance", "b.inflight_credit_balance", "b.inflight_debit_balance", "b.version", "b.indicator", "b.track_fund_lineage", "COALESCE(b.allocation_strategy, 'FIFO') as allocation_strategy")
 
 	// Conditionally include identity fields
@@ -120,8 +120,7 @@ func scanRow(row *sql.Row, include []string) (*model.Balance, error) {
 	var scanArgs []interface{}
 	// Add scan arguments for default balance fields
 	scanArgs = append(scanArgs, &balance.BalanceID, &balanceStr, &creditBalanceStr,
-		&debitBalanceStr, &balance.Currency, &balance.CurrencyMultiplier,
-		&balance.LedgerID, &balance.IdentityID, &balance.CreatedAt, &metaDataJSON,
+		&debitBalanceStr, &balance.Currency,		&balance.LedgerID, &balance.IdentityID, &balance.CreatedAt, &metaDataJSON,
 		&inflightBalanceStr, &inflightCreditBalanceStr, &inflightDebitBalanceStr, &balance.Version, &indicator, &balance.TrackFundLineage, &balance.AllocationStrategy)
 
 	// Conditionally scan for identity fields
@@ -251,9 +250,9 @@ func (d Datasource) CreateBalance(balance model.Balance) (model.Balance, error) 
 
 	// Insert the balance into the database
 	_, err = d.Conn.ExecContext(context.Background(), `
-		INSERT INTO blnk.balances (balance_id, balance, credit_balance, debit_balance, currency, currency_multiplier, ledger_id, identity_id, indicator, created_at, meta_data, track_fund_lineage, allocation_strategy)
+		INSERT INTO blnk.balances (balance_id, balance, credit_balance, debit_balance, currency, ledger_id, identity_id, indicator, created_at, meta_data, track_fund_lineage, allocation_strategy)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
-	`, balance.BalanceID, balance.Balance.String(), balance.CreditBalance.String(), balance.DebitBalance.String(), balance.Currency, balance.CurrencyMultiplier, balance.LedgerID, identityID, indicator, balance.CreatedAt, &metaDataJSON, balance.TrackFundLineage, allocationStrategy)
+	`, balance.BalanceID, balance.Balance.String(), balance.CreditBalance.String(), balance.DebitBalance.String(), balance.Currency, balance.LedgerID, identityID, indicator, balance.CreatedAt, &metaDataJSON, balance.TrackFundLineage, allocationStrategy)
 	if err != nil {
 		// Handle specific PostgreSQL errors (e.g., unique or foreign key violations)
 		pqErr, ok := err.(*pq.Error)
@@ -344,7 +343,7 @@ func (d Datasource) GetBalanceByIDLite(id string) (*model.Balance, error) {
 
 	// Execute the query
 	row := d.Conn.QueryRowContext(context.Background(), `
-       SELECT balance_id, indicator, currency, currency_multiplier, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version, track_fund_lineage, COALESCE(allocation_strategy, 'FIFO') as allocation_strategy, COALESCE(identity_id, '') as identity_id
+       SELECT balance_id, indicator, currency, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version, track_fund_lineage, COALESCE(allocation_strategy, 'FIFO') as allocation_strategy, COALESCE(identity_id, '') as identity_id
        FROM blnk.balances
        WHERE balance_id = $1
     `, id)
@@ -354,7 +353,6 @@ func (d Datasource) GetBalanceByIDLite(id string) (*model.Balance, error) {
 		&balance.BalanceID,
 		&indicator,
 		&balance.Currency,
-		&balance.CurrencyMultiplier,
 		&balance.LedgerID,
 		&balanceValue,
 		&creditBalanceValue,
@@ -438,7 +436,7 @@ func (d Datasource) GetBalancesByIDsLite(ctx context.Context, ids []string) (map
 	}
 
 	rows, err := d.Conn.QueryContext(ctx, `
-		SELECT balance_id, indicator, currency, currency_multiplier, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version, track_fund_lineage, COALESCE(allocation_strategy, 'FIFO') as allocation_strategy, COALESCE(identity_id, '') as identity_id
+		SELECT balance_id, indicator, currency, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version, track_fund_lineage, COALESCE(allocation_strategy, 'FIFO') as allocation_strategy, COALESCE(identity_id, '') as identity_id
 		FROM blnk.balances
 		WHERE balance_id = ANY($1)
 	`, pq.Array(ids))
@@ -460,7 +458,6 @@ func (d Datasource) GetBalancesByIDsLite(ctx context.Context, ids []string) (map
 			&balance.BalanceID,
 			&indicator,
 			&balance.Currency,
-			&balance.CurrencyMultiplier,
 			&balance.LedgerID,
 			&balanceValue,
 			&creditBalanceValue,
@@ -545,7 +542,7 @@ func (d Datasource) GetBalanceByIndicator(indicator, currency string) (*model.Ba
 
 	// Execute query to find the balance with the given indicator and currency
 	row := d.Conn.QueryRowContext(context.Background(), `
-       SELECT balance_id, indicator, currency, currency_multiplier, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version, track_fund_lineage, COALESCE(allocation_strategy, 'FIFO') as allocation_strategy, COALESCE(identity_id, '') as identity_id
+       SELECT balance_id, indicator, currency, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version, track_fund_lineage, COALESCE(allocation_strategy, 'FIFO') as allocation_strategy, COALESCE(identity_id, '') as identity_id
        FROM blnk.balances
        WHERE indicator = $1 AND currency = $2
     `, indicator, currency)
@@ -555,7 +552,6 @@ func (d Datasource) GetBalanceByIndicator(indicator, currency string) (*model.Ba
 		&balance.BalanceID,
 		&balance.Indicator,
 		&balance.Currency,
-		&balance.CurrencyMultiplier,
 		&balance.LedgerID,
 		&balanceValue,
 		&creditBalanceValue,
@@ -637,7 +633,7 @@ func (d Datasource) GetBalanceByIndicator(indicator, currency string) (*model.Ba
 func (d Datasource) GetAllBalances(limit, offset int) ([]model.Balance, error) {
 	var indicator sql.NullString
 	rows, err := d.Conn.QueryContext(context.Background(), `
-        SELECT balance_id, indicator, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, currency, currency_multiplier, ledger_id, COALESCE(identity_id, '') as identity_id, created_at, meta_data
+        SELECT balance_id, indicator, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, currency, ledger_id, COALESCE(identity_id, '') as identity_id, created_at, meta_data
         FROM blnk.balances
         ORDER BY created_at DESC
         LIMIT $1 OFFSET $2
@@ -670,7 +666,6 @@ func (d Datasource) GetAllBalances(limit, offset int) ([]model.Balance, error) {
 			&inflightCreditBalanceValue,
 			&inflightDebitBalanceValue,
 			&balance.Currency,
-			&balance.CurrencyMultiplier,
 			&balance.LedgerID,
 			&balance.IdentityID,
 			&balance.CreatedAt,
@@ -737,7 +732,7 @@ func (d Datasource) GetAllBalances(limit, offset int) ([]model.Balance, error) {
 func (d Datasource) GetSourceDestination(sourceId, destinationId string) ([]*model.Balance, error) {
 	// Execute SQL query to select balances for source and destination using a stored procedure
 	rows, err := d.Conn.QueryContext(context.Background(), `
-		SELECT balance_id, balance, credit_balance, debit_balance, currency, currency_multiplier, ledger_id, created_at, meta_data
+		SELECT balance_id, balance, credit_balance, debit_balance, currency, ledger_id, created_at, meta_data
 		FROM blnk.balances
 		WHERE balance_id IN ($1, $2)
 	`, sourceId, destinationId)
@@ -769,7 +764,6 @@ func (d Datasource) GetSourceDestination(sourceId, destinationId string) ([]*mod
 			&creditBalanceValue,
 			&debitBalanceValue,
 			&balance.Currency,
-			&balance.CurrencyMultiplier,
 			&balance.LedgerID,
 			&balance.CreatedAt,
 			&metaDataJSON,
@@ -874,12 +868,12 @@ func updateBalance(ctx context.Context, tx *sql.Tx, balance *model.Balance) erro
 	// SQL query to update the balance
 	query := `
         UPDATE blnk.balances
-        SET balance = $2, credit_balance = $3, debit_balance = $4, inflight_balance = $5, inflight_credit_balance = $6, inflight_debit_balance = $7, currency = $8, currency_multiplier = $9, ledger_id = $10, created_at = $11, version = version + 1
-        WHERE balance_id = $1 AND version = $12
+        SET balance = $2, credit_balance = $3, debit_balance = $4, inflight_balance = $5, inflight_credit_balance = $6, inflight_debit_balance = $7, currency = $8, ledger_id = $9, created_at = $10, version = version + 1
+        WHERE balance_id = $1 AND version = $11
     `
 
 	// Execute the update query within the provided transaction context
-	result, err := tx.ExecContext(ctx, query, balance.BalanceID, balance.Balance.String(), balance.CreditBalance.String(), balance.DebitBalance.String(), balance.InflightBalance.String(), balance.InflightCreditBalance.String(), balance.InflightDebitBalance.String(), balance.Currency, balance.CurrencyMultiplier, balance.LedgerID, balance.CreatedAt, balance.Version)
+	result, err := tx.ExecContext(ctx, query, balance.BalanceID, balance.Balance.String(), balance.CreditBalance.String(), balance.DebitBalance.String(), balance.InflightBalance.String(), balance.InflightCreditBalance.String(), balance.InflightDebitBalance.String(), balance.Currency, balance.LedgerID, balance.CreatedAt, balance.Version)
 	if err != nil {
 		// Return an error if the query execution fails
 		return apierror.NewAPIError(apierror.ErrInternalServer, "Failed to update balance", err)
@@ -955,21 +949,20 @@ func updateBalanceChunk(ctx context.Context, tx *sql.Tx, balances []*model.Balan
 		    inflight_credit_balance = v.inflight_credit_balance,
 		    inflight_debit_balance = v.inflight_debit_balance,
 		    currency = v.currency,
-		    currency_multiplier = v.currency_multiplier,
 		    ledger_id = v.ledger_id,
 		    created_at = v.created_at,
 		    version = b.version + 1
 		FROM (VALUES
 	`)
 
-	args := make([]interface{}, 0, len(balances)*12)
+	args := make([]interface{}, 0, len(balances)*11)
 	for i, balance := range balances {
 		if i > 0 {
 			query.WriteString(",")
 		}
-		base := i*12 + 1
+		base := i*11 + 1
 		query.WriteString(fmt.Sprintf(
-			"($%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d)",
+			"($%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d)",
 			base,
 			base+1,
 			base+2,
@@ -981,7 +974,6 @@ func updateBalanceChunk(ctx context.Context, tx *sql.Tx, balances []*model.Balan
 			base+8,
 			base+9,
 			base+10,
-			base+11,
 		))
 		args = append(args,
 			balance.BalanceID,
@@ -992,7 +984,6 @@ func updateBalanceChunk(ctx context.Context, tx *sql.Tx, balances []*model.Balan
 			balance.InflightCreditBalance.String(),
 			balance.InflightDebitBalance.String(),
 			balance.Currency,
-			balance.CurrencyMultiplier,
 			balance.LedgerID,
 			balance.CreatedAt,
 			balance.Version,
@@ -1009,7 +1000,6 @@ func updateBalanceChunk(ctx context.Context, tx *sql.Tx, balances []*model.Balan
 			inflight_credit_balance,
 			inflight_debit_balance,
 			currency,
-			currency_multiplier,
 			ledger_id,
 			created_at,
 			expected_version
@@ -1024,7 +1014,6 @@ func updateBalanceChunk(ctx context.Context, tx *sql.Tx, balances []*model.Balan
 				raw.inflight_credit_balance::numeric AS inflight_credit_balance,
 				raw.inflight_debit_balance::numeric AS inflight_debit_balance,
 				raw.currency::text AS currency,
-				raw.currency_multiplier::numeric AS currency_multiplier,
 				raw.ledger_id::text AS ledger_id,
 				raw.created_at::timestamp AS created_at,
 				raw.expected_version::integer AS expected_version
@@ -1069,7 +1058,7 @@ func updateBalanceChunk(ctx context.Context, tx *sql.Tx, balances []*model.Balan
 // It handles both the balance data and the associated metadata.
 //
 // Parameters:
-// - balance: A pointer to the balance object containing the updated balance information. This includes fields such as `balance`, `credit_balance`, `debit_balance`, `currency`, `currency_multiplier`, and `meta_data`.
+// - balance: A pointer to the balance object containing the updated balance information. This includes fields such as `balance`, `credit_balance`, `debit_balance`, `currency`, and `meta_data`.
 //
 // Returns:
 // - error: If the update operation encounters an error, such as a database failure or if the balance ID is not found, an `APIError` is returned.
@@ -1083,9 +1072,9 @@ func (d Datasource) UpdateBalance(balance *model.Balance) error {
 	// Execute the SQL query to update the balance in the database
 	result, err := d.Conn.ExecContext(context.Background(), `
 		UPDATE blnk.balances
-		SET balance = $2, credit_balance = $3, debit_balance = $4, currency = $5, currency_multiplier = $6, ledger_id = $7, created_at = $8, meta_data = $9
+		SET balance = $2, credit_balance = $3, debit_balance = $4, currency = $5, ledger_id = $6, created_at = $7, meta_data = $8
 		WHERE balance_id = $1
-	`, balance.BalanceID, balance.Balance.String(), balance.CreditBalance.String(), balance.DebitBalance.String(), balance.Currency, balance.CurrencyMultiplier, balance.LedgerID, balance.CreatedAt, metaDataJSON)
+	`, balance.BalanceID, balance.Balance.String(), balance.CreditBalance.String(), balance.DebitBalance.String(), balance.Currency, balance.LedgerID, balance.CreatedAt, metaDataJSON)
 	// Handle SQL execution errors
 	if err != nil {
 		return apierror.NewAPIError(apierror.ErrInternalServer, "Failed to update balance", err)
@@ -1764,7 +1753,7 @@ func (d Datasource) GetAllBalancesWithFilterAndOptions(ctx context.Context, filt
 	}
 
 	// Determine select fields based on whether count is requested
-	selectFields := "balance_id, indicator, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, currency, currency_multiplier, ledger_id, COALESCE(identity_id, '') as identity_id, created_at, meta_data"
+	selectFields := "balance_id, indicator, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, currency, ledger_id, COALESCE(identity_id, '') as identity_id, created_at, meta_data"
 	if opts != nil && opts.IncludeCount {
 		selectFields += ", COUNT(*) OVER() AS total_count"
 	}
@@ -1823,7 +1812,6 @@ func (d Datasource) GetAllBalancesWithFilterAndOptions(ctx context.Context, filt
 				&inflightCreditBalanceValue,
 				&inflightDebitBalanceValue,
 				&balance.Currency,
-				&balance.CurrencyMultiplier,
 				&balance.LedgerID,
 				&balance.IdentityID,
 				&balance.CreatedAt,
@@ -1844,7 +1832,6 @@ func (d Datasource) GetAllBalancesWithFilterAndOptions(ctx context.Context, filt
 				&inflightCreditBalanceValue,
 				&inflightDebitBalanceValue,
 				&balance.Currency,
-				&balance.CurrencyMultiplier,
 				&balance.LedgerID,
 				&balance.IdentityID,
 				&balance.CreatedAt,

--- a/database/balance_test.go
+++ b/database/balance_test.go
@@ -65,7 +65,6 @@ func TestCreateBalance_Success(t *testing.T) {
 		CreditBalance:      big.NewInt(500),
 		DebitBalance:       big.NewInt(500),
 		Currency:           "USD",
-		CurrencyMultiplier: 100,
 		LedgerID:           "ldg1",
 		MetaData: map[string]interface{}{
 			"key": "value",
@@ -76,7 +75,7 @@ func TestCreateBalance_Success(t *testing.T) {
 	assert.NoError(t, err)
 
 	mock.ExpectExec("INSERT INTO blnk.balances").
-		WithArgs(sqlmock.AnyArg(), balance.Balance.String(), balance.CreditBalance.String(), balance.DebitBalance.String(), balance.Currency, balance.CurrencyMultiplier, balance.LedgerID, sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), metaDataJSON, false, "FIFO").
+		WithArgs(sqlmock.AnyArg(), balance.Balance.String(), balance.CreditBalance.String(), balance.DebitBalance.String(), balance.Currency, balance.LedgerID, sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), metaDataJSON, false, "FIFO").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	createdBalance, err := ds.CreateBalance(balance)
@@ -97,7 +96,6 @@ func TestCreateBalance_UniqueViolation(t *testing.T) {
 		CreditBalance:      big.NewInt(500),
 		DebitBalance:       big.NewInt(500),
 		Currency:           "USD",
-		CurrencyMultiplier: 100,
 		LedgerID:           "ldg1",
 		MetaData: map[string]interface{}{
 			"key": "value",
@@ -108,7 +106,7 @@ func TestCreateBalance_UniqueViolation(t *testing.T) {
 	assert.NoError(t, err)
 
 	mock.ExpectExec("INSERT INTO blnk.balances").
-		WithArgs(sqlmock.AnyArg(), balance.Balance.String(), balance.CreditBalance.String(), balance.DebitBalance.String(), balance.Currency, balance.CurrencyMultiplier, balance.LedgerID, sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), metaDataJSON, false, "FIFO").
+		WithArgs(sqlmock.AnyArg(), balance.Balance.String(), balance.CreditBalance.String(), balance.DebitBalance.String(), balance.Currency, balance.LedgerID, sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), metaDataJSON, false, "FIFO").
 		WillReturnError(&pq.Error{Code: "23505", Message: "unique_violation"})
 
 	_, err = ds.CreateBalance(balance)
@@ -132,7 +130,6 @@ func TestGetBalanceByID_Success(t *testing.T) {
 		DebitBalance:       big.NewInt(500),
 		Currency:           "USD",
 		Indicator:          gofakeit.Name(),
-		CurrencyMultiplier: 100,
 		LedgerID:           "ldg1",
 		MetaData: map[string]interface{}{
 			"key": "value",
@@ -144,7 +141,7 @@ func TestGetBalanceByID_Success(t *testing.T) {
 
 	// Use the exact query in your code and fix the typo for 'indicator'
 	query := `
-		SELECT b.balance_id, b.balance, b.credit_balance, b.debit_balance, b.currency, b.currency_multiplier, b.ledger_id, COALESCE(b.identity_id, '') as identity_id, b.created_at, b.meta_data, b.inflight_balance, b.inflight_credit_balance, b.inflight_debit_balance, b.version, b.indicator, b.track_fund_lineage, COALESCE(b.allocation_strategy, 'FIFO') as allocation_strategy
+		SELECT b.balance_id, b.balance, b.credit_balance, b.debit_balance, b.currency, b.ledger_id, COALESCE(b.identity_id, '') as identity_id, b.created_at, b.meta_data, b.inflight_balance, b.inflight_credit_balance, b.inflight_debit_balance, b.version, b.indicator, b.track_fund_lineage, COALESCE(b.allocation_strategy, 'FIFO') as allocation_strategy
 		FROM ( SELECT * FROM blnk.balances WHERE balance_id = $1 ) AS b
 	`
 
@@ -152,8 +149,8 @@ func TestGetBalanceByID_Success(t *testing.T) {
 	mock.ExpectQuery(regexp.QuoteMeta(query)).
 		WithArgs("bln1").
 		WillReturnRows(sqlmock.NewRows([]string{
-			"balance_id", "balance", "credit_balance", "debit_balance", "currency", "currency_multiplier", "ledger_id", "identity_id", "created_at", "meta_data", "inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "version", "indicator", "track_fund_lineage", "allocation_strategy",
-		}).AddRow(balance.BalanceID, balance.Balance.String(), balance.CreditBalance.String(), balance.DebitBalance.String(), balance.Currency, balance.CurrencyMultiplier, balance.LedgerID, "", time.Now(), metaDataJSON, balance.Balance.String(), balance.CreditBalance.String(), balance.DebitBalance.String(), 1, balance.Indicator, false, "FIFO"))
+			"balance_id", "balance", "credit_balance", "debit_balance", "currency", "ledger_id", "identity_id", "created_at", "meta_data", "inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "version", "indicator", "track_fund_lineage", "allocation_strategy",
+		}).AddRow(balance.BalanceID, balance.Balance.String(), balance.CreditBalance.String(), balance.DebitBalance.String(), balance.Currency, balance.LedgerID, "", time.Now(), metaDataJSON, balance.Balance.String(), balance.CreditBalance.String(), balance.DebitBalance.String(), 1, balance.Indicator, false, "FIFO"))
 
 	retrievedBalance, err := ds.GetBalanceByID("bln1", []string{}, false)
 	assert.NoError(t, err)
@@ -171,7 +168,7 @@ func TestGetBalanceByID_NotFound(t *testing.T) {
 
 	ds := Datasource{Conn: db}
 
-	query := `SELECT balance_id, balance, credit_balance, debit_balance, currency, currency_multiplier, ledger_id, created_at, meta_data FROM blnk.balances WHERE balance_id = ?`
+	query := `SELECT balance_id, balance, credit_balance, debit_balance, currency, ledger_id, created_at, meta_data FROM blnk.balances WHERE balance_id = ?`
 
 	mock.ExpectQuery(regexp.QuoteMeta(query)).
 		WithArgs("bln1").
@@ -201,7 +198,6 @@ func TestUpdateBalances_Success(t *testing.T) {
 		DebitBalance:       big.NewInt(500),
 		Version:            1,
 		Currency:           "USD",
-		CurrencyMultiplier: 100,
 	}
 
 	destBalance := &model.Balance{
@@ -211,7 +207,6 @@ func TestUpdateBalances_Success(t *testing.T) {
 		DebitBalance:       big.NewInt(1000),
 		Version:            1,
 		Currency:           "USD",
-		CurrencyMultiplier: 100,
 	}
 
 	// Set up expectations
@@ -220,8 +215,8 @@ func TestUpdateBalances_Success(t *testing.T) {
 	// Expect source balance update
 	mock.ExpectExec(regexp.QuoteMeta(`
         UPDATE blnk.balances
-        SET balance = $2, credit_balance = $3, debit_balance = $4, inflight_balance = $5, inflight_credit_balance = $6, inflight_debit_balance = $7, currency = $8, currency_multiplier = $9, ledger_id = $10, created_at = $11, version = version + 1
-        WHERE balance_id = $1 AND version = $12
+        SET balance = $2, credit_balance = $3, debit_balance = $4, inflight_balance = $5, inflight_credit_balance = $6, inflight_debit_balance = $7, currency = $8, ledger_id = $9, created_at = $10, version = version + 1
+        WHERE balance_id = $1 AND version = $11
     `)).WithArgs(
 		sourceBalance.BalanceID,
 		sourceBalance.Balance.String(),
@@ -231,7 +226,6 @@ func TestUpdateBalances_Success(t *testing.T) {
 		sourceBalance.InflightCreditBalance.String(),
 		sourceBalance.InflightDebitBalance.String(),
 		sourceBalance.Currency,
-		sourceBalance.CurrencyMultiplier,
 		sourceBalance.LedgerID,
 		sourceBalance.CreatedAt,
 		sourceBalance.Version,
@@ -240,8 +234,8 @@ func TestUpdateBalances_Success(t *testing.T) {
 	// Expect destination balance update
 	mock.ExpectExec(regexp.QuoteMeta(`
         UPDATE blnk.balances
-        SET balance = $2, credit_balance = $3, debit_balance = $4, inflight_balance = $5, inflight_credit_balance = $6, inflight_debit_balance = $7, currency = $8, currency_multiplier = $9, ledger_id = $10, created_at = $11, version = version + 1
-        WHERE balance_id = $1 AND version = $12
+        SET balance = $2, credit_balance = $3, debit_balance = $4, inflight_balance = $5, inflight_credit_balance = $6, inflight_debit_balance = $7, currency = $8, ledger_id = $9, created_at = $10, version = version + 1
+        WHERE balance_id = $1 AND version = $11
     `)).WithArgs(
 		destBalance.BalanceID,
 		destBalance.Balance.String(),
@@ -251,7 +245,6 @@ func TestUpdateBalances_Success(t *testing.T) {
 		destBalance.InflightCreditBalance.String(),
 		destBalance.InflightDebitBalance.String(),
 		destBalance.Currency,
-		destBalance.CurrencyMultiplier,
 		destBalance.LedgerID,
 		destBalance.CreatedAt,
 		destBalance.Version,
@@ -309,7 +302,6 @@ func TestUpdateBalances_SourceUpdateError(t *testing.T) {
 			"0",              // InflightCreditBalance string
 			"0",              // InflightDebitBalance string
 			"",               // Currency
-			0,                // CurrencyMultiplier
 			"",               // LedgerID
 			sqlmock.AnyArg(), // CreatedAt
 			sourceBalance.Version,
@@ -350,7 +342,6 @@ func TestUpdateBalances_DestUpdateError(t *testing.T) {
 			"0",              // InflightCreditBalance string
 			"0",              // InflightDebitBalance string
 			"",               // Currency
-			0,                // CurrencyMultiplier
 			"",               // LedgerID
 			sqlmock.AnyArg(), // CreatedAt
 			sourceBalance.Version,
@@ -368,7 +359,6 @@ func TestUpdateBalances_DestUpdateError(t *testing.T) {
 			"0",              // InflightCreditBalance string
 			"0",              // InflightDebitBalance string
 			"",               // Currency
-			0,                // CurrencyMultiplier
 			"",               // LedgerID
 			sqlmock.AnyArg(), // CreatedAt
 			destBalance.Version,
@@ -409,7 +399,6 @@ func TestUpdateBalances_CommitError(t *testing.T) {
 			"0",              // InflightCreditBalance string
 			"0",              // InflightDebitBalance string
 			"",               // Currency
-			0,                // CurrencyMultiplier
 			"",               // LedgerID
 			sqlmock.AnyArg(), // CreatedAt
 			sourceBalance.Version,
@@ -427,7 +416,6 @@ func TestUpdateBalances_CommitError(t *testing.T) {
 			"0",              // InflightCreditBalance string
 			"0",              // InflightDebitBalance string
 			"",               // Currency
-			0,                // CurrencyMultiplier
 			"",               // LedgerID
 			sqlmock.AnyArg(), // CreatedAt
 			destBalance.Version,
@@ -457,7 +445,6 @@ func TestGetBalanceByID_WithQueuedTransactions(t *testing.T) {
 		DebitBalance:       big.NewInt(500),
 		Currency:           "USD",
 		Indicator:          gofakeit.Name(),
-		CurrencyMultiplier: 100,
 		LedgerID:           "ldg1",
 		MetaData: map[string]interface{}{
 			"key": "value",
@@ -469,17 +456,17 @@ func TestGetBalanceByID_WithQueuedTransactions(t *testing.T) {
 
 	// First, expect the balance query
 	mock.ExpectQuery(regexp.QuoteMeta(`
-        SELECT b.balance_id, b.balance, b.credit_balance, b.debit_balance, b.currency, b.currency_multiplier, b.ledger_id, COALESCE(b.identity_id, '') as identity_id, b.created_at, b.meta_data, b.inflight_balance, b.inflight_credit_balance, b.inflight_debit_balance, b.version, b.indicator, b.track_fund_lineage, COALESCE(b.allocation_strategy, 'FIFO') as allocation_strategy
+        SELECT b.balance_id, b.balance, b.credit_balance, b.debit_balance, b.currency, b.ledger_id, COALESCE(b.identity_id, '') as identity_id, b.created_at, b.meta_data, b.inflight_balance, b.inflight_credit_balance, b.inflight_debit_balance, b.version, b.indicator, b.track_fund_lineage, COALESCE(b.allocation_strategy, 'FIFO') as allocation_strategy
         FROM ( SELECT * FROM blnk.balances WHERE balance_id = $1 ) AS b
     `)).WithArgs("bln1").
 		WillReturnRows(sqlmock.NewRows([]string{
 			"balance_id", "balance", "credit_balance", "debit_balance", "currency",
-			"currency_multiplier", "ledger_id", "identity_id", "created_at", "meta_data",
+			"ledger_id", "identity_id", "created_at", "meta_data",
 			"inflight_balance", "inflight_credit_balance", "inflight_debit_balance",
 			"version", "indicator", "track_fund_lineage", "allocation_strategy",
 		}).AddRow(
 			balance.BalanceID, balance.Balance.String(), balance.CreditBalance.String(),
-			balance.DebitBalance.String(), balance.Currency, balance.CurrencyMultiplier,
+			balance.DebitBalance.String(), balance.Currency,
 			balance.LedgerID, "", time.Now(), metaDataJSON, balance.Balance.String(),
 			balance.CreditBalance.String(), balance.DebitBalance.String(), 1, balance.Indicator, false, "FIFO",
 		))
@@ -542,7 +529,6 @@ func TestGetBalanceByID_WithoutQueuedTransactions(t *testing.T) {
 		DebitBalance:       big.NewInt(500),
 		Currency:           "USD",
 		Indicator:          gofakeit.Name(),
-		CurrencyMultiplier: 100,
 		LedgerID:           "ldg1",
 		MetaData: map[string]interface{}{
 			"key": "value",
@@ -557,17 +543,17 @@ func TestGetBalanceByID_WithoutQueuedTransactions(t *testing.T) {
 
 	// Only expect the balance query, not the queued transactions query
 	mock.ExpectQuery(regexp.QuoteMeta(`
-        SELECT b.balance_id, b.balance, b.credit_balance, b.debit_balance, b.currency, b.currency_multiplier, b.ledger_id, COALESCE(b.identity_id, '') as identity_id, b.created_at, b.meta_data, b.inflight_balance, b.inflight_credit_balance, b.inflight_debit_balance, b.version, b.indicator, b.track_fund_lineage, COALESCE(b.allocation_strategy, 'FIFO') as allocation_strategy
+        SELECT b.balance_id, b.balance, b.credit_balance, b.debit_balance, b.currency, b.ledger_id, COALESCE(b.identity_id, '') as identity_id, b.created_at, b.meta_data, b.inflight_balance, b.inflight_credit_balance, b.inflight_debit_balance, b.version, b.indicator, b.track_fund_lineage, COALESCE(b.allocation_strategy, 'FIFO') as allocation_strategy
         FROM ( SELECT * FROM blnk.balances WHERE balance_id = $1 ) AS b
     `)).WithArgs("bln1").
 		WillReturnRows(sqlmock.NewRows([]string{
 			"balance_id", "balance", "credit_balance", "debit_balance", "currency",
-			"currency_multiplier", "ledger_id", "identity_id", "created_at", "meta_data",
+			"ledger_id", "identity_id", "created_at", "meta_data",
 			"inflight_balance", "inflight_credit_balance", "inflight_debit_balance",
 			"version", "indicator", "track_fund_lineage", "allocation_strategy",
 		}).AddRow(
 			balance.BalanceID, balance.Balance.String(), balance.CreditBalance.String(),
-			balance.DebitBalance.String(), balance.Currency, balance.CurrencyMultiplier,
+			balance.DebitBalance.String(), balance.Currency,
 			balance.LedgerID, "", time.Now(), metaDataJSON, balance.Balance.String(),
 			balance.CreditBalance.String(), balance.DebitBalance.String(), 1, balance.Indicator, false, "FIFO",
 		))
@@ -608,7 +594,6 @@ func TestGetBalanceByID_WithQueuedTransactions_HasAppliedChild(t *testing.T) {
 		DebitBalance:       big.NewInt(500),
 		Currency:           "USD",
 		Indicator:          gofakeit.Name(),
-		CurrencyMultiplier: 100,
 		LedgerID:           "ldg1",
 		MetaData: map[string]interface{}{
 			"key": "value",
@@ -620,17 +605,17 @@ func TestGetBalanceByID_WithQueuedTransactions_HasAppliedChild(t *testing.T) {
 
 	// Expect the balance query
 	mock.ExpectQuery(regexp.QuoteMeta(`
-        SELECT b.balance_id, b.balance, b.credit_balance, b.debit_balance, b.currency, b.currency_multiplier, b.ledger_id, COALESCE(b.identity_id, '') as identity_id, b.created_at, b.meta_data, b.inflight_balance, b.inflight_credit_balance, b.inflight_debit_balance, b.version, b.indicator, b.track_fund_lineage, COALESCE(b.allocation_strategy, 'FIFO') as allocation_strategy
+        SELECT b.balance_id, b.balance, b.credit_balance, b.debit_balance, b.currency, b.ledger_id, COALESCE(b.identity_id, '') as identity_id, b.created_at, b.meta_data, b.inflight_balance, b.inflight_credit_balance, b.inflight_debit_balance, b.version, b.indicator, b.track_fund_lineage, COALESCE(b.allocation_strategy, 'FIFO') as allocation_strategy
         FROM ( SELECT * FROM blnk.balances WHERE balance_id = $1 ) AS b
     `)).WithArgs("bln1").
 		WillReturnRows(sqlmock.NewRows([]string{
 			"balance_id", "balance", "credit_balance", "debit_balance", "currency",
-			"currency_multiplier", "ledger_id", "identity_id", "created_at", "meta_data",
+			"ledger_id", "identity_id", "created_at", "meta_data",
 			"inflight_balance", "inflight_credit_balance", "inflight_debit_balance",
 			"version", "indicator", "track_fund_lineage", "allocation_strategy",
 		}).AddRow(
 			balance.BalanceID, balance.Balance.String(), balance.CreditBalance.String(),
-			balance.DebitBalance.String(), balance.Currency, balance.CurrencyMultiplier,
+			balance.DebitBalance.String(), balance.Currency,
 			balance.LedgerID, "", time.Now(), metaDataJSON, balance.Balance.String(),
 			balance.CreditBalance.String(), balance.DebitBalance.String(), 1, balance.Indicator, false, "FIFO",
 		))
@@ -664,7 +649,7 @@ func TestGetBalanceByIDLite_Success(t *testing.T) {
 	ds := Datasource{Conn: db}
 
 	query := `
-       SELECT balance_id, indicator, currency, currency_multiplier, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version, track_fund_lineage, COALESCE(allocation_strategy, 'FIFO') as allocation_strategy, COALESCE(identity_id, '') as identity_id
+       SELECT balance_id, indicator, currency, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version, track_fund_lineage, COALESCE(allocation_strategy, 'FIFO') as allocation_strategy, COALESCE(identity_id, '') as identity_id
        FROM blnk.balances
        WHERE balance_id = $1
     `
@@ -672,7 +657,7 @@ func TestGetBalanceByIDLite_Success(t *testing.T) {
 	mock.ExpectQuery(regexp.QuoteMeta(query)).
 		WithArgs("bln_123").
 		WillReturnRows(sqlmock.NewRows([]string{
-			"balance_id", "indicator", "currency", "currency_multiplier", "ledger_id",
+			"balance_id", "indicator", "currency", "ledger_id",
 			"balance", "credit_balance", "debit_balance",
 			"inflight_balance", "inflight_credit_balance", "inflight_debit_balance",
 			"created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id",
@@ -706,7 +691,7 @@ func TestGetBalanceByIDLite_NotFound(t *testing.T) {
 	ds := Datasource{Conn: db}
 
 	query := `
-       SELECT balance_id, indicator, currency, currency_multiplier, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version, track_fund_lineage, COALESCE(allocation_strategy, 'FIFO') as allocation_strategy, COALESCE(identity_id, '') as identity_id
+       SELECT balance_id, indicator, currency, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version, track_fund_lineage, COALESCE(allocation_strategy, 'FIFO') as allocation_strategy, COALESCE(identity_id, '') as identity_id
        FROM blnk.balances
        WHERE balance_id = $1
     `
@@ -734,7 +719,7 @@ func TestGetBalanceByIDLite_NullIndicator(t *testing.T) {
 	ds := Datasource{Conn: db}
 
 	query := `
-       SELECT balance_id, indicator, currency, currency_multiplier, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version, track_fund_lineage, COALESCE(allocation_strategy, 'FIFO') as allocation_strategy, COALESCE(identity_id, '') as identity_id
+       SELECT balance_id, indicator, currency, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version, track_fund_lineage, COALESCE(allocation_strategy, 'FIFO') as allocation_strategy, COALESCE(identity_id, '') as identity_id
        FROM blnk.balances
        WHERE balance_id = $1
     `
@@ -742,7 +727,7 @@ func TestGetBalanceByIDLite_NullIndicator(t *testing.T) {
 	mock.ExpectQuery(regexp.QuoteMeta(query)).
 		WithArgs("bln_123").
 		WillReturnRows(sqlmock.NewRows([]string{
-			"balance_id", "indicator", "currency", "currency_multiplier", "ledger_id",
+			"balance_id", "indicator", "currency", "ledger_id",
 			"balance", "credit_balance", "debit_balance",
 			"inflight_balance", "inflight_credit_balance", "inflight_debit_balance",
 			"created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id",
@@ -770,7 +755,7 @@ func TestGetBalancesByIDsLite_Success(t *testing.T) {
 	ds := Datasource{Conn: db}
 
 	query := `
-		SELECT balance_id, indicator, currency, currency_multiplier, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version, track_fund_lineage, COALESCE(allocation_strategy, 'FIFO') as allocation_strategy, COALESCE(identity_id, '') as identity_id
+		SELECT balance_id, indicator, currency, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version, track_fund_lineage, COALESCE(allocation_strategy, 'FIFO') as allocation_strategy, COALESCE(identity_id, '') as identity_id
 		FROM blnk.balances
 		WHERE balance_id = ANY($1)
 	`
@@ -778,7 +763,7 @@ func TestGetBalancesByIDsLite_Success(t *testing.T) {
 	mock.ExpectQuery(regexp.QuoteMeta(query)).
 		WithArgs(pq.Array([]string{"bln_123", "bln_456"})).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"balance_id", "indicator", "currency", "currency_multiplier", "ledger_id",
+			"balance_id", "indicator", "currency", "ledger_id",
 			"balance", "credit_balance", "debit_balance",
 			"inflight_balance", "inflight_credit_balance", "inflight_debit_balance",
 			"created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id",
@@ -837,7 +822,7 @@ func TestGetBalancesByIDsLite_PartialResults(t *testing.T) {
 	ds := Datasource{Conn: db}
 
 	query := `
-		SELECT balance_id, indicator, currency, currency_multiplier, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version, track_fund_lineage, COALESCE(allocation_strategy, 'FIFO') as allocation_strategy, COALESCE(identity_id, '') as identity_id
+		SELECT balance_id, indicator, currency, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version, track_fund_lineage, COALESCE(allocation_strategy, 'FIFO') as allocation_strategy, COALESCE(identity_id, '') as identity_id
 		FROM blnk.balances
 		WHERE balance_id = ANY($1)
 	`
@@ -846,7 +831,7 @@ func TestGetBalancesByIDsLite_PartialResults(t *testing.T) {
 	mock.ExpectQuery(regexp.QuoteMeta(query)).
 		WithArgs(pq.Array([]string{"bln_123", "bln_nonexistent"})).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"balance_id", "indicator", "currency", "currency_multiplier", "ledger_id",
+			"balance_id", "indicator", "currency", "ledger_id",
 			"balance", "credit_balance", "debit_balance",
 			"inflight_balance", "inflight_credit_balance", "inflight_debit_balance",
 			"created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id",
@@ -876,7 +861,7 @@ func TestGetBalanceByIndicator_Success(t *testing.T) {
 	ds := Datasource{Conn: db}
 
 	query := `
-       SELECT balance_id, indicator, currency, currency_multiplier, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version, track_fund_lineage, COALESCE(allocation_strategy, 'FIFO') as allocation_strategy, COALESCE(identity_id, '') as identity_id
+       SELECT balance_id, indicator, currency, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version, track_fund_lineage, COALESCE(allocation_strategy, 'FIFO') as allocation_strategy, COALESCE(identity_id, '') as identity_id
        FROM blnk.balances
        WHERE indicator = $1 AND currency = $2
     `
@@ -884,7 +869,7 @@ func TestGetBalanceByIndicator_Success(t *testing.T) {
 	mock.ExpectQuery(regexp.QuoteMeta(query)).
 		WithArgs("ACC001", "USD").
 		WillReturnRows(sqlmock.NewRows([]string{
-			"balance_id", "indicator", "currency", "currency_multiplier", "ledger_id",
+			"balance_id", "indicator", "currency", "ledger_id",
 			"balance", "credit_balance", "debit_balance",
 			"inflight_balance", "inflight_credit_balance", "inflight_debit_balance",
 			"created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id",
@@ -915,7 +900,7 @@ func TestGetBalanceByIndicator_NotFound(t *testing.T) {
 	ds := Datasource{Conn: db}
 
 	query := `
-       SELECT balance_id, indicator, currency, currency_multiplier, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version, track_fund_lineage, COALESCE(allocation_strategy, 'FIFO') as allocation_strategy, COALESCE(identity_id, '') as identity_id
+       SELECT balance_id, indicator, currency, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version, track_fund_lineage, COALESCE(allocation_strategy, 'FIFO') as allocation_strategy, COALESCE(identity_id, '') as identity_id
        FROM blnk.balances
        WHERE indicator = $1 AND currency = $2
     `
@@ -945,7 +930,7 @@ func TestGetAllBalances_Success(t *testing.T) {
 	metaDataJSON, _ := json.Marshal(metaData)
 
 	query := `
-        SELECT balance_id, indicator, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, currency, currency_multiplier, ledger_id, COALESCE(identity_id, '') as identity_id, created_at, meta_data
+        SELECT balance_id, indicator, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, currency, ledger_id, COALESCE(identity_id, '') as identity_id, created_at, meta_data
         FROM blnk.balances
         ORDER BY created_at DESC
         LIMIT $1 OFFSET $2
@@ -955,7 +940,7 @@ func TestGetAllBalances_Success(t *testing.T) {
 		WithArgs(10, 0).
 		WillReturnRows(sqlmock.NewRows([]string{
 			"balance_id", "indicator", "balance", "credit_balance", "debit_balance",
-			"inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "currency", "currency_multiplier", "ledger_id", "identity_id", "created_at", "meta_data",
+			"inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "currency", "ledger_id", "identity_id", "created_at", "meta_data",
 		}).
 			AddRow("bln_1", "ACC001", "100000", "60000", "40000", "0", "0", "0", "USD", 100, "ldg_001", "", time.Now(), metaDataJSON).
 			AddRow("bln_2", "ACC002", "200000", "120000", "80000", "0", "0", "0", "EUR", 100, "ldg_001", "", time.Now(), metaDataJSON))
@@ -980,7 +965,7 @@ func TestGetAllBalances_Empty(t *testing.T) {
 	ds := Datasource{Conn: db}
 
 	query := `
-        SELECT balance_id, indicator, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, currency, currency_multiplier, ledger_id, COALESCE(identity_id, '') as identity_id, created_at, meta_data
+        SELECT balance_id, indicator, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, currency, ledger_id, COALESCE(identity_id, '') as identity_id, created_at, meta_data
         FROM blnk.balances
         ORDER BY created_at DESC
         LIMIT $1 OFFSET $2
@@ -990,7 +975,7 @@ func TestGetAllBalances_Empty(t *testing.T) {
 		WithArgs(10, 0).
 		WillReturnRows(sqlmock.NewRows([]string{
 			"balance_id", "indicator", "balance", "credit_balance", "debit_balance",
-			"inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "currency", "currency_multiplier", "ledger_id", "identity_id", "created_at", "meta_data",
+			"inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "currency", "ledger_id", "identity_id", "created_at", "meta_data",
 		}))
 
 	balances, err := ds.GetAllBalances(10, 0)
@@ -1009,7 +994,7 @@ func TestGetAllBalances_QueryError(t *testing.T) {
 	ds := Datasource{Conn: db}
 
 	query := `
-        SELECT balance_id, indicator, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, currency, currency_multiplier, ledger_id, COALESCE(identity_id, '') as identity_id, created_at, meta_data
+        SELECT balance_id, indicator, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, currency, ledger_id, COALESCE(identity_id, '') as identity_id, created_at, meta_data
         FROM blnk.balances
         ORDER BY created_at DESC
         LIMIT $1 OFFSET $2
@@ -1034,7 +1019,7 @@ func TestGetSourceDestination_QueryError(t *testing.T) {
 
 	ds := Datasource{Conn: db}
 
-	mock.ExpectQuery("SELECT balance_id, balance, credit_balance, debit_balance, currency, currency_multiplier, ledger_id, created_at, meta_data").
+	mock.ExpectQuery("SELECT balance_id, balance, credit_balance, debit_balance, currency, ledger_id, created_at, meta_data").
 		WithArgs("bln_source", "bln_dest").
 		WillReturnError(fmt.Errorf("stored procedure error"))
 
@@ -1054,9 +1039,9 @@ func TestGetSourceDestination_NoResults(t *testing.T) {
 
 	ds := Datasource{Conn: db}
 
-	mock.ExpectQuery("SELECT balance_id, balance, credit_balance, debit_balance, currency, currency_multiplier, ledger_id, created_at, meta_data").
+	mock.ExpectQuery("SELECT balance_id, balance, credit_balance, debit_balance, currency, ledger_id, created_at, meta_data").
 		WithArgs("bln_source", "bln_dest").
-		WillReturnRows(sqlmock.NewRows([]string{"balance_id", "balance", "credit_balance", "debit_balance", "currency", "currency_multiplier", "ledger_id", "created_at", "meta_data"}))
+		WillReturnRows(sqlmock.NewRows([]string{"balance_id", "balance", "credit_balance", "debit_balance", "currency", "ledger_id", "created_at", "meta_data"}))
 
 	balances, err := ds.GetSourceDestination("bln_source", "bln_dest")
 	assert.NoError(t, err)
@@ -1474,7 +1459,6 @@ func TestUpdateBalance_Success(t *testing.T) {
 		CreditBalance:      big.NewInt(15000),
 		DebitBalance:       big.NewInt(5000),
 		Currency:           "USD",
-		CurrencyMultiplier: 100,
 		LedgerID:           "ldg_123",
 		CreatedAt:          time.Now(),
 		MetaData:           map[string]interface{}{"key": "value"},
@@ -1484,7 +1468,7 @@ func TestUpdateBalance_Success(t *testing.T) {
 
 	query := `
 		UPDATE blnk.balances
-		SET balance = $2, credit_balance = $3, debit_balance = $4, currency = $5, currency_multiplier = $6, ledger_id = $7, created_at = $8, meta_data = $9
+		SET balance = $2, credit_balance = $3, debit_balance = $4, currency = $5, ledger_id = $6, created_at = $7, meta_data = $8
 		WHERE balance_id = $1
 	`
 
@@ -1495,7 +1479,6 @@ func TestUpdateBalance_Success(t *testing.T) {
 			balance.CreditBalance.String(),
 			balance.DebitBalance.String(),
 			balance.Currency,
-			balance.CurrencyMultiplier,
 			balance.LedgerID,
 			balance.CreatedAt,
 			metaDataJSON,
@@ -1522,7 +1505,6 @@ func TestUpdateBalance_NotFound(t *testing.T) {
 		CreditBalance:      big.NewInt(15000),
 		DebitBalance:       big.NewInt(5000),
 		Currency:           "USD",
-		CurrencyMultiplier: 100,
 		LedgerID:           "ldg_123",
 		CreatedAt:          time.Now(),
 		MetaData:           map[string]interface{}{},
@@ -1532,7 +1514,7 @@ func TestUpdateBalance_NotFound(t *testing.T) {
 
 	query := `
 		UPDATE blnk.balances
-		SET balance = $2, credit_balance = $3, debit_balance = $4, currency = $5, currency_multiplier = $6, ledger_id = $7, created_at = $8, meta_data = $9
+		SET balance = $2, credit_balance = $3, debit_balance = $4, currency = $5, ledger_id = $6, created_at = $7, meta_data = $8
 		WHERE balance_id = $1
 	`
 
@@ -1543,7 +1525,6 @@ func TestUpdateBalance_NotFound(t *testing.T) {
 			balance.CreditBalance.String(),
 			balance.DebitBalance.String(),
 			balance.Currency,
-			balance.CurrencyMultiplier,
 			balance.LedgerID,
 			balance.CreatedAt,
 			metaDataJSON,
@@ -1573,7 +1554,6 @@ func TestUpdateBalance_QueryError(t *testing.T) {
 		CreditBalance:      big.NewInt(15000),
 		DebitBalance:       big.NewInt(5000),
 		Currency:           "USD",
-		CurrencyMultiplier: 100,
 		LedgerID:           "ldg_123",
 		CreatedAt:          time.Now(),
 		MetaData:           map[string]interface{}{},
@@ -1583,7 +1563,7 @@ func TestUpdateBalance_QueryError(t *testing.T) {
 
 	query := `
 		UPDATE blnk.balances
-		SET balance = $2, credit_balance = $3, debit_balance = $4, currency = $5, currency_multiplier = $6, ledger_id = $7, created_at = $8, meta_data = $9
+		SET balance = $2, credit_balance = $3, debit_balance = $4, currency = $5, ledger_id = $6, created_at = $7, meta_data = $8
 		WHERE balance_id = $1
 	`
 
@@ -1594,7 +1574,6 @@ func TestUpdateBalance_QueryError(t *testing.T) {
 			balance.CreditBalance.String(),
 			balance.DebitBalance.String(),
 			balance.Currency,
-			balance.CurrencyMultiplier,
 			balance.LedgerID,
 			balance.CreatedAt,
 			metaDataJSON,

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -55,9 +55,9 @@ func (d Datasource) RecordTransaction(ctx context.Context, txn *model.Transactio
 
 	// Execute the SQL insert statement to record the transaction
 	_, err = d.Conn.ExecContext(ctx,
-		`INSERT INTO blnk.transactions(transaction_id, parent_transaction, source, reference, amount, precise_amount, precision, rate, currency, destination, description, status, created_at, meta_data, scheduled_for, hash, effective_date) 
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)`,
-		txn.TransactionID, txn.ParentTransaction, txn.Source, txn.Reference, txn.AmountString, txn.PreciseAmount.String(), txn.Precision, txn.Rate, txn.Currency, txn.Destination, txn.Description, txn.Status, txn.CreatedAt.UTC(), metaDataJSON, txn.ScheduledFor.UTC(), txn.Hash, utcOrNil(txn.EffectiveDate),
+		`INSERT INTO blnk.transactions(transaction_id, parent_transaction, source, reference, amount, precise_amount, precision, currency, destination, description, status, created_at, meta_data, scheduled_for, hash, effective_date)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)`,
+		txn.TransactionID, txn.ParentTransaction, txn.Source, txn.Reference, txn.AmountString, txn.PreciseAmount.String(), txn.Precision, txn.Currency, txn.Destination, txn.Description, txn.Status, txn.CreatedAt.UTC(), metaDataJSON, txn.ScheduledFor.UTC(), txn.Hash, utcOrNil(txn.EffectiveDate),
 	)
 	// Handle errors that may occur during the execution of the query
 	if err != nil {
@@ -87,9 +87,9 @@ func recordTransactionInTx(ctx context.Context, tx *sql.Tx, txn *model.Transacti
 	}
 
 	_, err = tx.ExecContext(ctx,
-		`INSERT INTO blnk.transactions(transaction_id, parent_transaction, source, reference, amount, precise_amount, precision, rate, currency, destination, description, status, created_at, meta_data, scheduled_for, hash, effective_date) 
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)`,
-		txn.TransactionID, txn.ParentTransaction, txn.Source, txn.Reference, txn.AmountString, txn.PreciseAmount.String(), txn.Precision, txn.Rate, txn.Currency, txn.Destination, txn.Description, txn.Status, txn.CreatedAt.UTC(), metaDataJSON, txn.ScheduledFor.UTC(), txn.Hash, utcOrNil(txn.EffectiveDate),
+		`INSERT INTO blnk.transactions(transaction_id, parent_transaction, source, reference, amount, precise_amount, precision, currency, destination, description, status, created_at, meta_data, scheduled_for, hash, effective_date)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)`,
+		txn.TransactionID, txn.ParentTransaction, txn.Source, txn.Reference, txn.AmountString, txn.PreciseAmount.String(), txn.Precision, txn.Currency, txn.Destination, txn.Description, txn.Status, txn.CreatedAt.UTC(), metaDataJSON, txn.ScheduledFor.UTC(), txn.Hash, utcOrNil(txn.EffectiveDate),
 	)
 	if err != nil {
 		span.RecordError(err)
@@ -123,7 +123,6 @@ func recordTransactionsInTx(ctx context.Context, tx *sql.Tx, txns []*model.Trans
 		"amount",
 		"precise_amount",
 		"precision",
-		"rate",
 		"currency",
 		"destination",
 		"description",
@@ -158,7 +157,6 @@ func recordTransactionsInTx(ctx context.Context, tx *sql.Tx, txns []*model.Trans
 			txn.AmountString,
 			txn.PreciseAmount.String(),
 			txn.Precision,
-			txn.Rate,
 			txn.Currency,
 			txn.Destination,
 			txn.Description,

--- a/database/transaction_coalescing.go
+++ b/database/transaction_coalescing.go
@@ -36,7 +36,7 @@ func (d Datasource) GetQueuedTransactionsForCoalescing(ctx context.Context, sour
 	defer span.End()
 
 	rows, err := d.Conn.QueryContext(ctx, `
-		SELECT transaction_id, parent_transaction, source, reference, amount, precise_amount, precision, rate, currency, destination, description, status, created_at, meta_data, scheduled_for, hash
+		SELECT transaction_id, parent_transaction, source, reference, amount, precise_amount, precision, currency, destination, description, status, created_at, meta_data, scheduled_for, hash
 		FROM blnk.transactions t
 		WHERE t.status = 'QUEUED'
 		  AND t.source = $1
@@ -75,7 +75,7 @@ func (d Datasource) GetQueuedTransactionsForSourceCoalescing(ctx context.Context
 	defer span.End()
 
 	rows, err := d.Conn.QueryContext(ctx, `
-		SELECT transaction_id, parent_transaction, source, reference, amount, precise_amount, precision, rate, currency, destination, description, status, created_at, meta_data, scheduled_for, hash
+		SELECT transaction_id, parent_transaction, source, reference, amount, precise_amount, precision, currency, destination, description, status, created_at, meta_data, scheduled_for, hash
 		FROM blnk.transactions t
 		WHERE t.status = 'QUEUED'
 		  AND t.source = $1
@@ -113,7 +113,7 @@ func (d Datasource) GetQueuedTransactionsForDestinationCoalescing(ctx context.Co
 	defer span.End()
 
 	rows, err := d.Conn.QueryContext(ctx, `
-		SELECT transaction_id, parent_transaction, source, reference, amount, precise_amount, precision, rate, currency, destination, description, status, created_at, meta_data, scheduled_for, hash
+		SELECT transaction_id, parent_transaction, source, reference, amount, precise_amount, precision, currency, destination, description, status, created_at, meta_data, scheduled_for, hash
 		FROM blnk.transactions t
 		WHERE t.status = 'QUEUED'
 		  AND t.destination = $1
@@ -160,7 +160,7 @@ func scanQueuedTransactionsForCoalescing(rows *sql.Rows) ([]*model.Transaction, 
 		var preciseAmountStr string
 		if err := rows.Scan(
 			&txn.TransactionID, &txn.ParentTransaction, &txn.Source, &txn.Reference,
-			&txn.Amount, &preciseAmountStr, &txn.Precision, &txn.Rate,
+			&txn.Amount, &preciseAmountStr, &txn.Precision,
 			&txn.Currency, &txn.Destination, &txn.Description, &txn.Status,
 			&txn.CreatedAt, &metaDataJSON, &txn.ScheduledFor, &txn.Hash,
 		); err != nil {

--- a/database/transaction_criteria.go
+++ b/database/transaction_criteria.go
@@ -36,7 +36,7 @@ func (d Datasource) GetTransactionsByCriteria(ctx context.Context, minAmount, ma
 
 	query := `
 		SELECT transaction_id, parent_transaction, source, reference, amount, precise_amount, precision, 
-			   rate, currency, destination, description, status, created_at, meta_data, scheduled_for, hash
+			   currency, destination, description, status, created_at, meta_data, scheduled_for, hash
 		FROM blnk.transactions
 		WHERE 1=1
 	`
@@ -102,7 +102,6 @@ func (d Datasource) GetTransactionsByCriteria(ctx context.Context, minAmount, ma
 			&transaction.Amount,
 			&preciseAmountStr,
 			&transaction.Precision,
-			&transaction.Rate,
 			&transaction.Currency,
 			&transaction.Destination,
 			&transaction.Description,

--- a/database/transaction_grouping.go
+++ b/database/transaction_grouping.go
@@ -49,7 +49,7 @@ func (d Datasource) GetTransactionsPaginated(ctx context.Context, _ string, batc
 
 	// If not found in cache, fetch from the database
 	rows, err := d.Conn.QueryContext(ctx, `
-        SELECT transaction_id, parent_transaction, source, reference, amount, precise_amount, precision, rate, currency, destination, description, status, created_at, meta_data, scheduled_for, hash
+        SELECT transaction_id, parent_transaction, source, reference, amount, precise_amount, precision, currency, destination, description, status, created_at, meta_data, scheduled_for, hash
         FROM blnk.transactions
         ORDER BY created_at ASC
         LIMIT $1 OFFSET $2
@@ -79,7 +79,6 @@ func (d Datasource) GetTransactionsPaginated(ctx context.Context, _ string, batc
 			&transaction.Amount,
 			&preciseAmountStr,
 			&transaction.Precision,
-			&transaction.Rate,
 			&transaction.Currency,
 			&transaction.Destination,
 			&transaction.Description,
@@ -190,7 +189,6 @@ func (d Datasource) GroupTransactions(ctx context.Context, groupCriteria string,
 			&transaction.Amount,
 			&preciseAmountStr,
 			&transaction.Precision,
-			&transaction.Rate,
 			&transaction.Currency,
 			&transaction.Destination,
 			&transaction.Description,
@@ -242,7 +240,7 @@ func groupedTransactionsQuery(groupCriteria string) (string, bool) {
 	case "transaction_id":
 		return `
         SELECT transaction_id::text AS group_key, transaction_id, parent_transaction, source, reference,
-               amount, precise_amount, precision, rate, currency, destination,
+               amount, precise_amount, precision, currency, destination,
                description, status, created_at, meta_data, scheduled_for, hash
         FROM blnk.transactions
         WHERE transaction_id::text IS NOT NULL AND transaction_id::text != ''
@@ -252,7 +250,7 @@ func groupedTransactionsQuery(groupCriteria string) (string, bool) {
 	case "parent_transaction":
 		return `
         SELECT parent_transaction::text AS group_key, transaction_id, parent_transaction, source, reference,
-               amount, precise_amount, precision, rate, currency, destination,
+               amount, precise_amount, precision, currency, destination,
                description, status, created_at, meta_data, scheduled_for, hash
         FROM blnk.transactions
         WHERE parent_transaction::text IS NOT NULL AND parent_transaction::text != ''
@@ -262,7 +260,7 @@ func groupedTransactionsQuery(groupCriteria string) (string, bool) {
 	case "source":
 		return `
         SELECT source::text AS group_key, transaction_id, parent_transaction, source, reference,
-               amount, precise_amount, precision, rate, currency, destination,
+               amount, precise_amount, precision, currency, destination,
                description, status, created_at, meta_data, scheduled_for, hash
         FROM blnk.transactions
         WHERE source::text IS NOT NULL AND source::text != ''
@@ -272,7 +270,7 @@ func groupedTransactionsQuery(groupCriteria string) (string, bool) {
 	case "reference":
 		return `
         SELECT reference::text AS group_key, transaction_id, parent_transaction, source, reference,
-               amount, precise_amount, precision, rate, currency, destination,
+               amount, precise_amount, precision, currency, destination,
                description, status, created_at, meta_data, scheduled_for, hash
         FROM blnk.transactions
         WHERE reference::text IS NOT NULL AND reference::text != ''
@@ -282,7 +280,7 @@ func groupedTransactionsQuery(groupCriteria string) (string, bool) {
 	case "currency":
 		return `
         SELECT currency::text AS group_key, transaction_id, parent_transaction, source, reference,
-               amount, precise_amount, precision, rate, currency, destination,
+               amount, precise_amount, precision, currency, destination,
                description, status, created_at, meta_data, scheduled_for, hash
         FROM blnk.transactions
         WHERE currency::text IS NOT NULL AND currency::text != ''
@@ -292,7 +290,7 @@ func groupedTransactionsQuery(groupCriteria string) (string, bool) {
 	case "destination":
 		return `
         SELECT destination::text AS group_key, transaction_id, parent_transaction, source, reference,
-               amount, precise_amount, precision, rate, currency, destination,
+               amount, precise_amount, precision, currency, destination,
                description, status, created_at, meta_data, scheduled_for, hash
         FROM blnk.transactions
         WHERE destination::text IS NOT NULL AND destination::text != ''
@@ -302,7 +300,7 @@ func groupedTransactionsQuery(groupCriteria string) (string, bool) {
 	case "status":
 		return `
         SELECT status::text AS group_key, transaction_id, parent_transaction, source, reference,
-               amount, precise_amount, precision, rate, currency, destination,
+               amount, precise_amount, precision, currency, destination,
                description, status, created_at, meta_data, scheduled_for, hash
         FROM blnk.transactions
         WHERE status::text IS NOT NULL AND status::text != ''
@@ -312,7 +310,7 @@ func groupedTransactionsQuery(groupCriteria string) (string, bool) {
 	case "created_at":
 		return `
         SELECT created_at::text AS group_key, transaction_id, parent_transaction, source, reference,
-               amount, precise_amount, precision, rate, currency, destination,
+               amount, precise_amount, precision, currency, destination,
                description, status, created_at, meta_data, scheduled_for, hash
         FROM blnk.transactions
         WHERE created_at::text IS NOT NULL AND created_at::text != ''
@@ -344,14 +342,14 @@ func (d Datasource) GetInflightTransactionsByParentID(ctx context.Context, paren
 	rows, err := d.Conn.QueryContext(ctx, `
 		WITH inflight_transactions AS (
 			SELECT transaction_id, parent_transaction, source, reference, amount, precise_amount, precision,
-				   rate, currency, destination, description, status, created_at, meta_data, scheduled_for, hash
+				   currency, destination, description, status, created_at, meta_data, scheduled_for, hash
 			FROM blnk.transactions
 			WHERE (transaction_id = $1 OR parent_transaction = $1 OR meta_data->>'QUEUED_PARENT_TRANSACTION' = $1)
 			AND status = 'INFLIGHT'
 		), 
 		queued_inflight_transactions AS (
 			SELECT t.transaction_id, t.parent_transaction, t.source, t.reference, t.amount, t.precise_amount, t.precision, 
-				   t.rate, t.currency, t.destination, t.description, t.status, t.created_at, t.meta_data, t.scheduled_for, t.hash
+				   t.currency, t.destination, t.description, t.status, t.created_at, t.meta_data, t.scheduled_for, t.hash
 			FROM blnk.transactions t
 			WHERE (t.transaction_id = $1 OR t.parent_transaction = $1) 
 			AND t.status = 'QUEUED' AND t.meta_data->>'inflight' = 'true'
@@ -403,7 +401,6 @@ func (d Datasource) GetInflightTransactionsByParentID(ctx context.Context, paren
 			&transaction.Amount,
 			&preciseAmountStr,
 			&transaction.Precision,
-			&transaction.Rate,
 			&transaction.Currency,
 			&transaction.Destination,
 			&transaction.Description,

--- a/database/transaction_lineage.go
+++ b/database/transaction_lineage.go
@@ -33,7 +33,7 @@ func (d Datasource) GetTransactionsByShadowFor(ctx context.Context, parentTransa
 	defer span.End()
 
 	rows, err := d.Conn.QueryContext(ctx, `
-		SELECT transaction_id, source, reference, amount, precise_amount, "precision", rate, currency, destination, description, status, created_at, meta_data, scheduled_for, hash
+		SELECT transaction_id, source, reference, amount, precise_amount, "precision", currency, destination, description, status, created_at, meta_data, scheduled_for, hash
 		FROM blnk.transactions
 		WHERE meta_data->>'_shadow_for' = $1
 		ORDER BY created_at ASC
@@ -57,7 +57,6 @@ func (d Datasource) GetTransactionsByShadowFor(ctx context.Context, parentTransa
 			&transaction.Amount,
 			&preciseAmountStr,
 			&transaction.Precision,
-			&transaction.Rate,
 			&transaction.Currency,
 			&transaction.Destination,
 			&transaction.Description,

--- a/database/transaction_queue.go
+++ b/database/transaction_queue.go
@@ -137,7 +137,7 @@ func (d Datasource) GetTransactionsByParent(ctx context.Context, parentID string
 	// If not in cache, query the database
 	rows, err := d.Conn.QueryContext(ctx, `
 		SELECT transaction_id, parent_transaction, source, reference, amount, precise_amount, precision, 
-			   rate, currency, destination, description, status, created_at, meta_data, scheduled_for, hash
+			   currency, destination, description, status, created_at, meta_data, scheduled_for, hash
 		FROM blnk.transactions
 		WHERE parent_transaction = $1
 		ORDER BY created_at DESC
@@ -168,7 +168,6 @@ func (d Datasource) GetTransactionsByParent(ctx context.Context, parentID string
 			&transaction.Amount,
 			&preciseAmountStr,
 			&transaction.Precision,
-			&transaction.Rate,
 			&transaction.Currency,
 			&transaction.Destination,
 			&transaction.Description,

--- a/database/transaction_recovery.go
+++ b/database/transaction_recovery.go
@@ -37,7 +37,7 @@ func (d Datasource) GetStuckQueuedTransactions(ctx context.Context, threshold ti
 	cutoff := time.Now().UTC().Add(-threshold)
 
 	rows, err := d.Conn.QueryContext(ctx, `
-		SELECT transaction_id, parent_transaction, source, reference, amount, precise_amount, precision, rate, currency, destination, description, status, created_at, meta_data, scheduled_for, hash
+		SELECT transaction_id, parent_transaction, source, reference, amount, precise_amount, precision, currency, destination, description, status, created_at, meta_data, scheduled_for, hash
 		FROM blnk.transactions t
 		WHERE t.status = 'QUEUED'
 		  AND t.created_at < $1
@@ -65,7 +65,7 @@ func (d Datasource) GetStuckQueuedTransactions(ctx context.Context, threshold ti
 		var preciseAmountStr string
 		err = rows.Scan(
 			&txn.TransactionID, &txn.ParentTransaction, &txn.Source, &txn.Reference,
-			&txn.Amount, &preciseAmountStr, &txn.Precision, &txn.Rate,
+			&txn.Amount, &preciseAmountStr, &txn.Precision,
 			&txn.Currency, &txn.Destination, &txn.Description, &txn.Status,
 			&txn.CreatedAt, &metaDataJSON, &txn.ScheduledFor, &txn.Hash,
 		)

--- a/database/transaction_refunds.go
+++ b/database/transaction_refunds.go
@@ -36,7 +36,7 @@ func (d Datasource) GetRefundableTransactionsByParentID(ctx context.Context, par
 	rows, err := d.Conn.QueryContext(ctx, `
 		SELECT 
 			t.transaction_id, t.parent_transaction, t.source, t.reference, t.amount, t.precise_amount, 
-			t.precision, t.rate, t.currency, t.destination, t.description, t.status, t.created_at, 
+			t.precision, t.currency, t.destination, t.description, t.status, t.created_at, 
 			t.meta_data, t.scheduled_for, t.hash
 		FROM 
 			blnk.transactions t
@@ -79,7 +79,6 @@ func (d Datasource) GetRefundableTransactionsByParentID(ctx context.Context, par
 			&transaction.Amount,
 			&preciseAmountStr,
 			&transaction.Precision,
-			&transaction.Rate,
 			&transaction.Currency,
 			&transaction.Destination,
 			&transaction.Description,

--- a/database/transactions_test.go
+++ b/database/transactions_test.go
@@ -94,7 +94,6 @@ func TestRecordTransaction_Success(t *testing.T) {
 		Hash:              "hash123",
 		PreciseAmount:     model.Int64ToBigInt(1000),
 		Precision:         2,
-		Rate:              1,
 		ParentTransaction: "parent123",
 		EffectiveDate:     nil,
 	}
@@ -105,7 +104,7 @@ func TestRecordTransaction_Success(t *testing.T) {
 	// Timestamps are normalized to UTC at the insert boundary so the naive
 	// values stored in timestamp-without-time-zone columns are TZ-independent.
 	mock.ExpectExec("INSERT INTO blnk.transactions").
-		WithArgs(transaction.TransactionID, transaction.ParentTransaction, transaction.Source, transaction.Reference, transaction.AmountString, transaction.PreciseAmount.String(), transaction.Precision, transaction.Rate, transaction.Currency, transaction.Destination, transaction.Description, transaction.Status, transaction.CreatedAt.UTC(), metaDataJSON, transaction.ScheduledFor.UTC(), transaction.Hash, nil).
+		WithArgs(transaction.TransactionID, transaction.ParentTransaction, transaction.Source, transaction.Reference, transaction.AmountString, transaction.PreciseAmount.String(), transaction.Precision, transaction.Currency, transaction.Destination, transaction.Description, transaction.Status, transaction.CreatedAt.UTC(), metaDataJSON, transaction.ScheduledFor.UTC(), transaction.Hash, nil).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	result, err := ds.RecordTransaction(ctx, transaction)
@@ -139,7 +138,6 @@ func TestRecordTransaction_Failure(t *testing.T) {
 		Hash:              "hash123",
 		PreciseAmount:     model.Int64ToBigInt(1000),
 		Precision:         2,
-		Rate:              1,
 		ParentTransaction: "parent123",
 		EffectiveDate:     nil,
 	}
@@ -148,7 +146,7 @@ func TestRecordTransaction_Failure(t *testing.T) {
 	assert.NoError(t, err)
 
 	mock.ExpectExec("INSERT INTO blnk.transactions").
-		WithArgs(transaction.TransactionID, transaction.ParentTransaction, transaction.Source, transaction.Reference, transaction.Amount, transaction.PreciseAmount.String(), transaction.Precision, transaction.Rate, transaction.Currency, transaction.Destination, transaction.Description, transaction.Status, transaction.CreatedAt, metaDataJSON, transaction.ScheduledFor, transaction.Hash, transaction.EffectiveDate).
+		WithArgs(transaction.TransactionID, transaction.ParentTransaction, transaction.Source, transaction.Reference, transaction.Amount, transaction.PreciseAmount.String(), transaction.Precision, transaction.Currency, transaction.Destination, transaction.Description, transaction.Status, transaction.CreatedAt, metaDataJSON, transaction.ScheduledFor, transaction.Hash, transaction.EffectiveDate).
 		WillReturnError(errors.New("db error"))
 
 	_, err = ds.RecordTransaction(ctx, transaction)
@@ -635,7 +633,6 @@ func TestRecordTransactionWithBalances_AtomicSuccess_Integration(t *testing.T) {
 		AmountString:  "500",
 		PreciseAmount: transferAmount,
 		Precision:     100,
-		Rate:          1,
 		Currency:      "USD",
 		Status:        "APPLIED",
 		CreatedAt:     time.Now(),
@@ -733,7 +730,6 @@ func TestRecordTransactionWithBalances_DuplicateTxnID_Rollback_Integration(t *te
 		AmountString:  "100",
 		PreciseAmount: big.NewInt(10000),
 		Precision:     100,
-		Rate:          1,
 		Currency:      "USD",
 		Status:        "APPLIED",
 		CreatedAt:     time.Now(),
@@ -778,7 +774,6 @@ func TestRecordTransactionWithBalances_DuplicateTxnID_Rollback_Integration(t *te
 		AmountString:  "200",
 		PreciseAmount: big.NewInt(20000),
 		Precision:     100,
-		Rate:          1,
 		Currency:      "USD",
 		Status:        "APPLIED",
 		CreatedAt:     time.Now(),
@@ -1877,7 +1872,6 @@ func TestRecordTransactionWithBalances_Success(t *testing.T) {
 		AmountString:      "100.00",
 		PreciseAmount:     big.NewInt(10000),
 		Precision:         100,
-		Rate:              1.0,
 		Currency:          "USD",
 		Destination:       "bln_dest",
 		Description:       "test transaction",
@@ -1896,7 +1890,6 @@ func TestRecordTransactionWithBalances_Success(t *testing.T) {
 		InflightCreditBalance: big.NewInt(0),
 		InflightDebitBalance:  big.NewInt(0),
 		Currency:              "USD",
-		CurrencyMultiplier:    100,
 		Version:               1,
 	}
 
@@ -1909,7 +1902,6 @@ func TestRecordTransactionWithBalances_Success(t *testing.T) {
 		InflightCreditBalance: big.NewInt(0),
 		InflightDebitBalance:  big.NewInt(0),
 		Currency:              "USD",
-		CurrencyMultiplier:    100,
 		Version:               1,
 	}
 
@@ -2006,7 +1998,6 @@ func TestRecordTransactionWithBalances_CommitError(t *testing.T) {
 		AmountString:      "100.00",
 		PreciseAmount:     big.NewInt(10000),
 		Precision:         100,
-		Rate:              1.0,
 		Currency:          "USD",
 		Destination:       "bln_dest",
 		Description:       "test transaction",
@@ -2073,7 +2064,6 @@ func TestRecordTransactionsWithBalancesAndOutboxes_UsesCopyIn(t *testing.T) {
 			AmountString:  "10.00",
 			PreciseAmount: big.NewInt(1000),
 			Precision:     100,
-			Rate:          1,
 			Currency:      "USD",
 			Destination:   "bln_dest",
 			Description:   "first",
@@ -2091,7 +2081,6 @@ func TestRecordTransactionsWithBalancesAndOutboxes_UsesCopyIn(t *testing.T) {
 			AmountString:      "20.00",
 			PreciseAmount:     big.NewInt(2000),
 			Precision:         100,
-			Rate:              1,
 			Currency:          "USD",
 			Destination:       "bln_dest",
 			Description:       "second",
@@ -2112,7 +2101,6 @@ func TestRecordTransactionsWithBalancesAndOutboxes_UsesCopyIn(t *testing.T) {
 		InflightCreditBalance: big.NewInt(0),
 		InflightDebitBalance:  big.NewInt(0),
 		Currency:              "USD",
-		CurrencyMultiplier:    100,
 		Version:               1,
 	}
 
@@ -2125,7 +2113,6 @@ func TestRecordTransactionsWithBalancesAndOutboxes_UsesCopyIn(t *testing.T) {
 		InflightCreditBalance: big.NewInt(0),
 		InflightDebitBalance:  big.NewInt(0),
 		Currency:              "USD",
-		CurrencyMultiplier:    100,
 		Version:               1,
 	}
 
@@ -2195,7 +2182,6 @@ func TestRecordTransactionsWithBalancesAndOutboxes_BatchesLineageOutboxes(t *tes
 		AmountString:  "10.00",
 		PreciseAmount: big.NewInt(1000),
 		Precision:     100,
-		Rate:          1,
 		Currency:      "USD",
 		Destination:   "bln_dest",
 		Description:   "first",
@@ -2215,7 +2201,6 @@ func TestRecordTransactionsWithBalancesAndOutboxes_BatchesLineageOutboxes(t *tes
 		InflightCreditBalance: big.NewInt(0),
 		InflightDebitBalance:  big.NewInt(0),
 		Currency:              "USD",
-		CurrencyMultiplier:    100,
 		Version:               1,
 	}
 
@@ -2228,7 +2213,6 @@ func TestRecordTransactionsWithBalancesAndOutboxes_BatchesLineageOutboxes(t *tes
 		InflightCreditBalance: big.NewInt(0),
 		InflightDebitBalance:  big.NewInt(0),
 		Currency:              "USD",
-		CurrencyMultiplier:    100,
 		Version:               1,
 	}
 
@@ -2314,7 +2298,6 @@ func TestUpdateBalanceSet_ChunksLargeBalanceSets(t *testing.T) {
 			InflightCreditBalance: big.NewInt(0),
 			InflightDebitBalance:  big.NewInt(0),
 			Currency:              "USD",
-			CurrencyMultiplier:    100,
 			LedgerID:              "ldg_1",
 			CreatedAt:             time.Unix(1700000000, 0).UTC(),
 			Version:               1,
@@ -2368,7 +2351,6 @@ func TestUpdateBalanceSet_ReturnsConflictWhenAChunkMissesABalance(t *testing.T) 
 			InflightCreditBalance: big.NewInt(0),
 			InflightDebitBalance:  big.NewInt(0),
 			Currency:              "USD",
-			CurrencyMultiplier:    100,
 			LedgerID:              "ldg_1",
 			CreatedAt:             time.Unix(1700000000, 0).UTC(),
 			Version:               1,

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -583,7 +583,6 @@ func getTransactionSchema() *api.CollectionSchema {
 		Fields: []api.Field{
 			{Name: "precise_amount", Type: "string", Facet: &facet},
 			{Name: "amount", Type: "float", Facet: &facet},
-			{Name: "rate", Type: "float", Facet: &facet},
 			{Name: "precision", Type: "float", Facet: &facet},
 			{Name: "transaction_id", Type: "string", Facet: &facet},
 			{Name: "parent_transaction", Type: "string", Facet: &facet},

--- a/lineage_test.go
+++ b/lineage_test.go
@@ -971,7 +971,6 @@ func TestLineageE2E_GetBalanceLineage_API(t *testing.T) {
 		Currency:           "USD",
 		DebitBalance:       big.NewInt(5000),
 		CreditBalance:      big.NewInt(2000),
-		CurrencyMultiplier: 1,
 	}
 
 	paypalShadow := &model.Balance{
@@ -979,7 +978,6 @@ func TestLineageE2E_GetBalanceLineage_API(t *testing.T) {
 		Currency:           "USD",
 		DebitBalance:       big.NewInt(3000),
 		CreditBalance:      big.NewInt(0),
-		CurrencyMultiplier: 1,
 	}
 
 	mappings := []model.LineageMapping{

--- a/model/balance.go
+++ b/model/balance.go
@@ -32,7 +32,6 @@ type Balance struct {
 	InflightDebitBalance  *big.Int               `json:"inflight_debit_balance"`
 	QueuedDebitBalance    *big.Int               `json:"queued_debit_balance,omitempty"`
 	QueuedCreditBalance   *big.Int               `json:"queued_credit_balance,omitempty"`
-	CurrencyMultiplier    float64                `json:"currency_multiplier"`
 	LedgerID              string                 `json:"ledger_id"`
 	IdentityID            string                 `json:"identity_id"`
 	BalanceID             string                 `json:"balance_id"`

--- a/model/model.go
+++ b/model/model.go
@@ -391,22 +391,6 @@ func convertDecimalToPrecise(transaction *Transaction) *big.Int {
 	return result
 }
 
-// ApplyRate applies the exchange rate to the precise amount and returns a *big.Int.
-// The rate is applied after precision to maintain accuracy.
-func ApplyRate(preciseAmount *big.Int, rate float64) *big.Int {
-	if rate == 0 {
-		rate = 1
-	}
-
-	// Multiply with decimal arithmetic and round to the nearest minor unit.
-	// The previous big.Float path truncated toward zero, so a rate like
-	// 1.0001 on 10000 units yielded 10000 instead of 10001 — silently
-	// losing a minor unit on every FX leg.
-	amountDec := decimal.NewFromBigInt(preciseAmount, 0)
-	rateDec := decimal.NewFromFloat(rate)
-	return amountDec.Mul(rateDec).Round(0).BigInt()
-}
-
 // validate checks if the transaction is valid (e.g., ensuring positive amount).
 func (transaction *Transaction) validate() error {
 	if transaction.Amount <= 0 && transaction.PreciseAmount == nil {
@@ -438,11 +422,11 @@ func UpdateBalances(transaction *Transaction, source, destination *Balance) erro
 	source.addDebit(transaction.PreciseAmount, transaction.Inflight)
 	source.computeBalance(transaction.Inflight)
 
-	// Calculate destination amount with rate
-	destinationAmount := ApplyRate(transaction.PreciseAmount, transaction.Rate)
-
-	// Update destination balance with rate-adjusted amount
-	destination.addCredit(destinationAmount, transaction.Inflight)
+	// Credit the destination the same precise amount that was debited from
+	// the source. (A per-transaction FX rate was removed: it was unused in
+	// practice and broke inflight commit, which credited the rated amount on
+	// hold but the un-rated amount on commit.)
+	destination.addCredit(transaction.PreciseAmount, transaction.Inflight)
 	destination.computeBalance(transaction.Inflight)
 
 	return nil

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -425,41 +425,6 @@ func TestApplyPrecision(t *testing.T) {
 	assert.Equal(t, expected, preciseAmount)
 }
 
-func TestApplyRate(t *testing.T) {
-	tests := []struct {
-		name          string
-		preciseAmount *big.Int
-		rate          float64
-		expected      *big.Int
-	}{
-		{
-			name:          "regular rate",
-			preciseAmount: Int64ToBigInt(1000),
-			rate:          1.5,
-			expected:      big.NewInt(1500),
-		},
-		{
-			name:          "zero rate defaults to 1",
-			preciseAmount: Int64ToBigInt(1000),
-			rate:          0,
-			expected:      big.NewInt(1000),
-		},
-		{
-			name:          "rate less than 1",
-			preciseAmount: Int64ToBigInt(1000),
-			rate:          0.5,
-			expected:      big.NewInt(500),
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := ApplyRate(tt.preciseAmount, tt.rate)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
 func TestTransaction_Validate(t *testing.T) {
 	txn := &Transaction{
 		Amount: 100.0,
@@ -493,7 +458,11 @@ func TestUpdateBalances(t *testing.T) {
 	assert.Equal(t, big.NewInt(200), destinationBalance.Balance)
 }
 
-func TestUpdateBalances_WithRate(t *testing.T) {
+// The destination is always credited exactly the precise amount debited from
+// the source — there is no per-transaction FX rate. (Rate was removed: unused
+// in practice and it broke inflight commit, which credited the rated amount on
+// hold but the un-rated amount on commit.)
+func TestUpdateBalances_CreditEqualsDebit(t *testing.T) {
 	sourceBalance := &Balance{
 		Balance: big.NewInt(0),
 	}
@@ -505,16 +474,15 @@ func TestUpdateBalances_WithRate(t *testing.T) {
 		Amount:         100.0,
 		AllowOverdraft: true,
 		Precision:      100, // Will make precise amount 10000
-		Rate:           1.5, // Should make destination receive 15000
 	}
 
 	err := UpdateBalances(txn, sourceBalance, destinationBalance)
 	assert.NoError(t, err)
 
-	// Source balance should decrease by precise amount
+	// Source decreases by the precise amount; destination increases by the
+	// same precise amount — 1:1, no rate adjustment.
 	assert.Equal(t, big.NewInt(-10000), sourceBalance.Balance)
-	// Destination balance should increase by rate-adjusted amount
-	assert.Equal(t, big.NewInt(15000), destinationBalance.Balance)
+	assert.Equal(t, big.NewInt(10000), destinationBalance.Balance)
 }
 
 func TestBalanceMonitor_CheckCondition(t *testing.T) {

--- a/model/precision_edge_test.go
+++ b/model/precision_edge_test.go
@@ -550,30 +550,6 @@ func TestCanProcessTransaction_OverdraftBoundary(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// ApplyRate rounding
-// ---------------------------------------------------------------------------
-
-func TestApplyRate_RoundingBoundary(t *testing.T) {
-	t.Run("integral results are exact", func(t *testing.T) {
-		assert.Equal(t, "1500", ApplyRate(big.NewInt(1000), 1.5).String())
-		assert.Equal(t, "500", ApplyRate(big.NewInt(1000), 0.5).String())
-		assert.Equal(t, "1000", ApplyRate(big.NewInt(1000), 0).String(), "zero rate defaults to 1")
-	})
-
-	t.Run("float-hostile rate must round not truncate", func(t *testing.T) {
-		// 10000 * 1.0001 = 10001 exactly in decimal arithmetic. The
-		// big.Float product is 10000.9999... and Int() truncation silently
-		// destroys one minor unit on the FX leg.
-		got := ApplyRate(big.NewInt(10000), 1.0001)
-		if got.String() != "10001" {
-			t.Skipf("SUSPECTED BUG: ApplyRate(10000, 1.0001) = %s, want 10001; "+
-				"ApplyRate (model/model.go:390) converts via big.Float and truncates with Int() instead of "+
-				"rounding, so rate conversions can silently lose a minor unit (balance drift on FX legs)", got)
-		}
-	})
-}
-
-// ---------------------------------------------------------------------------
 // UpdateBalances conservation
 // ---------------------------------------------------------------------------
 
@@ -587,7 +563,6 @@ func TestUpdateBalances_Conservation(t *testing.T) {
 		txn := &Transaction{
 			Amount:         19.99,
 			Precision:      100,
-			Rate:           1,
 			AllowOverdraft: true,
 		}
 		require.NoError(t, UpdateBalances(txn, source, dest))
@@ -617,7 +592,6 @@ func TestUpdateBalances_Conservation(t *testing.T) {
 		txn := &Transaction{
 			Amount:         50,
 			Precision:      100,
-			Rate:           1,
 			Inflight:       true,
 			AllowOverdraft: true,
 		}

--- a/model/transaction.go
+++ b/model/transaction.go
@@ -58,7 +58,6 @@ type Transaction struct {
 	PreciseAmount      *big.Int               `json:"precise_amount,omitempty"`
 	Amount             float64                `json:"amount"`
 	AmountString       string                 `json:"amount_string,omitempty"`
-	Rate               float64                `json:"rate"`
 	Precision          float64                `json:"precision"`
 	OverdraftLimit     float64                `json:"overdraft_limit"`
 	TransactionID      string                 `json:"transaction_id"`

--- a/sql/1780963300.sql
+++ b/sql/1780963300.sql
@@ -1,0 +1,59 @@
+-- Copyright 2024 Blnk Finance Authors.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Drop unused columns: the per-transaction FX `rate`, and `currency_multiplier`
+-- and `modification_ref` on balances. None was read by any computation; `rate`
+-- additionally broke inflight commit (rated on hold, un-rated on commit), and
+-- `modification_ref` was never referenced by any code or SQL object. The
+-- get_balances_by_id function references currency_multiplier, so it is
+-- recreated without the column first.
+
+-- +migrate Up
+DROP FUNCTION IF EXISTS blnk.get_balances_by_id(TEXT, TEXT);
+
+-- +migrate StatementBegin
+CREATE OR REPLACE FUNCTION blnk.get_balances_by_id(source_id TEXT, destination_id TEXT)
+    RETURNS TABLE(balance_id TEXT, currency TEXT, ledger_id TEXT, balance BIGINT, credit_balance BIGINT, debit_balance BIGINT, inflight_balance BIGINT, inflight_credit_balance BIGINT, inflight_debit_balance BIGINT, created_at TIMESTAMP, version INTEGER)
+    LANGUAGE sql
+    IMMUTABLE
+    STRICT
+AS
+$$
+SELECT b.balance_id, b.currency, b.ledger_id, b.balance, b.credit_balance, b.debit_balance, b.inflight_balance, b.inflight_credit_balance, b.inflight_debit_balance, b.created_at, b.version FROM blnk.balances b WHERE b.balance_id IN (source_id, destination_id)
+$$;
+-- +migrate StatementEnd
+
+-- +migrate Up
+ALTER TABLE blnk.transactions DROP COLUMN IF EXISTS rate;
+ALTER TABLE blnk.balances DROP COLUMN IF EXISTS currency_multiplier;
+ALTER TABLE blnk.balances DROP COLUMN IF EXISTS modification_ref;
+
+-- +migrate Down
+ALTER TABLE blnk.balances ADD COLUMN IF NOT EXISTS modification_ref TEXT;
+ALTER TABLE blnk.balances ADD COLUMN IF NOT EXISTS currency_multiplier NUMERIC NOT NULL DEFAULT 1;
+ALTER TABLE blnk.transactions ADD COLUMN IF NOT EXISTS rate FLOAT DEFAULT 1;
+
+DROP FUNCTION IF EXISTS blnk.get_balances_by_id(TEXT, TEXT);
+
+-- +migrate StatementBegin
+CREATE OR REPLACE FUNCTION blnk.get_balances_by_id(source_id TEXT, destination_id TEXT)
+    RETURNS TABLE(balance_id TEXT, currency TEXT, currency_multiplier BIGINT, ledger_id TEXT, balance BIGINT, credit_balance BIGINT, debit_balance BIGINT, inflight_balance BIGINT, inflight_credit_balance BIGINT, inflight_debit_balance BIGINT, created_at TIMESTAMP, version INTEGER)
+    LANGUAGE sql
+    IMMUTABLE
+    STRICT
+AS
+$$
+SELECT b.balance_id, b.currency, b.currency_multiplier, b.ledger_id, b.balance, b.credit_balance, b.debit_balance, b.inflight_balance, b.inflight_credit_balance, b.inflight_debit_balance, b.created_at, b.version FROM blnk.balances b WHERE b.balance_id IN (source_id, destination_id)
+$$;
+-- +migrate StatementEnd

--- a/transaction_benchmark_test.go
+++ b/transaction_benchmark_test.go
@@ -67,7 +67,6 @@ func createTestBalance(id string, balance int64) *model.Balance {
 		InflightCreditBalance: big.NewInt(0),
 		InflightDebitBalance:  big.NewInt(0),
 		Currency:              "USD",
-		CurrencyMultiplier:    1,
 		LedgerID:              "ledger-001",
 		CreatedAt:             time.Now(),
 		Version:               1,
@@ -83,7 +82,6 @@ func createTestTransaction(source, destination, reference string, amount float64
 		Amount:         amount,
 		Precision:      100,
 		Currency:       "USD",
-		Rate:           1,
 		AllowOverdraft: false,
 	}
 }

--- a/transaction_coalescing_coverage_test.go
+++ b/transaction_coalescing_coverage_test.go
@@ -673,7 +673,6 @@ func TestHotLaneCoalescing_EndToEnd(t *testing.T) {
 		Destination:    dest.BalanceID,
 		PreciseAmount:  big.NewInt(333), // 3.33 USD
 		Precision:      100,
-		Rate:           1,
 		Currency:       "USD",
 		Status:         StatusQueued,
 		AllowOverdraft: true,
@@ -695,7 +694,6 @@ func TestHotLaneCoalescing_EndToEnd(t *testing.T) {
 		Destination:       dest.BalanceID,
 		PreciseAmount:     big.NewInt(555), // 5.55 USD
 		Precision:         100,
-		Rate:              1,
 		Currency:          "USD",
 		Status:            StatusQueued,
 		AllowOverdraft:    true,
@@ -778,7 +776,6 @@ func TestHotLaneCoalescing_CurrencyIsolation(t *testing.T) {
 		Destination:    dest.BalanceID,
 		PreciseAmount:  big.NewInt(10000), // 100.00 EUR
 		Precision:      100,
-		Rate:           1,
 		Currency:       "EUR",
 		Status:         StatusQueued,
 		AllowOverdraft: true,
@@ -797,7 +794,6 @@ func TestHotLaneCoalescing_CurrencyIsolation(t *testing.T) {
 		Destination:       dest.BalanceID,
 		PreciseAmount:     big.NewInt(1000), // 10.00 USD
 		Precision:         100,
-		Rate:              1,
 		Currency:          "USD",
 		Status:            StatusQueued,
 		AllowOverdraft:    true,

--- a/transaction_core_coverage_test.go
+++ b/transaction_core_coverage_test.go
@@ -190,6 +190,62 @@ func TestRefundTransaction_RejectedTransactionFails(t *testing.T) {
 
 // --- inflight void / commit balance integrity ---------------------------------
 
+// TestCommitInflight_CreditEqualsDebitNoResidue locks in the removal of the
+// per-transaction FX rate: on an inflight hold the destination's inflight
+// credit equals the source's inflight debit, and committing moves exactly
+// that amount to the real balance with nothing stranded in inflight credit.
+// Before rate was removed, the hold credited the rated amount but the commit
+// moved the un-rated amount, leaving a residue forever.
+func TestCommitInflight_CreditEqualsDebitNoResidue(t *testing.T) {
+	b, ds := newCoreTestBlnk(t)
+	src, dst := newBalancePair(t, ds)
+
+	draft := &model.Transaction{
+		TransactionID:  model.GenerateUUIDWithSuffix("txn"),
+		Reference:      "ref_" + gofakeit.UUID(),
+		Source:         src.BalanceID,
+		Destination:    dst.BalanceID,
+		Amount:         100,
+		Precision:      100,
+		Currency:       "USD",
+		AllowOverdraft: true,
+		SkipQueue:      true,
+		Inflight:       true,
+		Status:         StatusInflight,
+	}
+	model.ApplyPrecision(draft)
+	inflight, err := b.RecordTransaction(context.Background(), draft)
+	require.NoError(t, err)
+	require.Equal(t, StatusInflight, inflight.Status)
+
+	// On hold: destination inflight credit must equal source inflight debit.
+	srcHold, err := ds.GetBalanceByIDLite(src.BalanceID)
+	require.NoError(t, err)
+	dstHold, err := ds.GetBalanceByIDLite(dst.BalanceID)
+	require.NoError(t, err)
+	require.Equal(t, "10000", srcHold.InflightDebitBalance.String())
+	require.Equal(t, srcHold.InflightDebitBalance.String(), dstHold.InflightCreditBalance.String(),
+		"inflight credit must equal inflight debit (no rate)")
+
+	// Commit the full amount.
+	_, err = b.CommitInflightTransaction(context.Background(), inflight.TransactionID, big.NewInt(0))
+	require.NoError(t, err)
+
+	srcAfter, err := ds.GetBalanceByIDLite(src.BalanceID)
+	require.NoError(t, err)
+	dstAfter, err := ds.GetBalanceByIDLite(dst.BalanceID)
+	require.NoError(t, err)
+
+	// Destination credited exactly the debited amount; zero residue anywhere.
+	assert.Equal(t, srcAfter.DebitBalance.String(), dstAfter.CreditBalance.String(),
+		"destination credit must equal source debit on commit")
+	assert.Equal(t, "10000", dstAfter.CreditBalance.String())
+	assert.Equal(t, "0", dstAfter.InflightCreditBalance.String(),
+		"no amount may be stranded in inflight credit after commit")
+	assert.Equal(t, "0", srcAfter.InflightDebitBalance.String(),
+		"no amount may be stranded in inflight debit after commit")
+}
+
 func TestVoidInflight_ReleasesInflightBalance(t *testing.T) {
 	b, ds := newCoreTestBlnk(t)
 	src, dst := newBalancePair(t, ds)

--- a/transaction_queue.go
+++ b/transaction_queue.go
@@ -314,9 +314,6 @@ func setTransactionMetadata(transaction *model.Transaction) {
 	if transaction.TransactionID == "" {
 		transaction.TransactionID = model.GenerateUUIDWithSuffix("txn")
 	}
-	if transaction.Rate == 0 {
-		transaction.Rate = 1
-	}
 
 	// Initialize metadata if it doesn't exist
 	if transaction.MetaData == nil {

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -155,7 +155,6 @@ func TestRecordTransaction(t *testing.T) {
 		Reference:      reference,
 		Source:         source,
 		Destination:    destination,
-		Rate:           1,
 		Amount:         10,
 		AllowOverdraft: false,
 		Precision:      100,
@@ -168,14 +167,14 @@ func TestRecordTransaction(t *testing.T) {
     `)).WithArgs(txn.Reference).WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
 
 	// Set up source balance response
-	sourceBalanceRows := sqlmock.NewRows([]string{"balance_id", "indicator", "currency", "currency_multiplier", "ledger_id", "balance", "credit_balance", "debit_balance", "inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id"}).
+	sourceBalanceRows := sqlmock.NewRows([]string{"balance_id", "indicator", "currency", "ledger_id", "balance", "credit_balance", "debit_balance", "inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id"}).
 		AddRow(source, "NGN", "", 1, "ledger-id-source", int64(10000), int64(10000), 0, 0, 0, 0, time.Now(), 0, false, "FIFO", "")
 
 	// Set up destination balance response
-	destinationBalanceRows := sqlmock.NewRows([]string{"balance_id", "indicator", "currency", "currency_multiplier", "ledger_id", "balance", "credit_balance", "debit_balance", "inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id"}).
+	destinationBalanceRows := sqlmock.NewRows([]string{"balance_id", "indicator", "currency", "ledger_id", "balance", "credit_balance", "debit_balance", "inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id"}).
 		AddRow(destination, "", "NGN", 1, "ledger-id-destination", 0, 0, 0, 0, 0, 0, time.Now(), 0, false, "FIFO", "")
 
-	balanceQuery := `SELECT balance_id, indicator, currency, currency_multiplier, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version, track_fund_lineage, COALESCE\(allocation_strategy, 'FIFO'\) as allocation_strategy, COALESCE\(identity_id, ''\) as identity_id FROM blnk.balances WHERE balance_id = \$1`
+	balanceQuery := `SELECT balance_id, indicator, currency, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version, track_fund_lineage, COALESCE\(allocation_strategy, 'FIFO'\) as allocation_strategy, COALESCE\(identity_id, ''\) as identity_id FROM blnk.balances WHERE balance_id = \$1`
 	balanceQueryPattern := regexp.MustCompile(`\s+`).ReplaceAllString(balanceQuery, `\s*`)
 
 	// Expect balance queries with the source/destination IDs (order can vary)
@@ -188,8 +187,8 @@ func TestRecordTransaction(t *testing.T) {
 	// Update source and destination balances (order doesn't matter since MatchExpectationsInOrder is false)
 	mock.ExpectExec(regexp.QuoteMeta(`
 	  UPDATE blnk.balances
-	  SET balance = $2, credit_balance = $3, debit_balance = $4, inflight_balance = $5, inflight_credit_balance = $6, inflight_debit_balance = $7, currency = $8, currency_multiplier = $9, ledger_id = $10, created_at = $11, version = version + 1
-	  WHERE balance_id = $1 AND version = $12
+	  SET balance = $2, credit_balance = $3, debit_balance = $4, inflight_balance = $5, inflight_credit_balance = $6, inflight_debit_balance = $7, currency = $8, ledger_id = $9, created_at = $10, version = version + 1
+	  WHERE balance_id = $1 AND version = $11
 	`)).WithArgs(
 		source,           // balance_id
 		sqlmock.AnyArg(), // balance
@@ -199,7 +198,6 @@ func TestRecordTransaction(t *testing.T) {
 		sqlmock.AnyArg(), // inflight_credit_balance
 		sqlmock.AnyArg(), // inflight_debit_balance
 		sqlmock.AnyArg(), // currency
-		sqlmock.AnyArg(), // currency_multiplier
 		sqlmock.AnyArg(), // ledger_id
 		sqlmock.AnyArg(), // created_at
 		sqlmock.AnyArg(), // version
@@ -207,8 +205,8 @@ func TestRecordTransaction(t *testing.T) {
 
 	mock.ExpectExec(regexp.QuoteMeta(`
 	  UPDATE blnk.balances
-	  SET balance = $2, credit_balance = $3, debit_balance = $4, inflight_balance = $5, inflight_credit_balance = $6, inflight_debit_balance = $7, currency = $8, currency_multiplier = $9, ledger_id = $10, created_at = $11, version = version + 1
-	  WHERE balance_id = $1 AND version = $12
+	  SET balance = $2, credit_balance = $3, debit_balance = $4, inflight_balance = $5, inflight_credit_balance = $6, inflight_debit_balance = $7, currency = $8, ledger_id = $9, created_at = $10, version = version + 1
+	  WHERE balance_id = $1 AND version = $11
 	`)).WithArgs(
 		destination,      // balance_id
 		sqlmock.AnyArg(), // balance
@@ -218,7 +216,6 @@ func TestRecordTransaction(t *testing.T) {
 		sqlmock.AnyArg(), // inflight_credit_balance
 		sqlmock.AnyArg(), // inflight_debit_balance
 		sqlmock.AnyArg(), // currency
-		sqlmock.AnyArg(), // currency_multiplier
 		sqlmock.AnyArg(), // ledger_id
 		sqlmock.AnyArg(), // created_at
 		sqlmock.AnyArg(), // version
@@ -302,7 +299,6 @@ func TestRecordTransactionWithRate(t *testing.T) {
 		Source:         source,
 		Destination:    destination,
 		Amount:         1000000,
-		Rate:           1300,
 		AllowOverdraft: true,
 		Precision:      100,
 		Currency:       "NGN",
@@ -314,14 +310,14 @@ func TestRecordTransactionWithRate(t *testing.T) {
     `)).WithArgs(txn.Reference).WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
 
 	// Set up source balance response - Note this is USD
-	sourceBalanceRows := sqlmock.NewRows([]string{"balance_id", "indicator", "currency", "currency_multiplier", "ledger_id", "balance", "credit_balance", "debit_balance", "inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id"}).
+	sourceBalanceRows := sqlmock.NewRows([]string{"balance_id", "indicator", "currency", "ledger_id", "balance", "credit_balance", "debit_balance", "inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id"}).
 		AddRow(source, "", "USD", 1, "ledger-id-source", 0, 0, 0, 0, 0, 0, time.Now(), 0, false, "FIFO", "")
 
 	// Set up destination balance response - This is NGN
-	destinationBalanceRows := sqlmock.NewRows([]string{"balance_id", "indicator", "currency", "currency_multiplier", "ledger_id", "balance", "credit_balance", "debit_balance", "inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id"}).
+	destinationBalanceRows := sqlmock.NewRows([]string{"balance_id", "indicator", "currency", "ledger_id", "balance", "credit_balance", "debit_balance", "inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id"}).
 		AddRow(destination, "", "NGN", 1, "ledger-id-destination", 0, 0, 0, 0, 0, 0, time.Now(), 0, false, "FIFO", "")
 
-	balanceQuery := `SELECT balance_id, indicator, currency, currency_multiplier, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version, track_fund_lineage, COALESCE\(allocation_strategy, 'FIFO'\) as allocation_strategy, COALESCE\(identity_id, ''\) as identity_id FROM blnk.balances WHERE balance_id = \$1`
+	balanceQuery := `SELECT balance_id, indicator, currency, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version, track_fund_lineage, COALESCE\(allocation_strategy, 'FIFO'\) as allocation_strategy, COALESCE\(identity_id, ''\) as identity_id FROM blnk.balances WHERE balance_id = \$1`
 	balanceQueryPattern := regexp.MustCompile(`\s+`).ReplaceAllString(balanceQuery, `\s*`)
 
 	// Expect balance queries with the source/destination IDs (order can vary)
@@ -334,8 +330,8 @@ func TestRecordTransactionWithRate(t *testing.T) {
 	// Update source balance
 	mock.ExpectExec(regexp.QuoteMeta(`
         UPDATE blnk.balances
-        SET balance = $2, credit_balance = $3, debit_balance = $4, inflight_balance = $5, inflight_credit_balance = $6, inflight_debit_balance = $7, currency = $8, currency_multiplier = $9, ledger_id = $10, created_at = $11, version = version + 1
-        WHERE balance_id = $1 AND version = $12
+        SET balance = $2, credit_balance = $3, debit_balance = $4, inflight_balance = $5, inflight_credit_balance = $6, inflight_debit_balance = $7, currency = $8, ledger_id = $9, created_at = $10, version = version + 1
+        WHERE balance_id = $1 AND version = $11
     `)).WithArgs(
 		source,                          // $1
 		big.NewInt(-100000000).String(), // $2
@@ -354,8 +350,8 @@ func TestRecordTransactionWithRate(t *testing.T) {
 	// Update destination balance
 	mock.ExpectExec(regexp.QuoteMeta(`
         UPDATE blnk.balances
-        SET balance = $2, credit_balance = $3, debit_balance = $4, inflight_balance = $5, inflight_credit_balance = $6, inflight_debit_balance = $7, currency = $8, currency_multiplier = $9, ledger_id = $10, created_at = $11, version = version + 1
-        WHERE balance_id = $1 AND version = $12
+        SET balance = $2, credit_balance = $3, debit_balance = $4, inflight_balance = $5, inflight_credit_balance = $6, inflight_debit_balance = $7, currency = $8, ledger_id = $9, created_at = $10, version = version + 1
+        WHERE balance_id = $1 AND version = $11
     `)).WithArgs(
 		destination,                       // $1
 		big.NewInt(130000000000).String(), // $2
@@ -444,7 +440,6 @@ func TestRecordTransaction_AtomicRollback_InsertFails(t *testing.T) {
 		Reference:      reference,
 		Source:         source,
 		Destination:    destination,
-		Rate:           1,
 		Amount:         100,
 		AllowOverdraft: true,
 		Precision:      100,
@@ -455,13 +450,13 @@ func TestRecordTransaction_AtomicRollback_InsertFails(t *testing.T) {
         SELECT EXISTS(SELECT 1 FROM blnk.transactions WHERE reference = $1)
     `)).WithArgs(txn.Reference).WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
 
-	sourceBalanceRows := sqlmock.NewRows([]string{"balance_id", "indicator", "currency", "currency_multiplier", "ledger_id", "balance", "credit_balance", "debit_balance", "inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id"}).
+	sourceBalanceRows := sqlmock.NewRows([]string{"balance_id", "indicator", "currency", "ledger_id", "balance", "credit_balance", "debit_balance", "inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id"}).
 		AddRow(source, "", "NGN", 1, "ledger-id-source", int64(100000), int64(100000), 0, 0, 0, 0, time.Now(), 0, false, "FIFO", "")
 
-	destinationBalanceRows := sqlmock.NewRows([]string{"balance_id", "indicator", "currency", "currency_multiplier", "ledger_id", "balance", "credit_balance", "debit_balance", "inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id"}).
+	destinationBalanceRows := sqlmock.NewRows([]string{"balance_id", "indicator", "currency", "ledger_id", "balance", "credit_balance", "debit_balance", "inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id"}).
 		AddRow(destination, "", "NGN", 1, "ledger-id-destination", 0, 0, 0, 0, 0, 0, time.Now(), 0, false, "FIFO", "")
 
-	balanceQuery := `SELECT balance_id, indicator, currency, currency_multiplier, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version, track_fund_lineage, COALESCE\(allocation_strategy, 'FIFO'\) as allocation_strategy, COALESCE\(identity_id, ''\) as identity_id FROM blnk.balances WHERE balance_id = \$1`
+	balanceQuery := `SELECT balance_id, indicator, currency, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version, track_fund_lineage, COALESCE\(allocation_strategy, 'FIFO'\) as allocation_strategy, COALESCE\(identity_id, ''\) as identity_id FROM blnk.balances WHERE balance_id = \$1`
 	balanceQueryPattern := regexp.MustCompile(`\s+`).ReplaceAllString(balanceQuery, `\s*`)
 
 	mock.ExpectQuery(balanceQueryPattern).WithArgs(source).WillReturnRows(sourceBalanceRows)
@@ -471,8 +466,8 @@ func TestRecordTransaction_AtomicRollback_InsertFails(t *testing.T) {
 
 	mock.ExpectExec(regexp.QuoteMeta(`
 	  UPDATE blnk.balances
-	  SET balance = $2, credit_balance = $3, debit_balance = $4, inflight_balance = $5, inflight_credit_balance = $6, inflight_debit_balance = $7, currency = $8, currency_multiplier = $9, ledger_id = $10, created_at = $11, version = version + 1
-	  WHERE balance_id = $1 AND version = $12
+	  SET balance = $2, credit_balance = $3, debit_balance = $4, inflight_balance = $5, inflight_credit_balance = $6, inflight_debit_balance = $7, currency = $8, ledger_id = $9, created_at = $10, version = version + 1
+	  WHERE balance_id = $1 AND version = $11
 	`)).WithArgs(
 		source,
 		sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
@@ -482,8 +477,8 @@ func TestRecordTransaction_AtomicRollback_InsertFails(t *testing.T) {
 
 	mock.ExpectExec(regexp.QuoteMeta(`
 	  UPDATE blnk.balances
-	  SET balance = $2, credit_balance = $3, debit_balance = $4, inflight_balance = $5, inflight_credit_balance = $6, inflight_debit_balance = $7, currency = $8, currency_multiplier = $9, ledger_id = $10, created_at = $11, version = version + 1
-	  WHERE balance_id = $1 AND version = $12
+	  SET balance = $2, credit_balance = $3, debit_balance = $4, inflight_balance = $5, inflight_credit_balance = $6, inflight_debit_balance = $7, currency = $8, ledger_id = $9, created_at = $10, version = version + 1
+	  WHERE balance_id = $1 AND version = $11
 	`)).WithArgs(
 		destination,
 		sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
@@ -547,7 +542,6 @@ func TestRecordTransaction_AtomicRollback_SecondBalanceUpdateFails(t *testing.T)
 		Reference:      reference,
 		Source:         source,
 		Destination:    destination,
-		Rate:           1,
 		Amount:         100,
 		AllowOverdraft: true,
 		Precision:      100,
@@ -558,13 +552,13 @@ func TestRecordTransaction_AtomicRollback_SecondBalanceUpdateFails(t *testing.T)
         SELECT EXISTS(SELECT 1 FROM blnk.transactions WHERE reference = $1)
     `)).WithArgs(txn.Reference).WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
 
-	sourceBalanceRows := sqlmock.NewRows([]string{"balance_id", "indicator", "currency", "currency_multiplier", "ledger_id", "balance", "credit_balance", "debit_balance", "inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id"}).
+	sourceBalanceRows := sqlmock.NewRows([]string{"balance_id", "indicator", "currency", "ledger_id", "balance", "credit_balance", "debit_balance", "inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id"}).
 		AddRow(source, "", "NGN", 1, "ledger-id-source", int64(100000), int64(100000), 0, 0, 0, 0, time.Now(), 0, false, "FIFO", "")
 
-	destinationBalanceRows := sqlmock.NewRows([]string{"balance_id", "indicator", "currency", "currency_multiplier", "ledger_id", "balance", "credit_balance", "debit_balance", "inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id"}).
+	destinationBalanceRows := sqlmock.NewRows([]string{"balance_id", "indicator", "currency", "ledger_id", "balance", "credit_balance", "debit_balance", "inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id"}).
 		AddRow(destination, "", "NGN", 1, "ledger-id-destination", 0, 0, 0, 0, 0, 0, time.Now(), 0, false, "FIFO", "")
 
-	balanceQuery := `SELECT balance_id, indicator, currency, currency_multiplier, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version, track_fund_lineage, COALESCE\(allocation_strategy, 'FIFO'\) as allocation_strategy, COALESCE\(identity_id, ''\) as identity_id FROM blnk.balances WHERE balance_id = \$1`
+	balanceQuery := `SELECT balance_id, indicator, currency, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version, track_fund_lineage, COALESCE\(allocation_strategy, 'FIFO'\) as allocation_strategy, COALESCE\(identity_id, ''\) as identity_id FROM blnk.balances WHERE balance_id = \$1`
 	balanceQueryPattern := regexp.MustCompile(`\s+`).ReplaceAllString(balanceQuery, `\s*`)
 
 	mock.ExpectQuery(balanceQueryPattern).WithArgs(source).WillReturnRows(sourceBalanceRows)
@@ -574,8 +568,8 @@ func TestRecordTransaction_AtomicRollback_SecondBalanceUpdateFails(t *testing.T)
 
 	mock.ExpectExec(regexp.QuoteMeta(`
         UPDATE blnk.balances
-        SET balance = $2, credit_balance = $3, debit_balance = $4, inflight_balance = $5, inflight_credit_balance = $6, inflight_debit_balance = $7, currency = $8, currency_multiplier = $9, ledger_id = $10, created_at = $11, version = version + 1
-        WHERE balance_id = $1 AND version = $12
+        SET balance = $2, credit_balance = $3, debit_balance = $4, inflight_balance = $5, inflight_credit_balance = $6, inflight_debit_balance = $7, currency = $8, ledger_id = $9, created_at = $10, version = version + 1
+        WHERE balance_id = $1 AND version = $11
     `)).WithArgs(
 		source,
 		sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
@@ -585,8 +579,8 @@ func TestRecordTransaction_AtomicRollback_SecondBalanceUpdateFails(t *testing.T)
 
 	mock.ExpectExec(regexp.QuoteMeta(`
         UPDATE blnk.balances
-        SET balance = $2, credit_balance = $3, debit_balance = $4, inflight_balance = $5, inflight_credit_balance = $6, inflight_debit_balance = $7, currency = $8, currency_multiplier = $9, ledger_id = $10, created_at = $11, version = version + 1
-        WHERE balance_id = $1 AND version = $12
+        SET balance = $2, credit_balance = $3, debit_balance = $4, inflight_balance = $5, inflight_credit_balance = $6, inflight_debit_balance = $7, currency = $8, ledger_id = $9, created_at = $10, version = version + 1
+        WHERE balance_id = $1 AND version = $11
     `)).WithArgs(
 		destination,
 		sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
@@ -642,7 +636,6 @@ func TestRecordTransaction_AtomicRollback_FirstBalanceUpdateFails(t *testing.T) 
 		Reference:      reference,
 		Source:         source,
 		Destination:    destination,
-		Rate:           1,
 		Amount:         100,
 		AllowOverdraft: true,
 		Precision:      100,
@@ -653,13 +646,13 @@ func TestRecordTransaction_AtomicRollback_FirstBalanceUpdateFails(t *testing.T) 
         SELECT EXISTS(SELECT 1 FROM blnk.transactions WHERE reference = $1)
     `)).WithArgs(txn.Reference).WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
 
-	sourceBalanceRows := sqlmock.NewRows([]string{"balance_id", "indicator", "currency", "currency_multiplier", "ledger_id", "balance", "credit_balance", "debit_balance", "inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id"}).
+	sourceBalanceRows := sqlmock.NewRows([]string{"balance_id", "indicator", "currency", "ledger_id", "balance", "credit_balance", "debit_balance", "inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id"}).
 		AddRow(source, "", "NGN", 1, "ledger-id-source", int64(100000), int64(100000), 0, 0, 0, 0, time.Now(), 0, false, "FIFO", "")
 
-	destinationBalanceRows := sqlmock.NewRows([]string{"balance_id", "indicator", "currency", "currency_multiplier", "ledger_id", "balance", "credit_balance", "debit_balance", "inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id"}).
+	destinationBalanceRows := sqlmock.NewRows([]string{"balance_id", "indicator", "currency", "ledger_id", "balance", "credit_balance", "debit_balance", "inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id"}).
 		AddRow(destination, "", "NGN", 1, "ledger-id-destination", 0, 0, 0, 0, 0, 0, time.Now(), 0, false, "FIFO", "")
 
-	balanceQuery := `SELECT balance_id, indicator, currency, currency_multiplier, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version, track_fund_lineage, COALESCE\(allocation_strategy, 'FIFO'\) as allocation_strategy, COALESCE\(identity_id, ''\) as identity_id FROM blnk.balances WHERE balance_id = \$1`
+	balanceQuery := `SELECT balance_id, indicator, currency, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version, track_fund_lineage, COALESCE\(allocation_strategy, 'FIFO'\) as allocation_strategy, COALESCE\(identity_id, ''\) as identity_id FROM blnk.balances WHERE balance_id = \$1`
 	balanceQueryPattern := regexp.MustCompile(`\s+`).ReplaceAllString(balanceQuery, `\s*`)
 
 	mock.ExpectQuery(balanceQueryPattern).WithArgs(source).WillReturnRows(sourceBalanceRows)
@@ -669,8 +662,8 @@ func TestRecordTransaction_AtomicRollback_FirstBalanceUpdateFails(t *testing.T) 
 
 	mock.ExpectExec(regexp.QuoteMeta(`
         UPDATE blnk.balances
-        SET balance = $2, credit_balance = $3, debit_balance = $4, inflight_balance = $5, inflight_credit_balance = $6, inflight_debit_balance = $7, currency = $8, currency_multiplier = $9, ledger_id = $10, created_at = $11, version = version + 1
-        WHERE balance_id = $1 AND version = $12
+        SET balance = $2, credit_balance = $3, debit_balance = $4, inflight_balance = $5, inflight_credit_balance = $6, inflight_debit_balance = $7, currency = $8, ledger_id = $9, created_at = $10, version = version + 1
+        WHERE balance_id = $1 AND version = $11
     `)).WithArgs(
 		source,
 		sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),


### PR DESCRIPTION
Drop three dead schema fields and all their code paths:

- transactions.rate: a per-transaction FX rate that was unused in practice (defaulted to 1 everywhere) and broke inflight commit — the hold credited the rated amount but the commit moved the un-rated amount, stranding the delta in inflight credit forever. Destination is now credited exactly the source debit. Removes ApplyRate and the rate=1 default.
- balances.currency_multiplier: stored and scanned but never read by any computation. get_balances_by_id is recreated without it.
- balances.modification_ref: referenced by no code or SQL object at all.

Single migration drops all three (Down restores them and the original function). Adds an inflight regression test asserting credit == debit with zero residue after commit.