### PR TITLE
Queue inflight commit/void by default with idempotency and skip_queue

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -89,3 +89,66 @@ jobs:
         run: go test -v -p 1 ./...
         env:
           BLNK_TYPESENSE_DNS: http://localhost:8108
+
+  race:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:latest
+        env:
+          POSTGRES_DB: blnk
+          POSTGRES_USER: postgres
+          POSTGRES_HOST_AUTH_METHOD: trust
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+      redis:
+        image: redis:latest
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+      typesense:
+        image: typesense/typesense:29.0
+        env:
+          TYPESENSE_API_KEY: blnk-api-key
+          TYPESENSE_DATA_DIR: /tmp
+        ports:
+          - 8108:8108
+        options: >-
+          --health-cmd "bash -c 'exec 3<>/dev/tcp/127.0.0.1/8108 && printf \"GET /health HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n\" >&3 && grep -q \"200 OK\" <&3'"
+          --health-interval 30s
+          --health-timeout 10s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.25.0
+
+      - name: Tidy
+        run: go mod tidy
+
+      - name: Migrate Database
+        run: go run ./cmd migrate up
+        env:
+          BLNK_DATA_SOURCE_DNS: postgres://postgres@localhost:5432/blnk?sslmode=disable
+          BLNK_REDIS_DNS: localhost:6379
+
+      - name: Test (race detector)
+        run: go test -race -p 1 ./...
+        env:
+          BLNK_TYPESENSE_DNS: http://localhost:8108

--- a/api/inflight_queue_test.go
+++ b/api/inflight_queue_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2024 Blnk Finance Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package api
+
+import (
+	"bytes"
+	"context"
+	"math/big"
+	"net/http"
+	"testing"
+
+	model2 "github.com/blnkfinance/blnk/api/model"
+	"github.com/blnkfinance/blnk/internal/request"
+	"github.com/blnkfinance/blnk/model"
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestInflightCommit_QueuedByDefault proves the default (no skip_queue) commit is
+// enqueued, not applied: the response is the still-inflight parent with
+// queued:true, the DB row stays INFLIGHT (no worker running), and a second
+// commit while the first is queued is rejected with 409.
+func TestInflightCommit_QueuedByDefault(t *testing.T) {
+	router, b, err := setupRouter()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	ledger, err := b.CreateLedger(model.Ledger{Name: gofakeit.Name()})
+	require.NoError(t, err)
+	src, err := b.CreateBalance(ctx, model.Balance{LedgerID: ledger.LedgerID, Currency: "USD"})
+	require.NoError(t, err)
+	dst, err := b.CreateBalance(ctx, model.Balance{LedgerID: ledger.LedgerID, Currency: "USD"})
+	require.NoError(t, err)
+
+	txnID := createInflightForBulk(t, router, src.BalanceID, dst.BalanceID, "USD", 100)
+
+	commitBody := func() *bytes.Buffer {
+		body, _ := request.ToJsonReq(&model2.InflightUpdate{Status: "commit"})
+		return body
+	}
+
+	var resp map[string]interface{}
+	rec, err := SetUpTestRequest(TestRequest{
+		Payload:  commitBody(),
+		Response: &resp,
+		Method:   "PUT",
+		Route:    "/transactions/inflight/" + txnID,
+		Router:   router,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, true, resp["queued"], "queued commit must be marked queued")
+	assert.Equal(t, "INFLIGHT", resp["status"], "response is the still-inflight parent")
+
+	dbTxn, err := b.GetTransaction(ctx, txnID)
+	require.NoError(t, err)
+	assert.Equal(t, "INFLIGHT", dbTxn.Status, "no worker running, so the row stays INFLIGHT")
+
+	// Second commit while the first is still queued -> 409.
+	var resp2 map[string]interface{}
+	rec2, err := SetUpTestRequest(TestRequest{
+		Payload:  commitBody(),
+		Response: &resp2,
+		Method:   "PUT",
+		Route:    "/transactions/inflight/" + txnID,
+		Router:   router,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusConflict, rec2.Code, "a second queued commit must be rejected")
+}
+
+// TestRunInflightActionByParent_PartialCommitIdempotent drives the worker
+// entrypoint directly: a partial commit replayed with the same ActionID must not
+// double-apply — the deterministic per-leg reference collides on the unique index
+// and the leg is skipped, leaving balances unchanged.
+func TestRunInflightActionByParent_PartialCommitIdempotent(t *testing.T) {
+	router, b, err := setupRouter()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	ledger, err := b.CreateLedger(model.Ledger{Name: gofakeit.Name()})
+	require.NoError(t, err)
+	src, err := b.CreateBalance(ctx, model.Balance{LedgerID: ledger.LedgerID, Currency: "USD"})
+	require.NoError(t, err)
+	dst, err := b.CreateBalance(ctx, model.Balance{LedgerID: ledger.LedgerID, Currency: "USD"})
+	require.NoError(t, err)
+
+	// Amount 100 @ precision 100 -> precise 10000.
+	txnID := createInflightForBulk(t, router, src.BalanceID, dst.BalanceID, "USD", 100)
+
+	actionID := "act_" + gofakeit.UUID()
+	partial := big.NewInt(5000)
+
+	// balances reads both legs and asserts the committed (main) balances.
+	balances := func(t *testing.T, wantSrc, wantDst string, msg string) {
+		t.Helper()
+		s, err := b.GetBalanceByID(ctx, src.BalanceID, nil, false)
+		require.NoError(t, err)
+		d, err := b.GetBalanceByID(ctx, dst.BalanceID, nil, false)
+		require.NoError(t, err)
+		assert.Equal(t, wantSrc, s.Balance.String(), "source "+msg)
+		assert.Equal(t, wantDst, d.Balance.String(), "destination "+msg)
+	}
+
+	// First partial commit moves exactly 5000 from source to destination.
+	retryable, err := b.RunInflightActionByParent(ctx, txnID, "commit", partial, actionID)
+	require.NoError(t, err)
+	assert.False(t, retryable)
+	balances(t, "-5000", "5000", "after first commit")
+
+	// Replay with the same ActionID and amount: idempotent no-op. Both legs must
+	// be unchanged — the deterministic per-leg reference collides on the unique
+	// index, so nothing is re-applied.
+	retryable2, err := b.RunInflightActionByParent(ctx, txnID, "commit", partial, actionID)
+	require.NoError(t, err, "a replayed partial commit must not error out the task")
+	assert.False(t, retryable2)
+	balances(t, "-5000", "5000", "after replay must be unchanged")
+}

--- a/api/model/transaction.go
+++ b/api/model/transaction.go
@@ -77,6 +77,9 @@ type InflightUpdate struct {
 	Status        string   `json:"status"`
 	Amount        float64  `json:"amount"`
 	PreciseAmount *big.Int `json:"precise_amount,omitempty"`
+	// SkipQueue processes the commit/void synchronously instead of routing it
+	// through the inflight-commit queue (the default).
+	SkipQueue bool `json:"skip_queue"`
 }
 
 // MaxBulkInflightItems caps the number of transactions accepted in a single
@@ -101,6 +104,9 @@ const MaxInstantReconciliationItems = 10000
 // of the batch.
 type BulkInflightVoidRequest struct {
 	TransactionIDs []string `json:"transaction_ids"`
+	// SkipQueue processes every item synchronously instead of routing them
+	// through the inflight-commit queue (the default).
+	SkipQueue bool `json:"skip_queue"`
 }
 
 // BulkInflightCommitItem describes one transaction in a bulk commit request.
@@ -118,6 +124,9 @@ type BulkInflightCommitItem struct {
 // its own amount for partial commits.
 type BulkInflightCommitRequest struct {
 	Transactions []BulkInflightCommitItem `json:"transactions"`
+	// SkipQueue processes every item synchronously instead of routing them
+	// through the inflight-commit queue (the default).
+	SkipQueue bool `json:"skip_queue"`
 }
 
 // BulkInflightResult is the per-item outcome reported in BulkInflightResponse.

--- a/api/transaction_api_test.go
+++ b/api/transaction_api_test.go
@@ -595,6 +595,7 @@ func TestInflightTransaction_Commit_API(t *testing.T) {
 	commitPayload := model2.InflightUpdate{
 		Status:        "commit",
 		PreciseAmount: inflightTxResponse.PreciseAmount,
+		SkipQueue:     true,
 	}
 	commitPayloadBytes, _ := request.ToJsonReq(&commitPayload)
 	var commitTxResponse model.Transaction
@@ -691,7 +692,8 @@ func TestInflightTransaction_Void_API(t *testing.T) {
 
 	// 3. Void Transaction
 	voidPayload := model2.InflightUpdate{
-		Status: "void",
+		Status:    "void",
+		SkipQueue: true,
 		// Amount is not strictly needed for void, but API might expect it or use precise_amount from original txn
 	}
 	voidPayloadBytes, _ := request.ToJsonReq(&voidPayload)
@@ -801,8 +803,9 @@ func TestInflightTransaction_Commit_WithAmount_API(t *testing.T) {
 	// 3. Partially Commit Transaction using Amount (float64)
 	partialAmountFloat := 100.25 // Changed to include decimals
 	commitPartialPayload := model2.InflightUpdate{
-		Status: "commit",
-		Amount: partialAmountFloat, // Using Amount (float64) instead of PreciseAmount
+		Status:    "commit",
+		Amount:    partialAmountFloat, // Using Amount (float64) instead of PreciseAmount
+		SkipQueue: true,
 	}
 	commitPartialPayloadBytes, _ := request.ToJsonReq(&commitPartialPayload)
 	var commitPartialTxResponse model.Transaction
@@ -843,7 +846,8 @@ func TestInflightTransaction_Commit_WithAmount_API(t *testing.T) {
 
 	// 5. Commit Remaining Transaction (by not specifying amount or precise_amount in payload)
 	commitRemainingPayload := model2.InflightUpdate{
-		Status: "commit",
+		Status:    "commit",
+		SkipQueue: true,
 		// Amount: 0.0, // Can be explicit 0.0 or absent due to omitempty
 		// PreciseAmount is nil by default
 	}
@@ -1036,7 +1040,7 @@ func TestBulkVoidInflight_Integration(t *testing.T) {
 	}
 
 	// 2. Bulk-void them
-	voidReq := model2.BulkInflightVoidRequest{TransactionIDs: ids}
+	voidReq := model2.BulkInflightVoidRequest{TransactionIDs: ids, SkipQueue: true}
 	voidBytes, _ := request.ToJsonReq(&voidReq)
 	var voidResp model2.BulkInflightResponse
 	rec, err := SetUpTestRequest(TestRequest{
@@ -1113,6 +1117,7 @@ func TestBulkCommitInflight_Integration(t *testing.T) {
 	// 2. Bulk-commit them, plus a deliberately-unknown id to verify partial
 	//    failure handling.
 	commitReq := model2.BulkInflightCommitRequest{
+		SkipQueue: true,
 		Transactions: []model2.BulkInflightCommitItem{
 			{TransactionID: id1},
 			{TransactionID: id2},

--- a/api/transactions.go
+++ b/api/transactions.go
@@ -16,6 +16,7 @@ limitations under the License.
 package api
 
 import (
+	"context"
 	"errors"
 	"io"
 	"math/big"
@@ -418,7 +419,29 @@ func (a Api) UpdateInflightStatus(c *gin.Context) {
 	}
 
 	status := req.Status
-	if status == "commit" {
+	if status != blnk.InflightActionCommit && status != blnk.InflightActionVoid {
+		respondCode(c, apierror.ErrTxnInvalidStatusAction, "status not supported. use either commit or void", nil)
+		return
+	}
+
+	// Default: route the action through the inflight-commit queue. The response
+	// is the still-inflight parent plus a queued marker; the worker applies it.
+	if !req.SkipQueue {
+		parent, err := a.blnk.QueueInflightAction(c.Request.Context(), id, amount, status)
+		if err != nil {
+			if errors.Is(err, blnk.ErrInflightActionQueued) {
+				respondCode(c, apierror.ErrGenConflict, "a commit or void is already queued for this transaction", nil)
+				return
+			}
+			respondError(c, err, withUpgrade(apierror.ErrGenNotFound, apierror.ErrTxnNotFound), withDefault(apierror.ErrGenBadRequest))
+			return
+		}
+		c.JSON(http.StatusOK, queuedInflightResponse{Transaction: transformTransaction(parent), Queued: true})
+		return
+	}
+
+	// skip_queue: process synchronously (legacy behavior).
+	if status == blnk.InflightActionCommit {
 		transaction, err := a.blnk.ProcessTransactionInBatches(c.Request.Context(), id, amount, 1, false, a.blnk.GetInflightTransactionsByParentID, a.blnk.CommitWorker)
 		if err != nil {
 			respondError(c, err, withUpgrade(apierror.ErrGenNotFound, apierror.ErrTxnNotFound), withDefault(apierror.ErrGenBadRequest))
@@ -429,7 +452,7 @@ func (a Api) UpdateInflightStatus(c *gin.Context) {
 			return
 		}
 		resp = transformTransaction(transaction[0])
-	} else if status == "void" {
+	} else {
 		transaction, err := a.blnk.ProcessTransactionInBatches(c.Request.Context(), id, amount, 1, false, a.blnk.GetInflightTransactionsByParentID, a.blnk.VoidWorker)
 		if err != nil {
 			respondError(c, err, withUpgrade(apierror.ErrGenNotFound, apierror.ErrTxnNotFound), withDefault(apierror.ErrGenBadRequest))
@@ -440,12 +463,18 @@ func (a Api) UpdateInflightStatus(c *gin.Context) {
 			return
 		}
 		resp = transformTransaction(transaction[0])
-	} else {
-		respondCode(c, apierror.ErrTxnInvalidStatusAction, "status not supported. use either commit or void", nil)
-		return
 	}
 
 	c.JSON(http.StatusOK, resp)
+}
+
+// queuedInflightResponse is the body returned when a commit/void is queued. The
+// embedded transaction promotes all its fields to the top level (unchanged for
+// existing clients); `queued` marks that the action was accepted but not yet
+// applied (the transaction is still INFLIGHT).
+type queuedInflightResponse struct {
+	*model.Transaction
+	Queued bool `json:"queued"`
 }
 
 // CreateBulkTransactions handles the creation of multiple transactions in a batch.
@@ -625,6 +654,11 @@ func (a Api) BulkVoidInflight(c *gin.Context) {
 		items[i] = blnk.BulkInflightItem{TransactionID: id}
 	}
 
+	if !req.SkipQueue {
+		c.JSON(http.StatusOK, a.queueBulkInflight(c.Request.Context(), blnk.InflightActionVoid, items))
+		return
+	}
+
 	outcomes, err := a.blnk.BulkInflightUpdate(c.Request.Context(), blnk.BulkInflightVoid, items, bulkInflightMaxWorkers)
 	if err != nil {
 		respondError(c, err, withDefault(apierror.ErrGenBadRequest))
@@ -632,6 +666,29 @@ func (a Api) BulkVoidInflight(c *gin.Context) {
 	}
 	resp, _ := toAPIResults(outcomes)
 	c.JSON(http.StatusOK, resp)
+}
+
+// queueBulkInflight enqueues a commit/void per item and builds the per-item
+// response: QUEUED on success, ALREADY_QUEUED when one is already in flight
+// (both count as accepted), and a classified failure code if pre-validation
+// rejects the item synchronously.
+func (a Api) queueBulkInflight(ctx context.Context, action string, items []blnk.BulkInflightItem) model2.BulkInflightResponse {
+	resp := model2.BulkInflightResponse{Results: make([]model2.BulkInflightResult, 0, len(items))}
+	for _, it := range items {
+		_, err := a.blnk.QueueInflightAction(ctx, it.TransactionID, it.Amount, action)
+		switch {
+		case err == nil:
+			resp.Results = append(resp.Results, model2.BulkInflightResult{TransactionID: it.TransactionID, Status: "queued", Code: "QUEUED"})
+			resp.Succeeded++
+		case errors.Is(err, blnk.ErrInflightActionQueued):
+			resp.Results = append(resp.Results, model2.BulkInflightResult{TransactionID: it.TransactionID, Status: "queued", Code: "ALREADY_QUEUED", Message: err.Error()})
+			resp.Succeeded++
+		default:
+			resp.Results = append(resp.Results, model2.BulkInflightResult{TransactionID: it.TransactionID, Status: "failed", Code: blnk.ClassifyInflightError(err), Message: err.Error()})
+			resp.Failed++
+		}
+	}
+	return resp
 }
 
 // BulkCommitInflight commits many independently-created inflight
@@ -679,6 +736,11 @@ func (a Api) BulkCommitInflight(c *gin.Context) {
 			amount = model.ApplyPrecisionWithDBLookup(&model.Transaction{Amount: it.Amount, TransactionID: it.TransactionID}, ds.Conn)
 		}
 		items[i] = blnk.BulkInflightItem{TransactionID: it.TransactionID, Amount: amount}
+	}
+
+	if !req.SkipQueue {
+		c.JSON(http.StatusOK, a.queueBulkInflight(c.Request.Context(), blnk.InflightActionCommit, items))
+		return
 	}
 
 	outcomes, err := a.blnk.BulkInflightUpdate(c.Request.Context(), blnk.BulkInflightCommit, items, bulkInflightMaxWorkers)

--- a/cmd/workers.go
+++ b/cmd/workers.go
@@ -252,18 +252,39 @@ func (b *blnkInstance) indexBatchData(ctx context.Context, t *asynq.Task) error 
 }
 
 func (b *blnkInstance) processInflightCommit(ctx context.Context, t *asynq.Task) error {
-	var txnID string
-	if err := json.Unmarshal(t.Payload(), &txnID); err != nil {
-		logrus.Error(err)
-		return err
+	var p blnk.InflightActionPayload
+	if err := json.Unmarshal(t.Payload(), &p); err != nil || p.TransactionID == "" {
+		// Legacy payload: a bare JSON string transaction ID from a scheduled
+		// auto-commit enqueued before this change. Treat it as a full commit.
+		var txnID string
+		if serr := json.Unmarshal(t.Payload(), &txnID); serr != nil || txnID == "" {
+			logrus.WithError(serr).Error("failed to unmarshal inflight action payload")
+			return serr
+		}
+		p = blnk.InflightActionPayload{TransactionID: txnID, Action: blnk.InflightActionCommit}
 	}
 
-	_, err := b.blnk.CommitInflightTransaction(ctx, txnID, big.NewInt(0))
+	action := p.Action
+	if action == "" {
+		action = blnk.InflightActionCommit
+	}
+
+	amount := big.NewInt(0)
+	if p.PreciseAmount != "" {
+		if parsed, ok := new(big.Int).SetString(p.PreciseAmount, 10); ok {
+			amount = parsed
+		}
+	}
+
+	retryable, err := b.blnk.RunInflightActionByParent(ctx, p.TransactionID, action, amount, p.ActionID)
+	if err != nil && retryable {
+		return err // transient failure; asynq will retry
+	}
 	if err != nil {
-		return err
+		// Non-retryable failure: ack so the task doesn't poison-loop. The
+		// service layer already logged the per-leg detail.
+		logrus.WithError(err).WithField("transaction_id", p.TransactionID).Error("inflight action failed permanently; acking task")
 	}
-
-	logrus.Printf(" [*] Inflight Transaction Committed %s", txnID)
 	return nil
 }
 

--- a/cmd/workers_lifecycle_test.go
+++ b/cmd/workers_lifecycle_test.go
@@ -115,9 +115,10 @@ func TestProcessInflightCommitAndExpiry(t *testing.T) {
 		// Committing creates a child COMMIT entry; the parent leaves INFLIGHT.
 		assert.NotEqual(t, "VOID", committed.Status)
 
-		// Committing again must fail: it is already committed.
+		// Committing again is idempotent: the already-committed leg is terminal,
+		// so the worker acks (nil) instead of double-committing.
 		err = b.processInflightCommit(ctx, task)
-		require.Error(t, err, "double commit must surface an error")
+		require.NoError(t, err, "a replayed commit must be acked, not errored")
 	})
 
 	t.Run("expiry voids", func(t *testing.T) {

--- a/queue.go
+++ b/queue.go
@@ -19,6 +19,7 @@ package blnk
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"time"
@@ -45,6 +46,58 @@ type Queue struct {
 // TransactionTypePayload represents the payload for a transaction type.
 type TransactionTypePayload struct {
 	Data model.Transaction
+}
+
+// Inflight action names carried in an InflightActionPayload.
+const (
+	InflightActionCommit = "commit"
+	InflightActionVoid   = "void"
+)
+
+// ErrInflightActionQueued is returned by EnqueueInflightAction when a commit or
+// void for the same transaction is already queued (asynq TaskID conflict). The
+// API maps it to HTTP 409.
+var ErrInflightActionQueued = errors.New("a commit or void is already queued for this transaction")
+
+// InflightActionPayload is the task payload for a queued inflight commit/void.
+// ActionID is generated once at enqueue time and seeds the per-leg commit/void
+// references so asynq retries are idempotent.
+type InflightActionPayload struct {
+	TransactionID string `json:"transaction_id"`
+	Action        string `json:"action"`         // "commit" | "void"
+	PreciseAmount string `json:"precise_amount"` // big.Int string; "0" = full remaining
+	ActionID      string `json:"action_id"`
+}
+
+// EnqueueInflightAction enqueues a commit or void to the inflight-commit queue.
+// The asynq TaskID dedups concurrent actions for the same transaction: a second
+// enqueue while one is pending/active returns ErrInflightActionQueued. The
+// "inflight-action:" prefix is intentionally distinct from the scheduled
+// auto-commit TaskID (the bare transaction ID) so a pre-scheduled
+// inflight_commit_date task does not block a manual commit/void.
+func (q *Queue) EnqueueInflightAction(ctx context.Context, p InflightActionPayload) error {
+	payload, err := json.Marshal(p)
+	if err != nil {
+		return err
+	}
+
+	taskOptions := []asynq.Option{
+		asynq.TaskID("inflight-action:" + p.TransactionID),
+		asynq.Queue(q.config.Queue.InflightCommitQueue),
+		asynq.MaxRetry(q.config.Queue.MaxRetryAttempts),
+	}
+
+	task := asynq.NewTask(q.config.Queue.InflightCommitQueue, payload, taskOptions...)
+	if _, err := q.Client.EnqueueContext(ctx, task); err != nil {
+		if errors.Is(err, asynq.ErrTaskIDConflict) {
+			return ErrInflightActionQueued
+		}
+		logrus.WithError(err).WithField("transaction_id", p.TransactionID).Error("failed to enqueue inflight action")
+		return err
+	}
+
+	logrus.WithFields(logrus.Fields{"transaction_id": p.TransactionID, "action": p.Action}).Debug("successfully enqueued inflight action")
+	return nil
 }
 
 // NewQueue initializes a new Queue instance with the provided configuration.
@@ -305,7 +358,15 @@ func (q *Queue) GetTransactionFromQueue(transactionID string) (*model.Transactio
 // Returns:
 // - error: An error if the task could not be enqueued.
 func (q *Queue) queueInflightCommit(transactionID string, commitAt time.Time) error {
-	IPayload, err := json.Marshal(transactionID)
+	// Use the same struct payload and worker path as manual actions so the
+	// scheduled auto-commit also covers all inflight legs and is idempotent on
+	// retry. The TaskID stays the bare transaction ID (unchanged).
+	IPayload, err := json.Marshal(InflightActionPayload{
+		TransactionID: transactionID,
+		Action:        InflightActionCommit,
+		PreciseAmount: "0",
+		ActionID:      model.GenerateUUIDWithSuffix("act"),
+	})
 	if err != nil {
 		return err
 	}

--- a/transaction_bulk.go
+++ b/transaction_bulk.go
@@ -187,6 +187,11 @@ func (l *Blnk) CreateBulkTransactions(ctx context.Context, req *model.BulkTransa
 			)
 		}
 
+		// processBulkTransactions mutates each transaction (status, metadata,
+		// parent); clone them so the background goroutine never races the caller
+		// still holding the request's transactions.
+		asyncTxns := cloneTransactionsForAsync(req.Transactions)
+
 		// Start processing in background
 		go func() {
 			defer asyncBulkSemaphore.Release(1)
@@ -196,10 +201,10 @@ func (l *Blnk) CreateBulkTransactions(ctx context.Context, req *model.BulkTransa
 			defer cancel()
 
 			logrus.Infof("Starting async bulk transaction batch %s with %d transactions (atomic: %v, inflight: %v)",
-				batchID, len(req.Transactions), req.Atomic, req.Inflight)
+				batchID, len(asyncTxns), req.Atomic, req.Inflight)
 
 			// Process transactions in batch
-			err := l.processBulkTransactions(bgCtx, req.Transactions, batchID, req.Inflight, req.SkipQueue)
+			err := l.processBulkTransactions(bgCtx, asyncTxns, batchID, req.Inflight, req.SkipQueue)
 
 			if err != nil {
 				// Handle failure (rollback if atomic, send webhook)

--- a/transaction_inflight.go
+++ b/transaction_inflight.go
@@ -176,6 +176,15 @@ func (l *Blnk) releaseSingleLock(ctx context.Context, locker *redlock.Locker) {
 // - *model.Transaction: A pointer to the committed Transaction model.
 // - error: An error if the transaction could not be committed.
 func (l *Blnk) CommitInflightTransaction(ctx context.Context, transactionID string, amount *big.Int) (*model.Transaction, error) {
+	return l.CommitInflightTransactionWithRef(ctx, transactionID, amount, "")
+}
+
+// CommitInflightTransactionWithRef commits an inflight transaction using a
+// caller-supplied reference for the committed child. A non-empty reference makes
+// asynq retries idempotent: a retry that re-commits the same amount collides on
+// the unique reference index. An empty reference preserves the legacy behavior
+// of generating a random reference.
+func (l *Blnk) CommitInflightTransactionWithRef(ctx context.Context, transactionID string, amount *big.Int, reference string) (*model.Transaction, error) {
 	ctx, span := tracer.Start(ctx, "CommitInflightTransaction")
 	defer span.End()
 
@@ -203,7 +212,7 @@ func (l *Blnk) CommitInflightTransaction(ctx context.Context, transactionID stri
 	span.AddEvent("Inflight transaction committed", trace.WithAttributes(attribute.String("transaction.id", transaction.TransactionID)))
 	metrics.InflightCommitTotal.Add(ctx, 1)
 
-	committedTxn, err := l.finalizeCommitment(ctx, transaction, false)
+	committedTxn, err := l.finalizeCommitment(ctx, transaction, false, reference)
 	if err != nil {
 		return nil, err
 	}
@@ -242,7 +251,7 @@ func (l *Blnk) CommitInflightTransactionWithQueue(ctx context.Context, transacti
 
 	span.AddEvent("Inflight transaction committed", trace.WithAttributes(attribute.String("transaction.id", transaction.TransactionID)))
 
-	committedTxn, err := l.finalizeCommitment(ctx, transaction, true)
+	committedTxn, err := l.finalizeCommitment(ctx, transaction, true, "")
 	if err != nil {
 		return nil, err
 	}
@@ -379,7 +388,7 @@ func (l *Blnk) convertPreciseToFloat(preciseAmount *big.Int, precision float64) 
 // Returns:
 // - *model.Transaction: A pointer to the finalized Transaction model.
 // - error: An error if the transaction could not be queued.
-func (l *Blnk) finalizeCommitment(ctx context.Context, transaction *model.Transaction, withQueue bool) (*model.Transaction, error) {
+func (l *Blnk) finalizeCommitment(ctx context.Context, transaction *model.Transaction, withQueue bool, reference string) (*model.Transaction, error) {
 	ctx, span := tracer.Start(ctx, "FinalizeCommitment")
 	defer span.End()
 
@@ -390,7 +399,11 @@ func (l *Blnk) finalizeCommitment(ctx context.Context, transaction *model.Transa
 		transaction.EffectiveDate = &transaction.CreatedAt
 	}
 	transaction.TransactionID = model.GenerateUUIDWithSuffix("txn")
-	transaction.Reference = model.GenerateUUIDWithSuffix("ref")
+	if reference != "" {
+		transaction.Reference = reference
+	} else {
+		transaction.Reference = model.GenerateUUIDWithSuffix("ref")
+	}
 	transaction.Hash = transaction.HashTxn()
 
 	if withQueue {
@@ -425,6 +438,13 @@ func (l *Blnk) finalizeCommitment(ctx context.Context, transaction *model.Transa
 // - *model.Transaction: A pointer to the voided Transaction model.
 // - error: An error if the transaction could not be voided.
 func (l *Blnk) VoidInflightTransaction(ctx context.Context, transactionID string) (*model.Transaction, error) {
+	return l.VoidInflightTransactionWithRef(ctx, transactionID, "")
+}
+
+// VoidInflightTransactionWithRef voids an inflight transaction using a
+// caller-supplied reference for the voided child, making asynq retries
+// idempotent. An empty reference preserves the legacy random-reference behavior.
+func (l *Blnk) VoidInflightTransactionWithRef(ctx context.Context, transactionID string, reference string) (*model.Transaction, error) {
 	ctx, span := tracer.Start(ctx, "VoidInflightTransaction")
 	defer span.End()
 
@@ -458,7 +478,7 @@ func (l *Blnk) VoidInflightTransaction(ctx context.Context, transactionID string
 	span.AddEvent("Inflight transaction voided", trace.WithAttributes(attribute.String("transaction.id", transaction.TransactionID)))
 	metrics.InflightVoidTotal.Add(ctx, 1)
 
-	voidedTxn, err := l.finalizeVoidTransaction(ctx, transaction, amountLeft)
+	voidedTxn, err := l.finalizeVoidTransaction(ctx, transaction, amountLeft, reference)
 	if err != nil {
 		return nil, err
 	}
@@ -567,7 +587,7 @@ func (l *Blnk) calculateRemainingAmount(ctx context.Context, transaction *model.
 // Returns:
 // - *model.Transaction: A pointer to the voided Transaction model.
 // - error: An error if the transaction could not be queued.
-func (l *Blnk) finalizeVoidTransaction(ctx context.Context, transaction *model.Transaction, amountLeft *big.Int) (*model.Transaction, error) {
+func (l *Blnk) finalizeVoidTransaction(ctx context.Context, transaction *model.Transaction, amountLeft *big.Int, reference string) (*model.Transaction, error) {
 	ctx, span := tracer.Start(ctx, "FinalizeVoidTransaction")
 	defer span.End()
 
@@ -579,7 +599,11 @@ func (l *Blnk) finalizeVoidTransaction(ctx context.Context, transaction *model.T
 	}
 	transaction.ParentTransaction = transaction.TransactionID
 	transaction.TransactionID = model.GenerateUUIDWithSuffix("txn")
-	transaction.Reference = model.GenerateUUIDWithSuffix("ref")
+	if reference != "" {
+		transaction.Reference = reference
+	} else {
+		transaction.Reference = model.GenerateUUIDWithSuffix("ref")
+	}
 	transaction.Hash = transaction.HashTxn()
 	model.ApplyPrecision(transaction)
 
@@ -590,6 +614,182 @@ func (l *Blnk) finalizeVoidTransaction(ctx context.Context, transaction *model.T
 	}
 
 	span.AddEvent("Void transaction finalized", trace.WithAttributes(attribute.String("transaction.id", transaction.TransactionID)))
+	return transaction, nil
+}
+
+// inflightActionReference derives the deterministic reference for a committed or
+// voided leg from the action ID carried in the queued task. The same actionID
+// on an asynq retry reproduces the same reference, so a re-applied leg collides
+// on the unique reference index. An empty actionID yields "" (random reference).
+func inflightActionReference(legTransactionID, action, actionID string) string {
+	if actionID == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s_%s_%s", legTransactionID, action, actionID)
+}
+
+// isTerminalInflightError reports whether an inflight commit/void error is
+// terminal — the action cannot succeed on retry and the queued task should be
+// acked rather than retried.
+func (l *Blnk) isTerminalInflightError(err error) bool {
+	if IsDuplicateReferenceError(err) {
+		return true
+	}
+	switch classifyInflightError(err) {
+	case "ALREADY_COMMITTED", "ALREADY_VOIDED", "NOT_INFLIGHT", "INVALID_AMOUNT":
+		return true
+	default:
+		return false
+	}
+}
+
+// collectInflightLegs snapshots every inflight leg under a parent transaction
+// (transaction_id == parent OR parent_transaction == parent). Committing a leg
+// creates a child row but leaves the leg's own row INFLIGHT, so snapshotting up
+// front avoids re-processing the same legs across pages.
+func (l *Blnk) collectInflightLegs(ctx context.Context, parentTransactionID string) ([]*model.Transaction, error) {
+	batchSize := l.Config().Transaction.BatchSize
+	if batchSize <= 0 {
+		batchSize = 100
+	}
+
+	var legs []*model.Transaction
+	for offset := int64(0); ; offset += int64(batchSize) {
+		batch, err := l.GetInflightTransactionsByParentID(ctx, parentTransactionID, batchSize, offset)
+		if err != nil {
+			return nil, err
+		}
+		legs = append(legs, batch...)
+		if len(batch) < batchSize {
+			return legs, nil
+		}
+	}
+}
+
+// applyInflightActionToLeg commits or voids a single inflight leg using the
+// deterministic reference (derived from actionID) that makes asynq retries
+// idempotent.
+func (l *Blnk) applyInflightActionToLeg(ctx context.Context, leg *model.Transaction, action string, amount *big.Int, actionID string) error {
+	ref := inflightActionReference(leg.TransactionID, action, actionID)
+	if action == InflightActionVoid {
+		_, err := l.VoidInflightTransactionWithRef(ctx, leg.TransactionID, ref)
+		return err
+	}
+	_, err := l.CommitInflightTransactionWithRef(ctx, leg.TransactionID, amount, ref)
+	return err
+}
+
+// RunInflightActionByParent commits or voids every inflight leg under a parent
+// transaction — the same expansion the synchronous endpoint performs — and is
+// the queued worker's entrypoint.
+//
+// retryable is true when at least one leg failed with a transient error (lock
+// contention, fetch failure, not-yet-visible), so the asynq task should retry;
+// already-finalized legs are terminal, skipped, and never block the ack.
+func (l *Blnk) RunInflightActionByParent(ctx context.Context, parentTransactionID, action string, amount *big.Int, actionID string) (retryable bool, err error) {
+	ctx, span := tracer.Start(ctx, "RunInflightActionByParent")
+	defer span.End()
+
+	legs, err := l.collectInflightLegs(ctx, parentTransactionID)
+	if err != nil {
+		span.RecordError(err)
+		return true, err // a fetch failure is transient
+	}
+	if len(legs) == 0 {
+		// Nothing inflight under this parent: already finalized or never existed.
+		span.AddEvent("No inflight legs to process")
+		return false, nil
+	}
+
+	var applied, skipped int
+	var lastTransientErr error
+	for _, leg := range legs {
+		switch err := l.applyInflightActionToLeg(ctx, leg, action, amount, actionID); {
+		case err == nil:
+			applied++
+		case l.isTerminalInflightError(err):
+			// Expected on a retry once a leg is already finalized; benign.
+			skipped++
+			logrus.WithFields(logrus.Fields{
+				"transaction_id": leg.TransactionID,
+				"reason":         classifyInflightError(err),
+			}).Debug("inflight leg already finalized; skipping (idempotent)")
+		default:
+			span.RecordError(err)
+			lastTransientErr = err
+		}
+	}
+
+	if lastTransientErr != nil {
+		return true, lastTransientErr
+	}
+
+	logrus.WithFields(logrus.Fields{
+		"parent_transaction_id": parentTransactionID,
+		"action":                action,
+		"applied":               applied,
+		"skipped":               skipped,
+	}).Info("inflight action processed")
+	return false, nil
+}
+
+// preValidateInflightAction performs the read-only checks an inflight commit/void
+// would perform, without mutating or persisting anything. It lets the API reject
+// an obviously-invalid request (not inflight, already finalized, amount too high)
+// synchronously before enqueuing, while the worker remains the authority.
+func (l *Blnk) preValidateInflightAction(ctx context.Context, transactionID, action string, amount *big.Int) (*model.Transaction, error) {
+	transaction, err := l.fetchAndValidateInflightTransaction(ctx, transactionID)
+	if err != nil {
+		return nil, err
+	}
+
+	amountLeft, err := l.calculateRemainingAmount(ctx, transaction)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := l.checkTransactionCommitStatus(amountLeft); err != nil {
+		return nil, err
+	}
+
+	if action == InflightActionCommit && amount != nil {
+		if err := l.validateRequestedAmount(transaction, amount, amountLeft); err != nil {
+			return nil, err
+		}
+	}
+
+	return transaction, nil
+}
+
+// QueueInflightAction pre-validates a commit/void and enqueues it for the worker.
+// It returns the still-inflight parent transaction (for the API response) and
+// ErrInflightActionQueued if an action for the same transaction is already queued.
+func (l *Blnk) QueueInflightAction(ctx context.Context, transactionID string, amount *big.Int, action string) (*model.Transaction, error) {
+	ctx, span := tracer.Start(ctx, "QueueInflightAction")
+	defer span.End()
+
+	transaction, err := l.preValidateInflightAction(ctx, transactionID, action, amount)
+	if err != nil {
+		span.RecordError(err)
+		return nil, err
+	}
+
+	preciseAmount := "0"
+	if amount != nil {
+		preciseAmount = amount.String()
+	}
+
+	payload := InflightActionPayload{
+		TransactionID: transactionID,
+		Action:        action,
+		PreciseAmount: preciseAmount,
+		ActionID:      model.GenerateUUIDWithSuffix("act"),
+	}
+	if err := l.queue.EnqueueInflightAction(ctx, payload); err != nil {
+		span.RecordError(err)
+		return nil, err
+	}
+
 	return transaction, nil
 }
 
@@ -627,6 +827,13 @@ type BulkInflightOutcome struct {
 // Codes are intentionally action-agnostic where possible. ALREADY_VOIDED and
 // ALREADY_COMMITTED are reported as observed — a void on an already-committed
 // txn surfaces ALREADY_COMMITTED, and vice versa.
+// ClassifyInflightError maps an inflight commit/void error to a stable code
+// (see classifyInflightError) so callers outside this package — e.g. the queued
+// bulk API path — can report per-item codes without regex-matching messages.
+func ClassifyInflightError(err error) string {
+	return classifyInflightError(err)
+}
+
 func classifyInflightError(err error) string {
 	if err == nil {
 		return ""

--- a/transaction_inflight_async_test.go
+++ b/transaction_inflight_async_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2024 Blnk Finance Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package blnk
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInflightActionReference(t *testing.T) {
+	assert.Equal(t, "txn_1_commit_act_9", inflightActionReference("txn_1", InflightActionCommit, "act_9"))
+	assert.Equal(t, "txn_1_void_act_9", inflightActionReference("txn_1", InflightActionVoid, "act_9"))
+	// An empty action ID yields no reference, so finalize* falls back to a random one.
+	assert.Equal(t, "", inflightActionReference("txn_1", InflightActionCommit, ""))
+}
+
+func TestIsTerminalInflightError(t *testing.T) {
+	l := &Blnk{}
+
+	terminal := []error{
+		errors.New("cannot commit. Transaction already committed"),
+		errors.New("transaction has already been voided"),
+		errors.New("transaction is not in inflight status"),
+		errors.New("cannot commit more than the remaining amount"),
+		errors.New(`duplicate key value violates unique constraint "idx_transactions_reference_unique"`),
+	}
+	for _, err := range terminal {
+		assert.Truef(t, l.isTerminalInflightError(err), "expected terminal: %v", err)
+	}
+
+	transient := []error{
+		errors.New("failed to acquire lock for inflight commit"),
+		errors.New("transaction not found"),
+		errors.New("connection reset by peer"),
+		nil,
+	}
+	for _, err := range transient {
+		assert.Falsef(t, l.isTerminalInflightError(err), "expected transient: %v", err)
+	}
+}

--- a/transaction_queue.go
+++ b/transaction_queue.go
@@ -181,6 +181,16 @@ func cloneTransactionForAsync(t *model.Transaction) *model.Transaction {
 	return &clone
 }
 
+// cloneTransactionsForAsync clones each transaction so a background worker can
+// mutate them without touching the slice the caller still holds.
+func cloneTransactionsForAsync(txns []*model.Transaction) []*model.Transaction {
+	clones := make([]*model.Transaction, len(txns))
+	for i, t := range txns {
+		clones[i] = cloneTransactionForAsync(t)
+	}
+	return clones
+}
+
 // handleSplitTransactions attempts to split a transaction into multiple transactions if needed.
 // It starts a tracing span, attempts to split the transaction, and validates the result.
 //


### PR DESCRIPTION
Route inflight commit and void through the inflight-commit asynq queue by default; pass skip_queue: true (single and bulk endpoints) for the previous synchronous behavior.

- Enqueue dedup: an asynq TaskID ("inflight-action:<txn>") rejects a second commit/void for the same transaction while one is queued (HTTP 409). The prefix is distinct from the scheduled auto-commit TaskID so a pre-scheduled inflight_commit_date task does not block a manual action.
- Idempotent retries: the task carries a single action ID that seeds a deterministic per-leg reference (<leg>_commit_<action>); on retry an already-applied leg collides on the unique reference index and is skipped.
- All legs: the worker expands the parent into every inflight leg via RunInflightActionByParent (collectInflightLegs + applyInflightActionToLeg), matching the synchronous endpoint instead of committing a single leg.
- Worker acks terminal leg outcomes (already committed/voided, duplicate reference, not inflight) and retries transient ones (lock contention, fetch failure); MaxRetry from config.
- Queued response returns the still-inflight parent plus queued: true.
- Scheduled auto-commit migrated to the same payload/worker path (now covers all legs and is idempotent); legacy plain-string payloads still process as a full commit.
- Logging: one Info summary per action (applied/skipped counts); per-leg idempotent skips moved to Debug.