### PR TITLE
fix(migrations): make 1769343506 Down a true inverse of Up

### DIFF
--- a/sql/1769343506.sql
+++ b/sql/1769343506.sql
@@ -90,5 +90,13 @@ DROP INDEX IF EXISTS blnk.idx_lineage_outbox_pending;
 DROP INDEX IF EXISTS blnk.idx_lineage_outbox_transaction;
 DROP INDEX IF EXISTS blnk.idx_lineage_outbox_failed;
 
--- Remove unique constraint
-ALTER TABLE blnk.lineage_outbox DROP CONSTRAINT IF EXISTS lineage_outbox_transaction_id_key;
+-- Remove the unique index on transaction_id. The Up migration creates this as a
+-- unique INDEX (lineage_outbox_transaction_id_uidx), not a table constraint, so it
+-- must be dropped with DROP INDEX — the previous ALTER TABLE ... DROP CONSTRAINT
+-- (with the wrong name "_key") was a silent no-op.
+DROP INDEX IF EXISTS blnk.lineage_outbox_transaction_id_uidx;
+
+-- Drop the lineage_outbox table created by the Up migration. Without this the Down
+-- migration leaves the table (and its remaining indexes) behind, so the rollback is
+-- not a true inverse. Dropping the table also removes any indexes still on it.
+DROP TABLE IF EXISTS blnk.lineage_outbox;


### PR DESCRIPTION
## Summary

The `1769343506` **Up** migration creates `blnk.lineage_outbox` and a unique **index** `lineage_outbox_transaction_id_uidx`, but the **Down** migration does not fully reverse it:

1. It removed the unique index via
   `ALTER TABLE blnk.lineage_outbox DROP CONSTRAINT IF EXISTS lineage_outbox_transaction_id_key;`
   — wrong mechanism (it was created as an **index**, not a table constraint) **and** wrong name (`_key` vs `_uidx`). With `IF EXISTS` this is a silent no-op, so the unique index is never removed.
2. It never drops the `lineage_outbox` **table** the Up migration created.

So rolling this migration back leaves the table and its unique index behind — the Down is not a true inverse of the Up.

## Fix

```sql
-- correct the unique-index removal (DROP INDEX, correct name)
DROP INDEX IF EXISTS blnk.lineage_outbox_transaction_id_uidx;

-- drop the table the Up created (also removes any indexes still on it)
DROP TABLE IF EXISTS blnk.lineage_outbox;
```

The FK-constraint and secondary-index drops already present in the Down are unchanged. Net effect: a clean, idempotent rollback that mirrors the Up.