### PR TITLE
Implement GetReconciliationResults method and update API call

### DIFF
--- a/api/reconciliation_api.go
+++ b/api/reconciliation_api.go
@@ -181,7 +181,7 @@ func (a Api) GetReconciliation(c *gin.Context) {
 		return
 	}
 
-	reconciliation, err := a.blnk.GetReconciliation(c.Request.Context(), reconciliationID)
+	reconciliation, err := a.blnk.GetReconciliationResults(c.Request.Context(), reconciliationID)
 	if err != nil {
 		logrus.Error(err)
 		if code, ok := classifyMessage(err.Error()); ok && apierror.StatusForCode(code) == http.StatusNotFound {

--- a/database/mocks/repo_mocks.go
+++ b/database/mocks/repo_mocks.go
@@ -701,3 +701,8 @@ func (m *MockDataSource) CountUnchainedTransactions(ctx context.Context, cutoff 
 	args := m.Called(ctx, cutoff)
 	return args.Get(0).(int64), args.Error(1)
 }
+
+func (m *MockDataSource) GetUnmatchedByReconciliationID(ctx context.Context, reconciliationID string) ([]string, error) {
+	args := m.Called(ctx, reconciliationID)
+	return args.Get(0).([]string), args.Error(1)
+}

--- a/database/reconciliation.go
+++ b/database/reconciliation.go
@@ -819,7 +819,7 @@ func (d Datasource) GetUnmatchedByReconciliationID(ctx context.Context, reconcil
 	}
 	defer func() { _ = rows.Close() }()
 
-	var ids []string
+	ids := []string{}
 	for rows.Next() {
 		var id string
 		if err := rows.Scan(&id); err != nil {

--- a/database/reconciliation.go
+++ b/database/reconciliation.go
@@ -43,7 +43,7 @@ func (d Datasource) RecordReconciliation(ctx context.Context, rec *model.Reconci
 
 	_, err := d.Conn.ExecContext(ctx,
 		`INSERT INTO blnk.reconciliations(
-			reconciliation_id, upload_id, status, matched_transactions, 
+			reconciliation_id, upload_id, status, matched_transactions,
 			unmatched_transactions, started_at, completed_at
 		) VALUES ($1, $2, $3, $4, $5, $6, $7)`,
 		rec.ReconciliationID, rec.UploadID, rec.Status, rec.MatchedTransactions,
@@ -68,7 +68,7 @@ func (d Datasource) GetReconciliation(ctx context.Context, id string) (*model.Re
 
 	rec := &model.Reconciliation{}
 	err := d.Conn.QueryRowContext(ctx, `
-		SELECT id, reconciliation_id, upload_id, status, matched_transactions, 
+		SELECT id, reconciliation_id, upload_id, status, matched_transactions,
 			unmatched_transactions, started_at, completed_at
 		FROM blnk.reconciliations
 		WHERE reconciliation_id = $1
@@ -135,7 +135,7 @@ func (d Datasource) GetReconciliationsByUploadID(ctx context.Context, uploadID s
 	defer span.End()
 
 	rows, err := d.Conn.QueryContext(ctx, `
-		SELECT id, reconciliation_id, upload_id, status, matched_transactions, 
+		SELECT id, reconciliation_id, upload_id, status, matched_transactions,
 			unmatched_transactions, started_at, completed_at
 		FROM blnk.reconciliations
 		WHERE upload_id = $1
@@ -797,6 +797,43 @@ func (d Datasource) FetchAndGroupExternalTransactions(ctx context.Context, uploa
 		attribute.Int("group.count", len(groupedTransactions)),
 	))
 	return groupedTransactions, nil
+}
+
+// GetUnmatchedByReconciliationID retrieves all unmatched external transaction IDs associated with a given reconciliation.
+// It queries the blnk.unmatched table to find all external transaction IDs that were not matched during the reconciliation process.
+// Parameters:
+// - ctx: Context for managing request and tracing.
+// - reconciliationID: The ID of the reconciliation to retrieve unmatched transactions for.
+// Returns:
+// - A slice of external transaction IDs (as strings) representing the unmatched transactions, or an error wrapped in an APIError if the operation fails.
+func (d Datasource) GetUnmatchedByReconciliationID(ctx context.Context, reconciliationID string) ([]string, error) {
+	ctx, span := otel.Tracer("reconciliation.database").Start(ctx, "Fetching unmatched transactions by reconciliation ID")
+	defer span.End()
+
+	rows, err := d.Conn.QueryContext(ctx, `
+		SELECT external_transaction_id
+		FROM blnk.unmatched
+		WHERE reconciliation_id = $1
+	`, reconciliationID)
+	if err != nil {
+		return nil, apierror.NewAPIError(apierror.ErrInternalServer, "Failed to retrieve unmatched transactions", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, apierror.NewAPIError(apierror.ErrInternalServer, "Failed to scan unmatched transaction", err)
+		}
+		ids = append(ids, id)
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, apierror.NewAPIError(apierror.ErrInternalServer, "Error occurred while iterating over unmatched transactions", err)
+	}
+
+	return ids, nil
 }
 
 func groupedExternalTransactionsQuery(groupCriteria string) (string, bool) {

--- a/database/reconciliation.go
+++ b/database/reconciliation.go
@@ -308,8 +308,7 @@ func (d Datasource) GetMatchesByReconciliationID(ctx context.Context, reconcilia
 	rows, err := d.Conn.QueryContext(ctx, `
 		SELECT m.external_transaction_id, m.internal_transaction_id, m.amount, m.date
 		FROM blnk.matches m
-		JOIN blnk.external_transactions et ON m.external_transaction_id = et.id
-		WHERE et.reconciliation_id = $1
+		WHERE m.reconciliation_id = $1
 	`, reconciliationID)
 	if err != nil {
 		return nil, apierror.NewAPIError(apierror.ErrInternalServer, "Failed to retrieve matches", err)

--- a/database/repository.go
+++ b/database/repository.go
@@ -168,6 +168,7 @@ type reconciliation interface {
 	RecordMatches(ctx context.Context, reconciliationID string, matches []model.Match) error                                                                            // Records matches for a reconciliation
 	RecordUnmatched(ctx context.Context, reconciliationID string, results []string) error                                                                               // Records unmatched results for a reconciliation
 	FetchAndGroupExternalTransactions(ctx context.Context, uploadID string, groupCriteria string, batchSize int, offset int64) (map[string][]*model.Transaction, error) // Fetches and groups external transactions based on criteria
+	GetUnmatchedByReconciliationID(ctx context.Context, reconciliationID string) ([]string, error)                                                                      // Retrieves unmatched transaction IDs by reconciliation ID
 }
 
 type apikey interface {
@@ -197,8 +198,8 @@ type lineage interface {
 
 // chain defines the hash-chain (tamper-evidence) operations.
 type chain interface {
-	ChainPendingTransactions(ctx context.Context, cutoff time.Time, batchSize int) (int, error)           // Seals the next batch of unchained transactions
-	GetChainState(ctx context.Context) (*model.ChainState, error)                                         // Returns the global chain bookmark
+	ChainPendingTransactions(ctx context.Context, cutoff time.Time, batchSize int) (int, error)                     // Seals the next batch of unchained transactions
+	GetChainState(ctx context.Context) (*model.ChainState, error)                                                   // Returns the global chain bookmark
 	GetChainedTransactionsAfter(ctx context.Context, afterSeq int64, limit int) ([]model.ChainedTransaction, error) // Pages chained transactions in chain order
-	CountUnchainedTransactions(ctx context.Context, cutoff time.Time) (int64, error)                      // Counts the chainer backlog
+	CountUnchainedTransactions(ctx context.Context, cutoff time.Time) (int64, error)                                // Counts the chainer backlog
 }

--- a/model/reconciliation_model.go
+++ b/model/reconciliation_model.go
@@ -18,11 +18,11 @@ package model
 import "time"
 
 type Match struct {
-	ExternalTransactionID string
-	InternalTransactionID string
-	ReconciliationID      string
-	Amount                float64
-	Date                  time.Time
+	ExternalTransactionID string    `json:"external_transaction_id"`
+	InternalTransactionID string    `json:"internal_transaction_id"`
+	ReconciliationID      string    `json:"-"`
+	Amount                float64   `json:"amount"`
+	Date                  time.Time `json:"date"`
 }
 
 type ExternalTransaction struct {

--- a/reconciliation.go
+++ b/reconciliation.go
@@ -264,6 +264,49 @@ func (s *Blnk) GetReconciliation(ctx context.Context, reconciliationID string) (
 	return reconciliation, nil
 }
 
+// GetReconciliationResults retrieves the full reconciliation results for a given reconciliation ID.
+// It combines the base reconciliation record with detailed matched and unmatched transaction data.
+// The method performs three queries:
+//  1. Retrieves the base reconciliation record (status, timestamps, etc.).
+//  2. Fetches all matched transactions ([]Match) from the matches table.
+//  3. Fetches all unmatched external transaction IDs from the unmatched table.
+//
+// Parameters:
+// - ctx: Context for managing request and tracing.
+// - reconciliationID: The ID of the reconciliation to retrieve results for.
+// Returns:
+// - A pointer to a ReconciliationResults struct containing the reconciliation summary, matched transactions, and unmatched transaction IDs.
+// - An error if any of the underlying queries fail.
+func (s *Blnk) GetReconciliationResults(ctx context.Context, reconciliationID string) (*model.ReconciliationResults, error) {
+	rec, err := s.datasource.GetReconciliation(ctx, reconciliationID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve reconciliation: %w", err)
+	}
+
+	matches, err := s.datasource.GetMatchesByReconciliationID(ctx, reconciliationID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve matches: %w", err)
+	}
+	matchSlice := make([]model.Match, len(matches))
+	for i, m := range matches {
+		matchSlice[i] = *m
+	}
+
+	unmatched, err := s.datasource.GetUnmatchedByReconciliationID(ctx, reconciliationID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve unmatched transactions: %w", err)
+	}
+
+	return &model.ReconciliationResults{
+		ReconciliationID:      rec.ReconciliationID,
+		Status:                rec.Status,
+		StartedAt:             rec.StartedAt,
+		CompletedAt:           rec.CompletedAt,
+		MatchedTransactions:   matchSlice,
+		UnmatchedTransactions: unmatched,
+	}, nil
+}
+
 // matchesRules checks whether an external transaction matches a group transaction based on specified matching rules.
 // It iterates through the rules and criteria, evaluating whether the transactions meet the conditions for a match.
 // Parameters:


### PR DESCRIPTION
* Added GetReconciliationResults method to retrieve detailed reconciliation results, including matched and unmatched transactions.
* Updated the API to call GetReconciliationResults instead of GetReconciliation, ensuring the retrieval of comprehensive reconciliation data.
* Introduced GetUnmatchedByReconciliationID method in the datasource to fetch unmatched transaction IDs, enhancing data retrieval capabilities.
* Updated repository interface and mock implementations to support the new method.

This change improves the reconciliation process by providing a complete overview of transaction statuses.

---

Response Changed to

```json
{
    "reconciliation_id": "recon_f9b345e1-f163-4d37-9f47-b273b8371954",
    "status": "completed",
    "started_at": "2026-06-25T02:47:04.755233Z",
    "completed_at": "2026-06-25T02:47:04.804479Z",
    "matched_transactions": [
        {
            "external_transaction_id": "ext-002",
            "internal_transaction_id": "txn_e83664db-d885-40fd-a6a2-42823947943b",
            "amount": 1000,
            "date": "2026-06-25T02:34:06Z"
        },
        {
            "external_transaction_id": "ext-001",
            "internal_transaction_id": "txn_1406fbf7-6901-413b-a190-07f0cfbe0a60",
            "amount": 500,
            "date": "2026-06-25T02:34:52Z"
        }
    ],
    "unmatched_transactions": []
}
```

Instead 

```json
{
  "reconciliation_id": "rec-123",
  "status": "completed",
  "matched_transactions": 20,
  "unmatched_transactions": 5,
  "created_at": "2025-03-17T12:00:00Z"
}
```