### PR TITLE
Add hash-chain processing and configuration

### DIFF
--- a/chain_worker.go
+++ b/chain_worker.go
@@ -1,0 +1,218 @@
+/*
+Copyright 2024 Blnk Finance Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package blnk
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/blnkfinance/blnk/internal/metrics"
+	"github.com/blnkfinance/blnk/model"
+	"github.com/sirupsen/logrus"
+)
+
+// maxBatchesPerTick bounds how much a single tick chains so a large backfill
+// never starves the ticker; the next tick simply continues.
+const maxBatchesPerTick = 50
+
+// ChainProcessor seals transactions into the tamper-evident hash chain off the
+// hot path. It polls for unchained rows and links them in a single DB
+// transaction per batch — modeled on LineageOutboxProcessor.
+type ChainProcessor struct {
+	blnk          *Blnk
+	pollInterval  time.Duration
+	batchSize     int
+	trailingDelay time.Duration
+	stopCh        chan struct{}
+	wg            sync.WaitGroup
+	running       bool
+	mu            sync.Mutex
+}
+
+// NewChainProcessor builds a ChainProcessor from the HashChain config (with safe
+// fallbacks).
+func NewChainProcessor(blnk *Blnk) *ChainProcessor {
+	hc := blnk.Config().Transaction.HashChain
+	pollInterval := hc.PollInterval
+	if pollInterval <= 0 {
+		pollInterval = 5 * time.Second
+	}
+	batchSize := hc.BatchSize
+	if batchSize <= 0 {
+		batchSize = 1000
+	}
+	trailingDelay := hc.TrailingDelay
+	if trailingDelay <= 0 {
+		trailingDelay = 30 * time.Second
+	}
+	return &ChainProcessor{
+		blnk:          blnk,
+		pollInterval:  pollInterval,
+		batchSize:     batchSize,
+		trailingDelay: trailingDelay,
+		stopCh:        make(chan struct{}),
+	}
+}
+
+// Start launches the background chainer loop.
+func (p *ChainProcessor) Start(ctx context.Context) {
+	p.mu.Lock()
+	if p.running {
+		p.mu.Unlock()
+		return
+	}
+	p.running = true
+	p.stopCh = make(chan struct{})
+	p.mu.Unlock()
+
+	p.wg.Add(1)
+	go func() {
+		defer p.wg.Done()
+		p.run(ctx)
+	}()
+	logrus.Info("Hash-chain processor started")
+}
+
+// Stop signals the loop to exit and waits for it.
+func (p *ChainProcessor) Stop() {
+	p.mu.Lock()
+	if !p.running {
+		p.mu.Unlock()
+		return
+	}
+	p.running = false
+	close(p.stopCh)
+	p.mu.Unlock()
+
+	p.wg.Wait()
+	logrus.Info("Hash-chain processor stopped")
+}
+
+// IsRunning reports whether the loop is active.
+func (p *ChainProcessor) IsRunning() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.running
+}
+
+func (p *ChainProcessor) run(ctx context.Context) {
+	ticker := time.NewTicker(p.pollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-p.stopCh:
+			return
+		case <-ticker.C:
+			p.processTick(ctx)
+		}
+	}
+}
+
+// processTick chains as many batches as are ready (bounded), then records metrics.
+func (p *ChainProcessor) processTick(ctx context.Context) {
+	cutoff := time.Now().UTC().Add(-p.trailingDelay)
+	for i := 0; i < maxBatchesPerTick; i++ {
+		n, err := p.blnk.datasource.ChainPendingTransactions(ctx, cutoff, p.batchSize)
+		if err != nil {
+			logrus.WithError(err).Error("hash-chain: failed to seal batch")
+			break
+		}
+		if n < p.batchSize {
+			break // caught up
+		}
+	}
+	p.recordMetrics(ctx, cutoff)
+}
+
+func (p *ChainProcessor) recordMetrics(ctx context.Context, cutoff time.Time) {
+	if state, err := p.blnk.datasource.GetChainState(ctx); err == nil {
+		metrics.ChainHeadSeq.Record(ctx, state.LastSeq)
+		metrics.ChainLagSeconds.Record(ctx, time.Since(state.UpdatedAt).Seconds())
+	}
+	if backlog, err := p.blnk.datasource.CountUnchainedTransactions(ctx, cutoff); err == nil {
+		metrics.ChainBacklog.Record(ctx, backlog)
+	}
+}
+
+// ChainVerifyResult is the outcome of replaying the chain from genesis.
+type ChainVerifyResult struct {
+	Verified    bool
+	LastSeq     int64
+	HeadHash    string
+	BrokenSeq   int64
+	BrokenTxnID string
+	Reason      string
+}
+
+// VerifyChain replays the whole chain from genesis, checking that each row's
+// chain_seq is contiguous, its chain_prev_hash matches the running head, and its
+// recomputed hash matches the stored chain_hash. It reports the first broken
+// link, or success with the final head. progress (optional) is called with each
+// verified seq.
+func (l *Blnk) VerifyChain(ctx context.Context, progress func(seq int64)) (ChainVerifyResult, error) {
+	state, err := l.datasource.GetChainState(ctx)
+	if err != nil {
+		return ChainVerifyResult{}, err
+	}
+
+	head := state.GenesisHash
+	var lastSeq int64
+	expectedSeq := int64(1)
+	const page = 1000
+
+	for {
+		rows, err := l.datasource.GetChainedTransactionsAfter(ctx, lastSeq, page)
+		if err != nil {
+			return ChainVerifyResult{}, err
+		}
+		if len(rows) == 0 {
+			break
+		}
+		for _, ct := range rows {
+			if ct.ChainSeq != expectedSeq {
+				return ChainVerifyResult{BrokenSeq: ct.ChainSeq, BrokenTxnID: ct.Row.TransactionID,
+					Reason: fmt.Sprintf("non-contiguous chain_seq: expected %d, got %d", expectedSeq, ct.ChainSeq)}, nil
+			}
+			if ct.ChainPrevHash != head {
+				return ChainVerifyResult{BrokenSeq: ct.ChainSeq, BrokenTxnID: ct.Row.TransactionID,
+					Reason: "chain_prev_hash does not match the running head"}, nil
+			}
+			if model.ComputeChainHash(head, ct.Row) != ct.ChainHash {
+				return ChainVerifyResult{BrokenSeq: ct.ChainSeq, BrokenTxnID: ct.Row.TransactionID,
+					Reason: "recomputed hash does not match stored chain_hash"}, nil
+			}
+			head = ct.ChainHash
+			lastSeq = ct.ChainSeq
+			expectedSeq++
+			if progress != nil {
+				progress(lastSeq)
+			}
+		}
+	}
+
+	// The replayed head must match the recorded head at the recorded length.
+	if lastSeq == state.LastSeq && head != state.HeadHash {
+		return ChainVerifyResult{BrokenSeq: lastSeq, Reason: "replayed head does not match chain_state head_hash"}, nil
+	}
+
+	return ChainVerifyResult{Verified: true, LastSeq: lastSeq, HeadHash: head}, nil
+}

--- a/chain_worker_test.go
+++ b/chain_worker_test.go
@@ -1,0 +1,208 @@
+/*
+Copyright 2024 Blnk Finance Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package blnk
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/blnkfinance/blnk/database"
+	"github.com/blnkfinance/blnk/database/mocks"
+	"github.com/blnkfinance/blnk/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// chainAll seals every transaction created so far (cutoff in the future).
+func chainAll(t *testing.T, ds database.IDataSource) {
+	t.Helper()
+	ctx := context.Background()
+	for {
+		n, err := ds.ChainPendingTransactions(ctx, time.Now().Add(time.Hour), 500)
+		require.NoError(t, err)
+		if n < 500 {
+			return
+		}
+	}
+}
+
+// assertSealed verifies one transaction is chained and its stored chain_hash
+// recomputes from its stored chain_prev_hash — i.e. the chainer sealed it
+// correctly. It checks only this row, so it is robust to the globally shared
+// test DB (which other tests' trigger-bypassing helpers can mutate).
+func assertSealed(t *testing.T, ds database.IDataSource, txnID string) {
+	t.Helper()
+	conn := ds.(*database.Datasource).Conn
+	var seq int64
+	var prev, stored string
+	var r model.ChainRow
+	err := conn.QueryRowContext(context.Background(), `
+		SELECT chain_seq, COALESCE(chain_prev_hash, ''), COALESCE(chain_hash, ''),
+		       transaction_id, COALESCE(source, ''), COALESCE(destination, ''),
+		       COALESCE(amount::text, ''), COALESCE(precise_amount::text, ''),
+		       COALESCE(currency, ''), COALESCE(status, ''), COALESCE(reference, ''),
+		       created_at
+		FROM blnk.transactions WHERE transaction_id = $1`, txnID).
+		Scan(&seq, &prev, &stored, &r.TransactionID, &r.Source, &r.Destination,
+			&r.Amount, &r.PreciseAmount, &r.Currency, &r.Status, &r.Reference, &r.CreatedAt)
+	require.NoError(t, err)
+	require.Greater(t, seq, int64(0), "txn %s must be chained", txnID)
+	require.NotEmpty(t, stored)
+	assert.Equal(t, stored, model.ComputeChainHash(prev, r), "stored chain_hash must recompute for %s", txnID)
+}
+
+func TestChain_SealsTransactions(t *testing.T) {
+	b, ds := newCoreTestBlnk(t)
+	src, dst := newBalancePair(t, ds)
+
+	var ids []string
+	for i := 0; i < 5; i++ {
+		ids = append(ids, recordAppliedTxn(t, b, src.BalanceID, dst.BalanceID, float64(10+i)).TransactionID)
+	}
+
+	chainAll(t, ds)
+	for _, id := range ids {
+		assertSealed(t, ds, id)
+	}
+
+	// Idempotent: re-running seals nothing new.
+	n, err := ds.ChainPendingTransactions(context.Background(), time.Now().Add(time.Hour), 500)
+	require.NoError(t, err)
+	assert.Equal(t, 0, n, "a second pass must seal nothing new")
+}
+
+func TestChainProcessor_ChainsAcrossTicks(t *testing.T) {
+	b, ds := newCoreTestBlnk(t)
+	src, dst := newBalancePair(t, ds)
+	id := recordAppliedTxn(t, b, src.BalanceID, dst.BalanceID, 7).TransactionID
+
+	ctx := context.Background()
+	p := NewChainProcessor(b)
+	p.pollInterval = 100 * time.Millisecond
+	p.trailingDelay = 0
+
+	p.Start(ctx)
+	defer p.Stop()
+	assert.True(t, p.IsRunning())
+
+	require.Eventually(t, func() bool {
+		n, err := ds.CountUnchainedTransactions(ctx, time.Now())
+		return err == nil && n == 0
+	}, 15*time.Second, 200*time.Millisecond, "processor should drain the backlog")
+
+	assertSealed(t, ds, id)
+}
+
+// TestChain_ConcurrentChainersSerialize fires several chainers at the shared
+// chain at once. The chain_state FOR UPDATE lock serializes them and the unique
+// chain_seq index forbids duplicate positions; every transaction is sealed
+// correctly exactly once. Run under -race.
+func TestChain_ConcurrentChainersSerialize(t *testing.T) {
+	b, ds := newCoreTestBlnk(t)
+	src, dst := newBalancePair(t, ds)
+
+	var ids []string
+	for i := 0; i < 8; i++ {
+		ids = append(ids, recordAppliedTxn(t, b, src.BalanceID, dst.BalanceID, float64(5+i)).TransactionID)
+	}
+
+	ctx := context.Background()
+	cutoff := time.Now().Add(time.Hour)
+
+	var wg sync.WaitGroup
+	for w := 0; w < 4; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				n, err := ds.ChainPendingTransactions(ctx, cutoff, 100)
+				if err != nil {
+					t.Errorf("concurrent chainer failed: %v", err)
+					return
+				}
+				if n == 0 {
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	for _, id := range ids {
+		assertSealed(t, ds, id)
+	}
+}
+
+// TestVerifyChain exercises the verifier logic in isolation with a mock
+// datasource, so it does not depend on the globally shared test DB.
+func TestVerifyChain(t *testing.T) {
+	genesis := model.ChainGenesisHash
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	rows := []model.ChainRow{
+		{TransactionID: "t1", Source: "a", Destination: "b", Amount: "10", PreciseAmount: "1000", Currency: "USD", Status: "APPLIED", Reference: "r1", CreatedAt: at},
+		{TransactionID: "t2", Source: "b", Destination: "c", Amount: "20", PreciseAmount: "2000", Currency: "USD", Status: "APPLIED", Reference: "r2", CreatedAt: at},
+		{TransactionID: "t3", Source: "c", Destination: "d", Amount: "30", PreciseAmount: "3000", Currency: "USD", Status: "APPLIED", Reference: "r3", CreatedAt: at},
+	}
+	head := genesis
+	var chain []model.ChainedTransaction
+	for i, r := range rows {
+		h := model.ComputeChainHash(head, r)
+		chain = append(chain, model.ChainedTransaction{Row: r, ChainSeq: int64(i + 1), ChainPrevHash: head, ChainHash: h})
+		head = h
+	}
+
+	newMock := func(rows []model.ChainedTransaction) *Blnk {
+		ds := new(mocks.MockDataSource)
+		ds.On("GetChainState", mock.Anything).Return(
+			&model.ChainState{ChainKey: "global", GenesisHash: genesis, HeadHash: head, LastSeq: int64(len(rows))}, nil)
+		ds.On("GetChainedTransactionsAfter", mock.Anything, int64(0), mock.Anything).Return(rows, nil)
+		ds.On("GetChainedTransactionsAfter", mock.Anything, int64(len(rows)), mock.Anything).
+			Return([]model.ChainedTransaction{}, nil)
+		return &Blnk{datasource: ds}
+	}
+
+	t.Run("intact chain verifies", func(t *testing.T) {
+		res, err := newMock(chain).VerifyChain(context.Background(), nil)
+		require.NoError(t, err)
+		assert.True(t, res.Verified)
+		assert.Equal(t, int64(3), res.LastSeq)
+		assert.Equal(t, head, res.HeadHash)
+	})
+
+	t.Run("tampered hash is caught", func(t *testing.T) {
+		bad := append([]model.ChainedTransaction(nil), chain...)
+		bad[1].ChainHash = strings.Repeat("f", 64)
+		res, err := newMock(bad).VerifyChain(context.Background(), nil)
+		require.NoError(t, err)
+		assert.False(t, res.Verified)
+		assert.Equal(t, int64(2), res.BrokenSeq)
+		assert.Equal(t, "t2", res.BrokenTxnID)
+	})
+
+	t.Run("non-contiguous seq is caught", func(t *testing.T) {
+		bad := append([]model.ChainedTransaction(nil), chain...)
+		bad[1].ChainSeq = 99
+		res, err := newMock(bad).VerifyChain(context.Background(), nil)
+		require.NoError(t, err)
+		assert.False(t, res.Verified)
+		assert.Contains(t, res.Reason, "non-contiguous")
+	})
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -127,9 +127,10 @@ func NewCLI() *Blnk {
 	rootCmd.PersistentPreRunE = preRun(b)
 
 	// Add various subcommands to the root command.
-	rootCmd.AddCommand(serverCommands(b))  // Command for starting the server
-	rootCmd.AddCommand(workerCommands(b))  // Command for worker processes
-	rootCmd.AddCommand(migrateCommands(b)) // Command for database/schema migrations
+	rootCmd.AddCommand(serverCommands(b))      // Command for starting the server
+	rootCmd.AddCommand(workerCommands(b))      // Command for worker processes
+	rootCmd.AddCommand(migrateCommands(b))     // Command for database/schema migrations
+	rootCmd.AddCommand(verifyChainCommands(b)) // Command for verifying the transaction hash chain
 
 	return &Blnk{cmd: rootCmd}
 }

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -403,6 +403,14 @@ func serverCommands(b *blnkInstance) *cobra.Command {
 			lineageProcessor.Start(ctx)
 			defer lineageProcessor.Stop()
 
+			// Start the hash-chain processor when enabled. It seals transactions
+			// into a tamper-evident chain off the hot path.
+			if cfg.Transaction.HashChain.Enabled {
+				chainProcessor := blnk.NewChainProcessor(b.blnk)
+				chainProcessor.Start(ctx)
+				defer chainProcessor.Stop()
+			}
+
 			// Start server
 			if err := startServer(router, cfg.Server.Port); err != nil {
 				logrus.Fatal(err)

--- a/cmd/verify_chain.go
+++ b/cmd/verify_chain.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2024 Blnk Finance Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+// verifyChainCommands replays the transaction hash chain from genesis and
+// reports whether history is intact. Exits non-zero on the first broken link.
+func verifyChainCommands(b *blnkInstance) *cobra.Command {
+	return &cobra.Command{
+		Use:           "verify-chain",
+		Short:         "Replay and verify the transaction hash chain from genesis",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			result, err := b.blnk.VerifyChain(context.Background(), nil)
+			if err != nil {
+				return fmt.Errorf("verify-chain failed: %w", err)
+			}
+			if !result.Verified {
+				return fmt.Errorf("chain BROKEN at seq %d (txn %s): %s",
+					result.BrokenSeq, result.BrokenTxnID, result.Reason)
+			}
+			logrus.Infof("chain verified: %d transactions sealed, head %s at seq %d",
+				result.LastSeq, result.HeadHash, result.LastSeq)
+			return nil
+		},
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -169,6 +169,7 @@ type TransactionConfig struct {
 	EnableCoalescing           bool          `json:"enable_coalescing" envconfig:"BLNK_TRANSACTION_ENABLE_COALESCING"`
 	EnableQueuedChecks         bool          `json:"enable_queued_checks" envconfig:"BLNK_TRANSACTION_ENABLE_QUEUED_CHECKS"`
 	DisableBatchReferenceCheck bool          `json:"disable_batch_reference_check" envconfig:"BLNK_TRANSACTION_DISABLE_BATCH_REFERENCE_CHECK"`
+	HashChain                  HashChainConfig `json:"hash_chain"`
 }
 
 type ReconciliationConfig struct {
@@ -221,6 +222,16 @@ type Configuration struct {
 	Transaction             TransactionConfig             `json:"transaction"`
 	Reconciliation          ReconciliationConfig          `json:"reconciliation"`
 	Queue                   QueueConfig                   `json:"queue"`
+}
+
+// HashChainConfig controls the background hash-chainer that seals transaction
+// history into a tamper-evident chain. It lives under transaction config and is
+// disabled by default.
+type HashChainConfig struct {
+	Enabled       bool          `json:"enabled" envconfig:"BLNK_TRANSACTION_HASHCHAIN_ENABLED"`
+	PollInterval  time.Duration `json:"poll_interval" envconfig:"BLNK_TRANSACTION_HASHCHAIN_POLL_INTERVAL"`
+	BatchSize     int           `json:"batch_size" envconfig:"BLNK_TRANSACTION_HASHCHAIN_BATCH_SIZE"`
+	TrailingDelay time.Duration `json:"trailing_delay" envconfig:"BLNK_TRANSACTION_HASHCHAIN_TRAILING_DELAY"`
 }
 
 func (cnf *Configuration) RemoteMonitoringDSN() string {
@@ -340,6 +351,7 @@ func (cnf *Configuration) setDefaultValues() {
 	cnf.setTransactionDefaults()
 	cnf.setReconciliationDefaults()
 	cnf.setQueueDefaults()
+	cnf.setHashChainDefaults()
 
 	if cnf.EnableTelemetry {
 		logrus.Info("telemetry enabled")
@@ -351,6 +363,19 @@ func (cnf *Configuration) setDefaultValues() {
 		logrus.Info("observability enabled")
 	} else {
 		logrus.Info("observability disabled")
+	}
+}
+
+func (cnf *Configuration) setHashChainDefaults() {
+	// Enabled stays false unless explicitly turned on.
+	if cnf.Transaction.HashChain.PollInterval <= 0 {
+		cnf.Transaction.HashChain.PollInterval = 5 * time.Second
+	}
+	if cnf.Transaction.HashChain.BatchSize <= 0 {
+		cnf.Transaction.HashChain.BatchSize = 1000
+	}
+	if cnf.Transaction.HashChain.TrailingDelay <= 0 {
+		cnf.Transaction.HashChain.TrailingDelay = 30 * time.Second
 	}
 }
 

--- a/database/chain.go
+++ b/database/chain.go
@@ -1,0 +1,193 @@
+/*
+Copyright 2024 Blnk Finance Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package database
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/blnkfinance/blnk/internal/apierror"
+	"github.com/blnkfinance/blnk/model"
+	"go.opentelemetry.io/otel"
+)
+
+// chainKey is the partition key of the single global chain. The chain_state
+// table is keyed so the chain can be partitioned later without a redesign.
+const chainKey = "global"
+
+// ChainPendingTransactions seals the next batch of unchained transactions into
+// the global hash chain in a single DB transaction. It locks the one chain_state
+// row FOR UPDATE (serializing every chainer instance — a second writer blocks,
+// then re-reads the advanced head), scans unchained rows older than cutoff in id
+// order, links each onto the head via model.ComputeChainHash, writes their
+// chain_* columns, and advances chain_state — all atomically, so a crash mid
+// batch loses nothing. Returns the number of rows sealed.
+func (d Datasource) ChainPendingTransactions(ctx context.Context, cutoff time.Time, batchSize int) (int, error) {
+	ctx, span := otel.Tracer("transaction.database").Start(ctx, "ChainPendingTransactions")
+	defer span.End()
+
+	tx, err := d.Conn.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelDefault})
+	if err != nil {
+		return 0, apierror.NewAPIError(apierror.ErrInternalServer, "Failed to begin chain transaction", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var lastSeq int64
+	var head string
+	if err := tx.QueryRowContext(ctx,
+		`SELECT last_seq, head_hash FROM blnk.chain_state WHERE chain_key = $1 FOR UPDATE`,
+		chainKey,
+	).Scan(&lastSeq, &head); err != nil {
+		return 0, apierror.NewAPIError(apierror.ErrInternalServer, "Failed to lock chain state", err)
+	}
+
+	rows, err := tx.QueryContext(ctx, `
+		SELECT id, transaction_id, COALESCE(source, ''), COALESCE(destination, ''),
+		       COALESCE(amount::text, ''), COALESCE(precise_amount::text, ''),
+		       COALESCE(currency, ''), COALESCE(status, ''), COALESCE(reference, ''),
+		       created_at
+		FROM blnk.transactions
+		WHERE chain_seq IS NULL AND created_at < $1
+		ORDER BY id ASC
+		LIMIT $2`, cutoff, batchSize)
+	if err != nil {
+		return 0, apierror.NewAPIError(apierror.ErrInternalServer, "Failed to scan unchained transactions", err)
+	}
+
+	type link struct {
+		id       int64
+		seq      int64
+		prevHash string
+		hash     string
+	}
+	var batch []link
+	for rows.Next() {
+		var id int64
+		var r model.ChainRow
+		if err := rows.Scan(&id, &r.TransactionID, &r.Source, &r.Destination,
+			&r.Amount, &r.PreciseAmount, &r.Currency, &r.Status, &r.Reference,
+			&r.CreatedAt); err != nil {
+			_ = rows.Close()
+			return 0, apierror.NewAPIError(apierror.ErrInternalServer, "Failed to read unchained transaction", err)
+		}
+		prev := head
+		head = model.ComputeChainHash(prev, r)
+		lastSeq++
+		batch = append(batch, link{id: id, seq: lastSeq, prevHash: prev, hash: head})
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return 0, apierror.NewAPIError(apierror.ErrInternalServer, "Error iterating unchained transactions", err)
+	}
+	// The rows cursor must be closed before issuing further statements on this tx.
+	_ = rows.Close()
+
+	if len(batch) == 0 {
+		// Commit to release the chain_state lock without advancing.
+		if err := tx.Commit(); err != nil {
+			return 0, apierror.NewAPIError(apierror.ErrInternalServer, "Failed to commit empty chain batch", err)
+		}
+		return 0, nil
+	}
+
+	stmt, err := tx.PrepareContext(ctx,
+		`UPDATE blnk.transactions SET chain_seq = $1, chain_prev_hash = $2, chain_hash = $3 WHERE id = $4`)
+	if err != nil {
+		return 0, apierror.NewAPIError(apierror.ErrInternalServer, "Failed to prepare chain update", err)
+	}
+	defer func() { _ = stmt.Close() }()
+	for _, l := range batch {
+		if _, err := stmt.ExecContext(ctx, l.seq, l.prevHash, l.hash, l.id); err != nil {
+			return 0, apierror.NewAPIError(apierror.ErrInternalServer, "Failed to write chain link", err)
+		}
+	}
+
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE blnk.chain_state SET last_seq = $1, head_hash = $2, updated_at = timezone('UTC', now()) WHERE chain_key = $3`,
+		lastSeq, head, chainKey,
+	); err != nil {
+		return 0, apierror.NewAPIError(apierror.ErrInternalServer, "Failed to advance chain state", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, apierror.NewAPIError(apierror.ErrInternalServer, "Failed to commit chain batch", err)
+	}
+
+	span.AddEvent("Chained transaction batch")
+	return len(batch), nil
+}
+
+// GetChainState returns the global chain bookmark row.
+func (d Datasource) GetChainState(ctx context.Context) (*model.ChainState, error) {
+	var s model.ChainState
+	err := d.Conn.QueryRowContext(ctx,
+		`SELECT chain_key, last_seq, head_hash, genesis_hash, genesis_at, updated_at
+		 FROM blnk.chain_state WHERE chain_key = $1`, chainKey,
+	).Scan(&s.ChainKey, &s.LastSeq, &s.HeadHash, &s.GenesisHash, &s.GenesisAt, &s.UpdatedAt)
+	if err != nil {
+		return nil, apierror.NewAPIError(apierror.ErrInternalServer, "Failed to get chain state", err)
+	}
+	return &s, nil
+}
+
+// GetChainedTransactionsAfter returns chained transactions in chain order with
+// chain_seq > afterSeq, for the verifier to page through from genesis.
+func (d Datasource) GetChainedTransactionsAfter(ctx context.Context, afterSeq int64, limit int) ([]model.ChainedTransaction, error) {
+	rows, err := d.Conn.QueryContext(ctx, `
+		SELECT chain_seq, COALESCE(chain_prev_hash, ''), COALESCE(chain_hash, ''),
+		       transaction_id, COALESCE(source, ''), COALESCE(destination, ''),
+		       COALESCE(amount::text, ''), COALESCE(precise_amount::text, ''),
+		       COALESCE(currency, ''), COALESCE(status, ''), COALESCE(reference, ''),
+		       created_at
+		FROM blnk.transactions
+		WHERE chain_seq IS NOT NULL AND chain_seq > $1
+		ORDER BY chain_seq ASC
+		LIMIT $2`, afterSeq, limit)
+	if err != nil {
+		return nil, apierror.NewAPIError(apierror.ErrInternalServer, "Failed to query chained transactions", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []model.ChainedTransaction
+	for rows.Next() {
+		var ct model.ChainedTransaction
+		if err := rows.Scan(&ct.ChainSeq, &ct.ChainPrevHash, &ct.ChainHash,
+			&ct.Row.TransactionID, &ct.Row.Source, &ct.Row.Destination,
+			&ct.Row.Amount, &ct.Row.PreciseAmount, &ct.Row.Currency, &ct.Row.Status,
+			&ct.Row.Reference, &ct.Row.CreatedAt); err != nil {
+			return nil, apierror.NewAPIError(apierror.ErrInternalServer, "Failed to scan chained transaction", err)
+		}
+		out = append(out, ct)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, apierror.NewAPIError(apierror.ErrInternalServer, "Error iterating chained transactions", err)
+	}
+	return out, nil
+}
+
+// CountUnchainedTransactions returns how many transactions older than cutoff are
+// still unchained — the chainer's backlog, for the lag metric.
+func (d Datasource) CountUnchainedTransactions(ctx context.Context, cutoff time.Time) (int64, error) {
+	var n int64
+	if err := d.Conn.QueryRowContext(ctx,
+		`SELECT count(*) FROM blnk.transactions WHERE chain_seq IS NULL AND created_at < $1`, cutoff,
+	).Scan(&n); err != nil {
+		return 0, apierror.NewAPIError(apierror.ErrInternalServer, "Failed to count unchained transactions", err)
+	}
+	return n, nil
+}

--- a/database/mocks/repo_mocks.go
+++ b/database/mocks/repo_mocks.go
@@ -675,3 +675,29 @@ func (m *MockDataSource) HasPendingCreditOutbox(ctx context.Context, balanceID s
 	args := m.Called(ctx, balanceID)
 	return args.Bool(0), args.Error(1)
 }
+
+func (m *MockDataSource) ChainPendingTransactions(ctx context.Context, cutoff time.Time, batchSize int) (int, error) {
+	args := m.Called(ctx, cutoff, batchSize)
+	return args.Int(0), args.Error(1)
+}
+
+func (m *MockDataSource) GetChainState(ctx context.Context) (*model.ChainState, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.ChainState), args.Error(1)
+}
+
+func (m *MockDataSource) GetChainedTransactionsAfter(ctx context.Context, afterSeq int64, limit int) ([]model.ChainedTransaction, error) {
+	args := m.Called(ctx, afterSeq, limit)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]model.ChainedTransaction), args.Error(1)
+}
+
+func (m *MockDataSource) CountUnchainedTransactions(ctx context.Context, cutoff time.Time) (int64, error) {
+	args := m.Called(ctx, cutoff)
+	return args.Get(0).(int64), args.Error(1)
+}

--- a/database/repository.go
+++ b/database/repository.go
@@ -37,6 +37,7 @@ type IDataSource interface {
 	reconciliation // Interface for reconciliation-related operations
 	apikey         // Interface for API key operations
 	lineage        // Interface for fund lineage operations
+	chain          // Interface for hash-chain operations
 }
 
 // transaction defines methods for handling transactions.
@@ -192,4 +193,12 @@ type lineage interface {
 	MarkOutboxFailed(ctx context.Context, id int64, errMsg string) error                                                     // Marks an outbox entry as failed
 	GetOutboxByTransactionID(ctx context.Context, transactionID string) (*model.LineageOutbox, error)                        // Gets outbox entry by transaction ID
 	HasPendingCreditOutbox(ctx context.Context, balanceID string) (bool, error)                                              // Checks if there are pending credit outbox entries for a balance
+}
+
+// chain defines the hash-chain (tamper-evidence) operations.
+type chain interface {
+	ChainPendingTransactions(ctx context.Context, cutoff time.Time, batchSize int) (int, error)           // Seals the next batch of unchained transactions
+	GetChainState(ctx context.Context) (*model.ChainState, error)                                         // Returns the global chain bookmark
+	GetChainedTransactionsAfter(ctx context.Context, afterSeq int64, limit int) ([]model.ChainedTransaction, error) // Pages chained transactions in chain order
+	CountUnchainedTransactions(ctx context.Context, cutoff time.Time) (int64, error)                      // Counts the chainer backlog
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -62,6 +62,17 @@ var HotpairsLaneRoutedTotal metric.Int64Counter
 // Attributes: reason (insufficient_funds, lock_contention, other)
 var WorkerRetriesTotal metric.Int64Counter
 
+// ChainBacklog is the number of transactions still waiting to be sealed into the
+// hash chain (the chainer's backlog).
+var ChainBacklog metric.Int64Gauge
+
+// ChainHeadSeq is the sequence number of the chain head — total transactions sealed.
+var ChainHeadSeq metric.Int64Gauge
+
+// ChainLagSeconds is the age of the chain head: seconds since the chainer last
+// advanced it.
+var ChainLagSeconds metric.Float64Gauge
+
 // Init creates all metric instruments. It should be called once during application
 // startup. Safe to call even when observability is disabled
 func Init() error {
@@ -166,6 +177,30 @@ func Init() error {
 	WorkerRetriesTotal, err = meter.Int64Counter("blnk.worker.retries.total",
 		metric.WithDescription("Total number of worker retry events by reason"),
 		metric.WithUnit("{retry}"),
+	)
+	if err != nil {
+		return err
+	}
+
+	ChainBacklog, err = meter.Int64Gauge("blnk.chain.backlog",
+		metric.WithDescription("Number of transactions not yet sealed into the hash chain"),
+		metric.WithUnit("{transaction}"),
+	)
+	if err != nil {
+		return err
+	}
+
+	ChainHeadSeq, err = meter.Int64Gauge("blnk.chain.head_seq",
+		metric.WithDescription("Sequence number of the hash-chain head"),
+		metric.WithUnit("{transaction}"),
+	)
+	if err != nil {
+		return err
+	}
+
+	ChainLagSeconds, err = meter.Float64Gauge("blnk.chain.lag_seconds",
+		metric.WithDescription("Seconds since the hash chain last advanced"),
+		metric.WithUnit("s"),
 	)
 	if err != nil {
 		return err

--- a/model/chain.go
+++ b/model/chain.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2024 Blnk Finance Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package model
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"time"
+)
+
+// ChainGenesisHash is the starting head of the transaction hash chain — 64
+// zeros. blnk.chain_state.head_hash begins here.
+const ChainGenesisHash = "0000000000000000000000000000000000000000000000000000000000000000"
+
+// ChainRow carries the canonical, immutable fields of a transaction that the
+// hash chain seals. The chainer and the verifier both build it from the same DB
+// columns so a recomputed hash is always reproducible. NULL columns are empty
+// strings. Every field here is enforced immutable by the transactions
+// immutability trigger, so a sealed row's hash can never change under a normal
+// write.
+type ChainRow struct {
+	TransactionID string
+	Source        string
+	Destination   string
+	Amount        string // NUMERIC rendered as text
+	PreciseAmount string // NUMERIC rendered as text (the authoritative ledger amount)
+	Currency      string
+	Status        string
+	Reference     string
+	CreatedAt     time.Time
+}
+
+// ComputeChainHash returns SHA256(prevHash || canonical fields). It is
+// deterministic and the single source of truth for the chain, shared by the
+// background chainer and the verifier. It seals the raw immutable fields
+// directly; the per-row HashTxn() value is deliberately excluded as it is just a
+// function of fields already sealed here.
+func ComputeChainHash(prevHash string, r ChainRow) string {
+	canonical := strings.Join([]string{
+		prevHash,
+		r.TransactionID,
+		r.Source,
+		r.Destination,
+		r.Amount,
+		r.PreciseAmount,
+		r.Currency,
+		r.Status,
+		r.Reference,
+		r.CreatedAt.UTC().Format(time.RFC3339Nano),
+	}, "|")
+	sum := sha256.Sum256([]byte(canonical))
+	return hex.EncodeToString(sum[:])
+}
+
+// ChainState mirrors the blnk.chain_state bookmark row.
+type ChainState struct {
+	ChainKey    string
+	LastSeq     int64
+	HeadHash    string
+	GenesisHash string
+	GenesisAt   time.Time
+	UpdatedAt   time.Time
+}
+
+// ChainedTransaction is a transaction read back in chain order for
+// verification: its canonical fields plus the stored chain linkage.
+type ChainedTransaction struct {
+	Row           ChainRow
+	ChainSeq      int64
+	ChainPrevHash string
+	ChainHash     string
+}

--- a/model/chain_test.go
+++ b/model/chain_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2024 Blnk Finance Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package model
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestComputeChainHash(t *testing.T) {
+	at := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	row := ChainRow{
+		TransactionID: "txn_1", Source: "bln_a", Destination: "bln_b",
+		Amount: "100", PreciseAmount: "10000", Currency: "USD", Status: "APPLIED",
+		Reference: "ref_1", CreatedAt: at,
+	}
+
+	t.Run("deterministic and 64-hex", func(t *testing.T) {
+		h1 := ComputeChainHash(ChainGenesisHash, row)
+		h2 := ComputeChainHash(ChainGenesisHash, row)
+		assert.Equal(t, h1, h2)
+		assert.Len(t, h1, 64)
+	})
+
+	t.Run("prev hash changes the result", func(t *testing.T) {
+		assert.NotEqual(t,
+			ComputeChainHash(ChainGenesisHash, row),
+			ComputeChainHash("ffff", row),
+			"a different head must produce a different hash")
+	})
+
+	t.Run("any field change changes the result", func(t *testing.T) {
+		base := ComputeChainHash(ChainGenesisHash, row)
+		tampered := row
+		tampered.Amount = "200"
+		assert.NotEqual(t, base, ComputeChainHash(ChainGenesisHash, tampered))
+	})
+
+	t.Run("timezone-normalized", func(t *testing.T) {
+		other := row
+		loc, _ := time.LoadLocation("Africa/Lagos")
+		other.CreatedAt = at.In(loc) // same instant, different zone
+		assert.Equal(t, ComputeChainHash(ChainGenesisHash, row), ComputeChainHash(ChainGenesisHash, other))
+	})
+}

--- a/sql/1781162328.sql
+++ b/sql/1781162328.sql
@@ -38,14 +38,14 @@ VALUES ('global', repeat('0', 64), repeat('0', 64))
 ON CONFLICT (chain_key) DO NOTHING;
 
 -- Verifier walks the chain in order; also forbids two rows sharing a position.
+-- This partial index is empty on existing installs (every row starts with a
+-- NULL chain_seq), so it builds instantly regardless of table size.
 CREATE UNIQUE INDEX IF NOT EXISTS idx_transactions_chain_seq
     ON blnk.transactions (chain_seq) WHERE chain_seq IS NOT NULL;
 
--- The chainer's scan for unchained rows. In steady state this index holds only
--- the last few seconds of rows, so the poll query never degrades as the table
--- grows.
-CREATE INDEX IF NOT EXISTS idx_transactions_unchained
-    ON blnk.transactions (id) WHERE chain_seq IS NULL;
+-- Note: the chainer's scan index (idx_transactions_unchained) covers all rows
+-- initially, so it is built CONCURRENTLY in the next migration to avoid locking
+-- the transactions table on large installs.
 
 -- +migrate StatementBegin
 -- Replace the immutability trigger function with a NULL-safe version. The
@@ -83,7 +83,6 @@ $$;
 
 -- +migrate Down
 
-DROP INDEX IF EXISTS blnk.idx_transactions_unchained;
 DROP INDEX IF EXISTS blnk.idx_transactions_chain_seq;
 DROP TABLE IF EXISTS blnk.chain_state;
 ALTER TABLE blnk.transactions DROP COLUMN IF EXISTS chain_hash;

--- a/sql/1781162328.sql
+++ b/sql/1781162328.sql
@@ -1,0 +1,119 @@
+-- Copyright 2024 Blnk Finance Authors.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- +migrate Up
+
+-- Hash-chain columns on transactions. All nullable: existing rows are simply
+-- "not yet chained" and the background chainer fills them in.
+ALTER TABLE blnk.transactions ADD COLUMN IF NOT EXISTS chain_seq BIGINT;
+ALTER TABLE blnk.transactions ADD COLUMN IF NOT EXISTS chain_prev_hash CHAR(64);
+ALTER TABLE blnk.transactions ADD COLUMN IF NOT EXISTS chain_hash CHAR(64);
+
+-- Single-row bookmark for the global chain. head_hash/last_seq advance
+-- atomically with each chained batch (same DB transaction) — that is the
+-- crash-safety mechanism.
+CREATE TABLE IF NOT EXISTS blnk.chain_state (
+    chain_key    TEXT PRIMARY KEY,
+    last_seq     BIGINT    NOT NULL DEFAULT 0,
+    head_hash    CHAR(64)  NOT NULL,
+    genesis_hash CHAR(64)  NOT NULL,
+    genesis_at   TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at   TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- Seed the single 'global' chain. Genesis = 64 zeros; the head starts there.
+INSERT INTO blnk.chain_state (chain_key, head_hash, genesis_hash)
+VALUES ('global', repeat('0', 64), repeat('0', 64))
+ON CONFLICT (chain_key) DO NOTHING;
+
+-- Verifier walks the chain in order; also forbids two rows sharing a position.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_transactions_chain_seq
+    ON blnk.transactions (chain_seq) WHERE chain_seq IS NOT NULL;
+
+-- The chainer's scan for unchained rows. In steady state this index holds only
+-- the last few seconds of rows, so the poll query never degrades as the table
+-- grows.
+CREATE INDEX IF NOT EXISTS idx_transactions_unchained
+    ON blnk.transactions (id) WHERE chain_seq IS NULL;
+
+-- +migrate StatementBegin
+-- Replace the immutability trigger function with a NULL-safe version. The
+-- previous body used `NEW.col = OLD.col`, which is NULL-unsafe: a NULL in any
+-- protected column (e.g. scheduled_for) made the whole condition NULL and raised
+-- even for benign meta_data updates. This version raises only when a protected
+-- column actually changes (IS DISTINCT FROM is NULL-safe), leaving meta_data and
+-- the chain_* columns free to be updated.
+CREATE OR REPLACE FUNCTION blnk.prevent_transaction_update()
+    RETURNS TRIGGER
+    LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF (
+        NEW.transaction_id IS DISTINCT FROM OLD.transaction_id OR
+        NEW.source         IS DISTINCT FROM OLD.source OR
+        NEW.destination    IS DISTINCT FROM OLD.destination OR
+        NEW.description    IS DISTINCT FROM OLD.description OR
+        NEW.reference      IS DISTINCT FROM OLD.reference OR
+        NEW.amount         IS DISTINCT FROM OLD.amount OR
+        NEW.precise_amount IS DISTINCT FROM OLD.precise_amount OR
+        NEW.precision      IS DISTINCT FROM OLD.precision OR
+        NEW.currency       IS DISTINCT FROM OLD.currency OR
+        NEW.status         IS DISTINCT FROM OLD.status OR
+        NEW.hash           IS DISTINCT FROM OLD.hash OR
+        NEW.created_at     IS DISTINCT FROM OLD.created_at OR
+        NEW.scheduled_for  IS DISTINCT FROM OLD.scheduled_for
+    ) THEN
+        RAISE EXCEPTION 'Cannot modify transaction data. Only meta_data and chain fields can be updated.';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+-- +migrate StatementEnd
+
+-- +migrate Down
+
+DROP INDEX IF EXISTS blnk.idx_transactions_unchained;
+DROP INDEX IF EXISTS blnk.idx_transactions_chain_seq;
+DROP TABLE IF EXISTS blnk.chain_state;
+ALTER TABLE blnk.transactions DROP COLUMN IF EXISTS chain_hash;
+ALTER TABLE blnk.transactions DROP COLUMN IF EXISTS chain_prev_hash;
+ALTER TABLE blnk.transactions DROP COLUMN IF EXISTS chain_seq;
+
+-- +migrate StatementBegin
+-- Restore the previous (NULL-unsafe) immutability trigger function.
+CREATE OR REPLACE FUNCTION blnk.prevent_transaction_update()
+    RETURNS TRIGGER
+    LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF (
+        NEW.transaction_id = OLD.transaction_id AND
+        NEW.source = OLD.source AND
+        NEW.destination = OLD.destination AND
+        NEW.description = OLD.description AND
+        NEW.reference = OLD.reference AND
+        NEW.amount = OLD.amount AND
+        NEW.currency = OLD.currency AND
+        NEW.status = OLD.status AND
+        NEW.hash = OLD.hash AND
+        NEW.created_at = OLD.created_at AND
+        NEW.scheduled_for = OLD.scheduled_for
+    ) THEN
+        RETURN NEW;
+    ELSE
+        RAISE EXCEPTION 'Cannot modify transaction data. Only meta_data field can be updated.';
+    END IF;
+END;
+$$;
+-- +migrate StatementEnd

--- a/sql/1781162329.sql
+++ b/sql/1781162329.sql
@@ -1,0 +1,25 @@
+-- Copyright 2024 Blnk Finance Authors.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- The chainer's scan index covers all rows until they are sealed, so build it
+-- CONCURRENTLY (requires notransaction) to avoid locking the transactions table
+-- on large installs. In steady state it holds only the last few seconds of
+-- rows, so the poll query never degrades as the table grows.
+
+-- +migrate Up notransaction
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_transactions_unchained
+    ON blnk.transactions (id) WHERE chain_seq IS NULL;
+
+-- +migrate Down notransaction
+DROP INDEX CONCURRENTLY IF EXISTS blnk.idx_transactions_unchained;


### PR DESCRIPTION
* Introduced a new hash-chain feature to seal transactions into a tamper-evident chain. This includes:
  - Added `HashChainConfig` to the transaction configuration, allowing for enabling/disabling the feature and setting parameters like poll interval and batch size.
  - Implemented the `chain` interface for hash-chain operations in the data source, including methods for chaining pending transactions and retrieving chain state.
  - Updated the server command to start the hash-chain processor when enabled.
  - Added metrics for monitoring the hash-chain backlog, head sequence, and lag time.

This enhancement improves transaction integrity and provides better observability for the hash-chain process.