### PR TITLE
Enhance reconciliation upload functionality

### DIFF
--- a/api/reconciliation_api.go
+++ b/api/reconciliation_api.go
@@ -16,9 +16,15 @@ limitations under the License.
 package api
 
 import (
+	"context"
+	"encoding/json"
+	"io"
 	"net/http"
+	"net/url"
+	"path"
 	"strconv"
 	"strings"
+	"time"
 
 	model2 "github.com/blnkfinance/blnk/api/model"
 	"github.com/blnkfinance/blnk/config"
@@ -48,27 +54,179 @@ func (a Api) UploadExternalData(c *gin.Context) {
 
 	source := c.PostForm("source")
 	file, header, err := c.Request.FormFile("file")
-	if err != nil {
-		// http.MaxBytesReader surfaces oversized bodies here; report 413.
-		if strings.Contains(err.Error(), "request body too large") {
-			respondCode(c, apierror.ErrGenPayloadTooLarge, "upload exceeds the maximum allowed size", nil)
+	if err == nil {
+		// Multipart file upload path (existing behaviour). `file` wins when
+		// both `file` and `url` are present, preserving backward compatibility.
+		defer file.Close()
+		fileName := header.Filename
+
+		uploadID, total, err := a.blnk.UploadExternalData(c.Request.Context(), source, file, fileName)
+		if err != nil {
+			logrus.Error(err)
+			respondCode(c, apierror.ErrReconUploadProcessingFailed, "Failed to process upload", nil)
 			return
 		}
+
+		c.JSON(http.StatusOK, gin.H{"upload_id": uploadID, "record_count": total, "source": source})
+		return
+	}
+
+	// http.MaxBytesReader surfaces oversized multipart bodies as a FormFile error.
+	if strings.Contains(err.Error(), "request body too large") {
+		respondCode(c, apierror.ErrGenPayloadTooLarge, "upload exceeds the maximum allowed size", nil)
+		return
+	}
+
+	// No `file` part. Fall back to the URL download path if a `url` was supplied
+	// via a form field or a JSON body. If neither is present, return the legacy
+	// 400 "File upload failed" so existing clients see unchanged behaviour.
+	rawURL, jsonSource := resolveUploadURL(c)
+	if jsonSource != "" && source == "" {
+		source = jsonSource
+	}
+	if rawURL == "" {
 		respondCode(c, apierror.ErrReconUploadFailed, "File upload failed", nil)
 		return
 	}
-	defer file.Close()
 
-	fileName := header.Filename
-
-	uploadID, total, err := a.blnk.UploadExternalData(c.Request.Context(), source, file, fileName)
-	if err != nil {
-		logrus.Error(err)
-		respondCode(c, apierror.ErrReconUploadProcessingFailed, "Failed to process upload", nil)
-		return
+	uploadID, total, ok := a.downloadAndUpload(c, source, rawURL)
+	if !ok {
+		return // downloadAndUpload already wrote the error response.
 	}
 
 	c.JSON(http.StatusOK, gin.H{"upload_id": uploadID, "record_count": total, "source": source})
+}
+
+// resolveUploadURL extracts the `url` for a URL-based upload. For JSON bodies
+// ({"url": "...", "source": "..."}) it returns both fields; for multipart form
+// data it reads the `url` form field (the source is read separately by the
+// caller via PostForm).
+func resolveUploadURL(c *gin.Context) (rawURL, source string) {
+	ctype := c.GetHeader("Content-Type")
+	if strings.HasPrefix(strings.ToLower(ctype), "application/json") {
+		var body struct {
+			URL    string `json:"url"`
+			Source string `json:"source"`
+		}
+		if err := json.NewDecoder(c.Request.Body).Decode(&body); err == nil {
+			return body.URL, body.Source
+		}
+		return "", ""
+	}
+	return c.PostForm("url"), ""
+}
+
+// downloadAndUpload fetches the remote body at rawURL and pipes it through the
+// unchanged UploadExternalData service. It enforces SSRF protection
+// (http(s)-only, deny-by-default host whitelist, redirect re-validation), a
+// configurable GET timeout, and the existing MaxUploadSizeMB body cap via
+// io.LimitReader. On failure it writes the error response and returns ok=false.
+func (a Api) downloadAndUpload(c *gin.Context, source, rawURL string) (uploadID string, total int, ok bool) {
+	cfg, _ := config.Fetch()
+
+	u, err := url.Parse(rawURL)
+	if err != nil || u == nil {
+		respondCode(c, apierror.ErrReconUploadURLInvalid, "invalid upload URL", nil)
+		return "", 0, false
+	}
+
+	// Scheme guard: http/https only (rejects ftp://, file://, gopher://, ...).
+	scheme := strings.ToLower(u.Scheme)
+	if scheme != "http" && scheme != "https" {
+		respondCode(c, apierror.ErrReconUploadURLInvalid, "upload URL must use http or https", nil)
+		return "", 0, false
+	}
+
+	host := strings.ToLower(strings.TrimSpace(u.Hostname()))
+	if host == "" {
+		respondCode(c, apierror.ErrReconUploadURLInvalid, "invalid upload URL", nil)
+		return "", 0, false
+	}
+
+	// Whitelist guard: exact-host match, deny-by-default when empty.
+	allowed := cfg.UploadWhitelistHosts()
+	if !hostAllowed(host, allowed) {
+		respondCode(c, apierror.ErrReconUploadHostNotAllowed, "upload host not allowed", nil)
+		return "", 0, false
+	}
+
+	// Filename from the URL path; the service layer relies on the extension for
+	// type detection. Fall back to "download" when the path has no basename.
+	name := path.Base(u.Path)
+	if name == "." || name == "/" || name == "" {
+		name = "download"
+	}
+
+	timeout := time.Duration(config.DEFAULT_UPLOAD_URL_TIMEOUT_SEC) * time.Second
+	if cfg != nil && cfg.Server.UploadURLTimeoutSec > 0 {
+		timeout = time.Duration(cfg.Server.UploadURLTimeoutSec) * time.Second
+	}
+	ctx, cancel := context.WithTimeout(c.Request.Context(), timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		logrus.WithError(err).Error("failed to build upload download request")
+		respondCode(c, apierror.ErrReconUploadProcessingFailed, "Failed to process upload", nil)
+		return "", 0, false
+	}
+	req.Header.Set("User-Agent", "blnk-reconciliation/1.0")
+
+	// Custom client that re-validates every redirect's host against the
+	// whitelist so a whitelisted host can't 302 to an internal IP/loopback.
+	client := &http.Client{
+		CheckRedirect: func(next *http.Request, _ []*http.Request) error {
+			if next == nil {
+				return http.ErrUseLastResponse
+			}
+			nextHost := strings.ToLower(strings.TrimSpace(next.URL.Hostname()))
+			if nextHost == "" || !hostAllowed(nextHost, allowed) {
+				return http.ErrUseLastResponse
+			}
+			return nil
+		},
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		logrus.WithError(err).Error("failed to fetch upload URL")
+		respondCode(c, apierror.ErrReconUploadProcessingFailed, "Failed to process upload", nil)
+		return "", 0, false
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		logrus.WithField("status", resp.StatusCode).Error("upload URL returned non-2xx")
+		respondCode(c, apierror.ErrReconUploadProcessingFailed, "Failed to process upload", nil)
+		return "", 0, false
+	}
+
+	// Cap the downloaded body at MaxUploadSizeMB. An oversize response is
+	// truncated, which surfaces downstream as a parse/processing failure (500).
+	limit := int64(config.DEFAULT_MAX_UPLOAD_SIZE_MB) * 1024 * 1024
+	if cfg != nil && cfg.Server.MaxUploadSizeMB > 0 {
+		limit = cfg.Server.MaxUploadSizeMB * 1024 * 1024
+	}
+	limited := io.LimitReader(resp.Body, limit+1)
+
+	id, total, err := a.blnk.UploadExternalData(ctx, source, limited, name)
+	if err != nil {
+		logrus.WithError(err).Error("failed to process URL upload")
+		respondCode(c, apierror.ErrReconUploadProcessingFailed, "Failed to process upload", nil)
+		return "", 0, false
+	}
+
+	return id, total, true
+}
+
+// hostAllowed reports whether host is present in the (lowercased) whitelist.
+func hostAllowed(host string, allowed []string) bool {
+	for _, a := range allowed {
+		if a == host {
+			return true
+		}
+	}
+	return false
 }
 
 // StartReconciliation initiates a new reconciliation process based on the provided parameters.

--- a/api/reconciliation_api.go
+++ b/api/reconciliation_api.go
@@ -144,7 +144,7 @@ func (a Api) downloadAndUpload(c *gin.Context, source, rawURL string) (uploadID 
 	}
 
 	// Whitelist guard: exact-host match, deny-by-default when empty.
-	allowed := cfg.UploadWhitelistHosts()
+	allowed := cfg.UploadDomainWhitelistHosts()
 	if !hostAllowed(host, allowed) {
 		respondCode(c, apierror.ErrReconUploadHostNotAllowed, "upload host not allowed", nil)
 		return "", 0, false
@@ -257,10 +257,22 @@ func (a Api) StartReconciliation(c *gin.Context) {
 		return
 	}
 
-	reconciliationID, err := a.blnk.StartReconciliation(c.Request.Context(), req.UploadID, req.Strategy, req.GroupingCriteria, req.MatchingRuleIDs, req.DryRun)
+	reconciliationID, err := a.blnk.StartReconciliation(
+		c.Request.Context(),
+		req.UploadID,
+		req.Strategy,
+		req.GroupingCriteria,
+		req.MatchingRuleIDs,
+		req.DryRun,
+	)
 	if err != nil {
 		logrus.Error(err)
-		respondError(c, err, withDefault(apierror.ErrReconStartFailed), withFallbackMessage("Failed to start reconciliation"))
+		respondError(
+			c,
+			err,
+			withDefault(apierror.ErrReconStartFailed),
+			withFallbackMessage("Failed to start reconciliation"),
+		)
 		return
 	}
 
@@ -315,7 +327,12 @@ func (a Api) InstantReconciliation(c *gin.Context) {
 	)
 	if err != nil {
 		logrus.Error(err)
-		respondError(c, err, withDefault(apierror.ErrReconStartFailed), withFallbackMessage("Failed to start instant reconciliation"))
+		respondError(
+			c,
+			err,
+			withDefault(apierror.ErrReconStartFailed),
+			withFallbackMessage("Failed to start instant reconciliation"),
+		)
 		return
 	}
 
@@ -374,7 +391,12 @@ func (a Api) CreateMatchingRule(c *gin.Context) {
 	createdRule, err := a.blnk.CreateMatchingRule(c.Request.Context(), rule)
 	if err != nil {
 		logrus.Error(err)
-		respondError(c, err, withDefault(apierror.ErrGenInternal), withFallbackMessage("Failed to create matching rule"))
+		respondError(
+			c,
+			err,
+			withDefault(apierror.ErrGenInternal),
+			withFallbackMessage("Failed to create matching rule"),
+		)
 		return
 	}
 
@@ -408,7 +430,13 @@ func (a Api) UpdateMatchingRule(c *gin.Context) {
 	updatedRule, err := a.blnk.UpdateMatchingRule(c.Request.Context(), rule)
 	if err != nil {
 		logrus.Error(err)
-		respondError(c, err, withUpgrade(apierror.ErrGenNotFound, apierror.ErrReconRuleNotFound), withDefault(apierror.ErrGenInternal), withFallbackMessage("Failed to update matching rule"))
+		respondError(
+			c,
+			err,
+			withUpgrade(apierror.ErrGenNotFound, apierror.ErrReconRuleNotFound),
+			withDefault(apierror.ErrGenInternal),
+			withFallbackMessage("Failed to update matching rule"),
+		)
 		return
 	}
 
@@ -435,7 +463,13 @@ func (a Api) DeleteMatchingRule(c *gin.Context) {
 	err := a.blnk.DeleteMatchingRule(c.Request.Context(), ruleID)
 	if err != nil {
 		logrus.Error(err)
-		respondError(c, err, withUpgrade(apierror.ErrGenNotFound, apierror.ErrReconRuleNotFound), withDefault(apierror.ErrGenInternal), withFallbackMessage("Failed to delete matching rule"))
+		respondError(
+			c,
+			err,
+			withUpgrade(apierror.ErrGenNotFound, apierror.ErrReconRuleNotFound),
+			withDefault(apierror.ErrGenInternal),
+			withFallbackMessage("Failed to delete matching rule"),
+		)
 		return
 	}
 

--- a/api/reconciliation_api_test.go
+++ b/api/reconciliation_api_test.go
@@ -20,8 +20,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/brianvoe/gofakeit/v6"
-	"github.com/gin-gonic/gin"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
@@ -29,6 +27,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/gin-gonic/gin"
 
 	model2 "github.com/blnkfinance/blnk/api/model"
 	"github.com/blnkfinance/blnk/config"
@@ -102,7 +103,12 @@ func TestInstantReconciliation(t *testing.T) {
 	t.Run("Too many external transactions", func(t *testing.T) {
 		txns := make([]map[string]interface{}, model2.MaxInstantReconciliationItems+1)
 		for i := range txns {
-			txns[i] = map[string]interface{}{"id": fmt.Sprintf("ext_%d", i), "amount": 1, "reference": fmt.Sprintf("r%d", i), "currency": "USD"}
+			txns[i] = map[string]interface{}{
+				"id":        fmt.Sprintf("ext_%d", i),
+				"amount":    1,
+				"reference": fmt.Sprintf("r%d", i),
+				"currency":  "USD",
+			}
 		}
 		payload := map[string]interface{}{
 			"external_transactions": txns,
@@ -171,7 +177,11 @@ func TestUpdateMatchingRule(t *testing.T) {
 	})
 
 	t.Run("Invalid JSON", func(t *testing.T) {
-		req := httptest.NewRequest("PUT", "/reconciliation/matching-rules/mr_test", bytes.NewReader([]byte("invalid json")))
+		req := httptest.NewRequest(
+			"PUT",
+			"/reconciliation/matching-rules/mr_test",
+			bytes.NewReader([]byte("invalid json")),
+		)
 		req.Header.Set("Content-Type", "application/json")
 		resp := httptest.NewRecorder()
 		router.ServeHTTP(resp, req)
@@ -200,7 +210,12 @@ func TestDeleteMatchingRule(t *testing.T) {
 	})
 }
 
-func uploadMultipart(t *testing.T, router *gin.Engine, fieldName, fileName, source string, content []byte) *httptest.ResponseRecorder {
+func uploadMultipart(
+	t *testing.T,
+	router *gin.Engine,
+	fieldName, fileName, source string,
+	content []byte,
+) *httptest.ResponseRecorder {
 	t.Helper()
 
 	var buf bytes.Buffer
@@ -254,7 +269,13 @@ func TestUploadExternalData(t *testing.T) {
 	})
 
 	t.Run("Valid JSON upload", func(t *testing.T) {
-		jsonContent := []byte(fmt.Sprintf(`[{"id": "ext_%s", "amount": 300, "currency": "USD", "reference": "ref_%s", "description": "json row", "date": "2024-01-03T10:00:00Z"}]`, gofakeit.UUID(), gofakeit.UUID()))
+		jsonContent := []byte(
+			fmt.Sprintf(
+				`[{"id": "ext_%s", "amount": 300, "currency": "USD", "reference": "ref_%s", "description": "json row", "date": "2024-01-03T10:00:00Z"}]`,
+				gofakeit.UUID(),
+				gofakeit.UUID(),
+			),
+		)
 		resp := uploadMultipart(t, router, "file", "data.json", "bank-test", jsonContent)
 		assert.Equal(t, http.StatusOK, resp.Code)
 
@@ -319,10 +340,11 @@ func uploadServerHost(srv *httptest.Server) string {
 }
 
 // startUploadTestServer spins up an httptest.Server serving:
-//   /data.csv  -> a valid 2-row CSV
-//   /big.csv   -> a >1MB body (for oversize tests)
-//   /error     -> HTTP 500
-//   /slow      -> sleeps 5s before responding (for timeout tests)
+//
+//	/data.csv  -> a valid 2-row CSV
+//	/big.csv   -> a >1MB body (for oversize tests)
+//	/error     -> HTTP 500
+//	/slow      -> sleeps 5s before responding (for timeout tests)
 func startUploadTestServer(t *testing.T, bigBody []byte) *httptest.Server {
 	t.Helper()
 	csv := newCSVContent(t, 2)
@@ -374,7 +396,13 @@ func uploadMultipartURL(t *testing.T, router *gin.Engine, urlVal, source string)
 
 // uploadMultipartFileAndURL posts a multipart form with BOTH a `file` part and
 // a `url` field, used to verify that `file` wins.
-func uploadMultipartFileAndURL(t *testing.T, router *gin.Engine, fileName, source string, content []byte, urlVal string) *httptest.ResponseRecorder {
+func uploadMultipartFileAndURL(
+	t *testing.T,
+	router *gin.Engine,
+	fileName, source string,
+	content []byte,
+	urlVal string,
+) *httptest.ResponseRecorder {
 	t.Helper()
 	var buf bytes.Buffer
 	writer := multipart.NewWriter(&buf)
@@ -424,7 +452,7 @@ func TestUploadExternalData_URLDownload(t *testing.T) {
 	t.Run("url field points to valid CSV", func(t *testing.T) {
 		srv := startUploadTestServer(t, nil)
 		router, _, _ := setupRouterWithConfig(t, func(c *config.Configuration) {
-			c.Server.UploadWhitelist = uploadServerHost(srv)
+			c.Server.UploadDomainWhitelist = uploadServerHost(srv)
 		})
 		resp := uploadMultipartURL(t, router, srv.URL+"/data.csv", "bank-test")
 		assert.Equal(t, http.StatusOK, resp.Code)
@@ -447,7 +475,7 @@ func TestUploadExternalData_URLDownload(t *testing.T) {
 	t.Run("url field pointing to a server that returns an error", func(t *testing.T) {
 		srv := startUploadTestServer(t, nil)
 		router, _, _ := setupRouterWithConfig(t, func(c *config.Configuration) {
-			c.Server.UploadWhitelist = uploadServerHost(srv)
+			c.Server.UploadDomainWhitelist = uploadServerHost(srv)
 		})
 		resp := uploadMultipartURL(t, router, srv.URL+"/error", "bank-test")
 		assert.Equal(t, http.StatusInternalServerError, resp.Code)
@@ -457,7 +485,7 @@ func TestUploadExternalData_URLDownload(t *testing.T) {
 	t.Run("both file and url present, file wins", func(t *testing.T) {
 		srv := startUploadTestServer(t, nil)
 		router, _, _ := setupRouterWithConfig(t, func(c *config.Configuration) {
-			c.Server.UploadWhitelist = uploadServerHost(srv)
+			c.Server.UploadDomainWhitelist = uploadServerHost(srv)
 		})
 		fileContent := newCSVContent(t, 1) // 1 row — distinct from the URL's 2
 		resp := uploadMultipartFileAndURL(t, router, "data.csv", "bank-test", fileContent, srv.URL+"/data.csv")
@@ -473,7 +501,7 @@ func TestUploadExternalData_URLDownload(t *testing.T) {
 	t.Run("JSON body url points to valid CSV", func(t *testing.T) {
 		srv := startUploadTestServer(t, nil)
 		router, _, _ := setupRouterWithConfig(t, func(c *config.Configuration) {
-			c.Server.UploadWhitelist = uploadServerHost(srv)
+			c.Server.UploadDomainWhitelist = uploadServerHost(srv)
 		})
 		resp := uploadJSONURL(t, router, srv.URL+"/data.csv", "bank-json")
 		assert.Equal(t, http.StatusOK, resp.Code)
@@ -491,7 +519,7 @@ func TestUploadExternalData_URLWhitelist(t *testing.T) {
 	t.Run("host not in whitelist", func(t *testing.T) {
 		srv := startUploadTestServer(t, nil)
 		router, _, _ := setupRouterWithConfig(t, func(c *config.Configuration) {
-			c.Server.UploadWhitelist = "allowed.example.com" // does not include srv host
+			c.Server.UploadDomainWhitelist = "allowed.example.com" // does not include srv host
 		})
 		resp := uploadMultipartURL(t, router, srv.URL+"/data.csv", "bank-test")
 		assert.Equal(t, http.StatusBadRequest, resp.Code)
@@ -501,7 +529,7 @@ func TestUploadExternalData_URLWhitelist(t *testing.T) {
 	t.Run("empty whitelist denies all", func(t *testing.T) {
 		srv := startUploadTestServer(t, nil)
 		router, _, _ := setupRouterWithConfig(t, func(c *config.Configuration) {
-			c.Server.UploadWhitelist = ""
+			c.Server.UploadDomainWhitelist = ""
 		})
 		resp := uploadMultipartURL(t, router, srv.URL+"/data.csv", "bank-test")
 		assert.Equal(t, http.StatusBadRequest, resp.Code)
@@ -515,7 +543,7 @@ func TestUploadExternalData_URLWhitelist(t *testing.T) {
 		srv := startUploadTestServer(t, bigBody)
 		router, _, _ := setupRouterWithConfig(t, func(c *config.Configuration) {
 			c.Server.MaxUploadSizeMB = 1
-			c.Server.UploadWhitelist = uploadServerHost(srv)
+			c.Server.UploadDomainWhitelist = uploadServerHost(srv)
 		})
 		resp := uploadMultipartURL(t, router, srv.URL+"/big.csv", "bank-test")
 		assert.Equal(t, http.StatusInternalServerError, resp.Code)
@@ -526,7 +554,7 @@ func TestUploadExternalData_URLWhitelist(t *testing.T) {
 		srv := startUploadTestServer(t, nil)
 		router, _, _ := setupRouterWithConfig(t, func(c *config.Configuration) {
 			c.Server.UploadURLTimeoutSec = 1
-			c.Server.UploadWhitelist = uploadServerHost(srv)
+			c.Server.UploadDomainWhitelist = uploadServerHost(srv)
 		})
 		resp := uploadMultipartURL(t, router, srv.URL+"/slow", "bank-test")
 		assert.Equal(t, http.StatusInternalServerError, resp.Code)

--- a/api/reconciliation_api_test.go
+++ b/api/reconciliation_api_test.go
@@ -25,7 +25,10 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
+	"time"
 
 	model2 "github.com/blnkfinance/blnk/api/model"
 	"github.com/blnkfinance/blnk/config"
@@ -288,4 +291,245 @@ func TestUploadExternalData_RejectsOversizedBody(t *testing.T) {
 
 	assert.Equal(t, http.StatusRequestEntityTooLarge, resp.Code)
 	assert.Contains(t, resp.Body.String(), "exceeds the maximum allowed size")
+}
+
+// newCSVContent builds a 2-row external-transaction CSV payload.
+func newCSVContent(t *testing.T, rows int) []byte {
+	t.Helper()
+	if rows < 1 {
+		rows = 1
+	}
+	var b strings.Builder
+	b.WriteString("ID,Amount,Currency,Reference,Description,Date\n")
+	for i := 0; i < rows; i++ {
+		fmt.Fprintf(&b, "ext_%s,100.50,USD,ref_%s,row %d,2024-01-0%dT10:00:00Z\n",
+			gofakeit.UUID(), gofakeit.UUID(), i+1, i+1)
+	}
+	return []byte(b.String())
+}
+
+// uploadServerHost returns the lowercase hostname of a test server's base URL,
+// suitable for use as an exact-host whitelist entry.
+func uploadServerHost(srv *httptest.Server) string {
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		panic(err)
+	}
+	return strings.ToLower(u.Hostname())
+}
+
+// startUploadTestServer spins up an httptest.Server serving:
+//   /data.csv  -> a valid 2-row CSV
+//   /big.csv   -> a >1MB body (for oversize tests)
+//   /error     -> HTTP 500
+//   /slow      -> sleeps 5s before responding (for timeout tests)
+func startUploadTestServer(t *testing.T, bigBody []byte) *httptest.Server {
+	t.Helper()
+	csv := newCSVContent(t, 2)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/data.csv", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/csv")
+		_, _ = w.Write(csv)
+	})
+	mux.HandleFunc("/big.csv", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/csv")
+		_, _ = w.Write(bigBody)
+	})
+	mux.HandleFunc("/error", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	})
+	mux.HandleFunc("/slow", func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(5 * time.Second)
+		w.Header().Set("Content-Type", "text/csv")
+		_, _ = w.Write(csv)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// uploadMultipartURL posts a multipart form carrying only a `url` field
+// (and optional source), mirroring uploadMultipart but with no file part.
+func uploadMultipartURL(t *testing.T, router *gin.Engine, urlVal, source string) *httptest.ResponseRecorder {
+	t.Helper()
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	if source != "" {
+		if err := writer.WriteField("source", source); err != nil {
+			t.Fatalf("Failed to write source field: %v", err)
+		}
+	}
+	if err := writer.WriteField("url", urlVal); err != nil {
+		t.Fatalf("Failed to write url field: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("Failed to close multipart writer: %v", err)
+	}
+	req := httptest.NewRequest("POST", "/reconciliation/upload", &buf)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+	return resp
+}
+
+// uploadMultipartFileAndURL posts a multipart form with BOTH a `file` part and
+// a `url` field, used to verify that `file` wins.
+func uploadMultipartFileAndURL(t *testing.T, router *gin.Engine, fileName, source string, content []byte, urlVal string) *httptest.ResponseRecorder {
+	t.Helper()
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	if source != "" {
+		if err := writer.WriteField("source", source); err != nil {
+			t.Fatalf("Failed to write source field: %v", err)
+		}
+	}
+	if err := writer.WriteField("url", urlVal); err != nil {
+		t.Fatalf("Failed to write url field: %v", err)
+	}
+	part, err := writer.CreateFormFile("file", fileName)
+	if err != nil {
+		t.Fatalf("Failed to create form file: %v", err)
+	}
+	if _, err := part.Write(content); err != nil {
+		t.Fatalf("Failed to write file content: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("Failed to close multipart writer: %v", err)
+	}
+	req := httptest.NewRequest("POST", "/reconciliation/upload", &buf)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+	return resp
+}
+
+// uploadJSONURL posts an application/json body {"url","source"}.
+func uploadJSONURL(t *testing.T, router *gin.Engine, urlVal, source string) *httptest.ResponseRecorder {
+	t.Helper()
+	body, _ := json.Marshal(map[string]string{"url": urlVal, "source": source})
+	req := httptest.NewRequest("POST", "/reconciliation/upload", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+	return resp
+}
+
+func TestUploadExternalData_URLDownload(t *testing.T) {
+	// Router whose whitelist contains the test server's hostname.
+	router, _, _ := setupRouterWithConfig(t, func(c *config.Configuration) {
+		// whitelist is set per-subtest via the dedicated function below; here we
+		// just ensure MaxUploadSizeMB is a sane default.
+	})
+
+	t.Run("url field points to valid CSV", func(t *testing.T) {
+		srv := startUploadTestServer(t, nil)
+		router, _, _ := setupRouterWithConfig(t, func(c *config.Configuration) {
+			c.Server.UploadWhitelist = uploadServerHost(srv)
+		})
+		resp := uploadMultipartURL(t, router, srv.URL+"/data.csv", "bank-test")
+		assert.Equal(t, http.StatusOK, resp.Code)
+
+		var response map[string]interface{}
+		if err := json.Unmarshal(resp.Body.Bytes(), &response); err != nil {
+			t.Fatalf("Failed to decode response: %v", err)
+		}
+		assert.Contains(t, response["upload_id"], "upload_")
+		assert.Equal(t, float64(2), response["record_count"])
+		assert.Equal(t, "bank-test", response["source"])
+	})
+
+	t.Run("url field with invalid scheme", func(t *testing.T) {
+		resp := uploadMultipartURL(t, router, "ftp://example.com/x.csv", "bank-test")
+		assert.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.Contains(t, resp.Body.String(), "RECON_UPLOAD_URL_INVALID")
+	})
+
+	t.Run("url field pointing to a server that returns an error", func(t *testing.T) {
+		srv := startUploadTestServer(t, nil)
+		router, _, _ := setupRouterWithConfig(t, func(c *config.Configuration) {
+			c.Server.UploadWhitelist = uploadServerHost(srv)
+		})
+		resp := uploadMultipartURL(t, router, srv.URL+"/error", "bank-test")
+		assert.Equal(t, http.StatusInternalServerError, resp.Code)
+		assert.Contains(t, resp.Body.String(), "Failed to process upload")
+	})
+
+	t.Run("both file and url present, file wins", func(t *testing.T) {
+		srv := startUploadTestServer(t, nil)
+		router, _, _ := setupRouterWithConfig(t, func(c *config.Configuration) {
+			c.Server.UploadWhitelist = uploadServerHost(srv)
+		})
+		fileContent := newCSVContent(t, 1) // 1 row — distinct from the URL's 2
+		resp := uploadMultipartFileAndURL(t, router, "data.csv", "bank-test", fileContent, srv.URL+"/data.csv")
+		assert.Equal(t, http.StatusOK, resp.Code)
+
+		var response map[string]interface{}
+		if err := json.Unmarshal(resp.Body.Bytes(), &response); err != nil {
+			t.Fatalf("Failed to decode response: %v", err)
+		}
+		assert.Equal(t, float64(1), response["record_count"], "file content (1 row) must win over url (2 rows)")
+	})
+
+	t.Run("JSON body url points to valid CSV", func(t *testing.T) {
+		srv := startUploadTestServer(t, nil)
+		router, _, _ := setupRouterWithConfig(t, func(c *config.Configuration) {
+			c.Server.UploadWhitelist = uploadServerHost(srv)
+		})
+		resp := uploadJSONURL(t, router, srv.URL+"/data.csv", "bank-json")
+		assert.Equal(t, http.StatusOK, resp.Code)
+
+		var response map[string]interface{}
+		if err := json.Unmarshal(resp.Body.Bytes(), &response); err != nil {
+			t.Fatalf("Failed to decode response: %v", err)
+		}
+		assert.Equal(t, float64(2), response["record_count"])
+		assert.Equal(t, "bank-json", response["source"])
+	})
+}
+
+func TestUploadExternalData_URLWhitelist(t *testing.T) {
+	t.Run("host not in whitelist", func(t *testing.T) {
+		srv := startUploadTestServer(t, nil)
+		router, _, _ := setupRouterWithConfig(t, func(c *config.Configuration) {
+			c.Server.UploadWhitelist = "allowed.example.com" // does not include srv host
+		})
+		resp := uploadMultipartURL(t, router, srv.URL+"/data.csv", "bank-test")
+		assert.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.Contains(t, resp.Body.String(), "RECON_UPLOAD_HOST_NOT_ALLOWED")
+	})
+
+	t.Run("empty whitelist denies all", func(t *testing.T) {
+		srv := startUploadTestServer(t, nil)
+		router, _, _ := setupRouterWithConfig(t, func(c *config.Configuration) {
+			c.Server.UploadWhitelist = ""
+		})
+		resp := uploadMultipartURL(t, router, srv.URL+"/data.csv", "bank-test")
+		assert.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.Contains(t, resp.Body.String(), "RECON_UPLOAD_HOST_NOT_ALLOWED")
+	})
+
+	t.Run("oversize download returns 500", func(t *testing.T) {
+		// 2 MB CSV body, but MaxUploadSizeMB=1: the LimitReader truncates, so
+		// processing fails downstream.
+		bigBody := bytes.Repeat([]byte("a"), 2*1024*1024)
+		srv := startUploadTestServer(t, bigBody)
+		router, _, _ := setupRouterWithConfig(t, func(c *config.Configuration) {
+			c.Server.MaxUploadSizeMB = 1
+			c.Server.UploadWhitelist = uploadServerHost(srv)
+		})
+		resp := uploadMultipartURL(t, router, srv.URL+"/big.csv", "bank-test")
+		assert.Equal(t, http.StatusInternalServerError, resp.Code)
+		assert.Contains(t, resp.Body.String(), "Failed to process upload")
+	})
+
+	t.Run("timeout enforced", func(t *testing.T) {
+		srv := startUploadTestServer(t, nil)
+		router, _, _ := setupRouterWithConfig(t, func(c *config.Configuration) {
+			c.Server.UploadURLTimeoutSec = 1
+			c.Server.UploadWhitelist = uploadServerHost(srv)
+		})
+		resp := uploadMultipartURL(t, router, srv.URL+"/slow", "bank-test")
+		assert.Equal(t, http.StatusInternalServerError, resp.Code)
+		assert.Contains(t, resp.Body.String(), "Failed to process upload")
+	})
 }

--- a/config/config.go
+++ b/config/config.go
@@ -19,6 +19,7 @@ package config
 import (
 	"encoding/json"
 	"errors"
+	"net/url"
 	"os"
 	"strings"
 	"sync/atomic"
@@ -38,6 +39,10 @@ const (
 	// DEFAULT_MAX_REQUEST_BODY_SIZE_MB caps non-upload request bodies so a large
 	// POST can't exhaust memory before a handler (or the auth middleware) reads it.
 	DEFAULT_MAX_REQUEST_BODY_SIZE_MB = 5
+	// DEFAULT_UPLOAD_URL_TIMEOUT_SEC caps how long a URL-based reconciliation
+	// upload may spend fetching the remote body, preventing a slow or stalled
+	// upstream from hanging the handler.
+	DEFAULT_UPLOAD_URL_TIMEOUT_SEC = 30
 )
 
 // Default values for different configurations
@@ -106,6 +111,15 @@ type ServerConfig struct {
 	MetricsBearerToken string `json:"metrics_bearer_token" envconfig:"BLNK_METRICS_BEARER_TOKEN"`
 	MaxUploadSizeMB      int64 `json:"max_upload_size_mb" envconfig:"BLNK_SERVER_MAX_UPLOAD_SIZE_MB"`
 	MaxRequestBodySizeMB int64 `json:"max_request_body_size_mb" envconfig:"BLNK_SERVER_MAX_REQUEST_BODY_SIZE_MB"`
+
+	// UploadWhitelist is a comma-separated list of exact hostnames permitted as
+	// targets for URL-based reconciliation uploads (BLNK_UPLOAD_WHITELIST).
+	// Empty/unset means deny-by-default: every URL upload is rejected. Listing a
+	// bare IP literal or "localhost" is unsafe and defeats the SSRF guard.
+	UploadWhitelist string `json:"upload_whitelist" envconfig:"BLNK_UPLOAD_WHITELIST"`
+	// UploadURLTimeoutSec caps the HTTP GET issued for a URL-based upload
+	// (BLNK_UPLOAD_URL_TIMEOUT_SEC). Defaults to DEFAULT_UPLOAD_URL_TIMEOUT_SEC.
+	UploadURLTimeoutSec int `json:"upload_url_timeout_sec" envconfig:"BLNK_UPLOAD_URL_TIMEOUT_SEC"`
 }
 
 type DataSourceConfig struct {
@@ -341,6 +355,10 @@ func (cnf *Configuration) setDefaultValues() {
 		cnf.Server.MaxRequestBodySizeMB = DEFAULT_MAX_REQUEST_BODY_SIZE_MB
 	}
 
+	if cnf.Server.UploadURLTimeoutSec <= 0 {
+		cnf.Server.UploadURLTimeoutSec = DEFAULT_UPLOAD_URL_TIMEOUT_SEC
+	}
+
 	if cnf.TypeSenseKey == "" {
 		cnf.TypeSenseKey = DEFAULT_TYPESENSE_KEY
 	}
@@ -498,6 +516,47 @@ func (cnf *Configuration) trimWhitespace() {
 	cnf.Server.Port = strings.TrimSpace(cnf.Server.Port)
 	cnf.DataSource.Dns = strings.TrimSpace(cnf.DataSource.Dns)
 	cnf.Redis.Dns = strings.TrimSpace(cnf.Redis.Dns)
+}
+
+// UploadWhitelistHosts returns the parsed, trimmed, de-duplicated, lowercase
+// list of exact hostnames permitted as targets for URL-based reconciliation
+// uploads. Entries may be supplied as bare hostnames ("example.com") or full
+// URLs ("https://example.com/path"); the hostname is extracted either way.
+// An empty/unset whitelist yields an empty slice, which the upload handler
+// treats as deny-by-default.
+func (cnf *Configuration) UploadWhitelistHosts() []string {
+	raw := strings.TrimSpace(cnf.Server.UploadWhitelist)
+	if raw == "" {
+		return nil
+	}
+
+	seen := make(map[string]struct{})
+	hosts := make([]string, 0, 4)
+	for _, entry := range strings.Split(raw, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		// Tolerate entries supplied as full URLs by extracting the hostname.
+		var host string
+		if strings.Contains(entry, "://") {
+			if u, err := url.Parse(entry); err == nil {
+				host = u.Hostname()
+			}
+		} else {
+			host = entry
+		}
+		host = strings.ToLower(strings.TrimSpace(host))
+		if host == "" {
+			continue
+		}
+		if _, ok := seen[host]; ok {
+			continue
+		}
+		seen[host] = struct{}{}
+		hosts = append(hosts, host)
+	}
+	return hosts
 }
 
 func (cnf *Configuration) setupRateLimiting() {

--- a/config/config.go
+++ b/config/config.go
@@ -101,40 +101,40 @@ var (
 var ConfigStore atomic.Value
 
 type ServerConfig struct {
-	SSL                bool   `json:"ssl" envconfig:"BLNK_SERVER_SSL"`
-	CertStoragePath    string `json:"cert_storage_path" envconfig:"BLNK_CERT_STORAGE_PATH"`
-	Secure             bool   `json:"secure" envconfig:"BLNK_SERVER_SECURE"`
-	SecretKey          string `json:"secret_key" envconfig:"BLNK_SERVER_SECRET_KEY"`
-	Domain             string `json:"domain" envconfig:"BLNK_SERVER_SSL_DOMAIN"`
-	Email              string `json:"ssl_email" envconfig:"BLNK_SERVER_SSL_EMAIL"`
-	Port               string `json:"port" envconfig:"BLNK_SERVER_PORT"`
-	MetricsBearerToken string `json:"metrics_bearer_token" envconfig:"BLNK_METRICS_BEARER_TOKEN"`
-	MaxUploadSizeMB      int64 `json:"max_upload_size_mb" envconfig:"BLNK_SERVER_MAX_UPLOAD_SIZE_MB"`
-	MaxRequestBodySizeMB int64 `json:"max_request_body_size_mb" envconfig:"BLNK_SERVER_MAX_REQUEST_BODY_SIZE_MB"`
+	SSL                  bool   `json:"ssl"                      envconfig:"BLNK_SERVER_SSL"`
+	CertStoragePath      string `json:"cert_storage_path"        envconfig:"BLNK_CERT_STORAGE_PATH"`
+	Secure               bool   `json:"secure"                   envconfig:"BLNK_SERVER_SECURE"`
+	SecretKey            string `json:"secret_key"               envconfig:"BLNK_SERVER_SECRET_KEY"`
+	Domain               string `json:"domain"                   envconfig:"BLNK_SERVER_SSL_DOMAIN"`
+	Email                string `json:"ssl_email"                envconfig:"BLNK_SERVER_SSL_EMAIL"`
+	Port                 string `json:"port"                     envconfig:"BLNK_SERVER_PORT"`
+	MetricsBearerToken   string `json:"metrics_bearer_token"     envconfig:"BLNK_METRICS_BEARER_TOKEN"`
+	MaxUploadSizeMB      int64  `json:"max_upload_size_mb"       envconfig:"BLNK_SERVER_MAX_UPLOAD_SIZE_MB"`
+	MaxRequestBodySizeMB int64  `json:"max_request_body_size_mb" envconfig:"BLNK_SERVER_MAX_REQUEST_BODY_SIZE_MB"`
 
 	// UploadWhitelist is a comma-separated list of exact hostnames permitted as
-	// targets for URL-based reconciliation uploads (BLNK_UPLOAD_WHITELIST).
+	// targets for URL-based reconciliation uploads (BLNK_UPLOAD_DOMAIN_WHITELIST).
 	// Empty/unset means deny-by-default: every URL upload is rejected. Listing a
 	// bare IP literal or "localhost" is unsafe and defeats the SSRF guard.
-	UploadWhitelist string `json:"upload_whitelist" envconfig:"BLNK_UPLOAD_WHITELIST"`
+	UploadDomainWhitelist string `json:"upload_whitelist"       envconfig:"BLNK_UPLOAD_DOMAIN_WHITELIST"`
 	// UploadURLTimeoutSec caps the HTTP GET issued for a URL-based upload
 	// (BLNK_UPLOAD_URL_TIMEOUT_SEC). Defaults to DEFAULT_UPLOAD_URL_TIMEOUT_SEC.
 	UploadURLTimeoutSec int `json:"upload_url_timeout_sec" envconfig:"BLNK_UPLOAD_URL_TIMEOUT_SEC"`
 }
 
 type DataSourceConfig struct {
-	Dns             string        `json:"dns" envconfig:"BLNK_DATA_SOURCE_DNS"`
-	MaxOpenConns    int           `json:"max_open_conns" envconfig:"BLNK_DATABASE_MAX_OPEN_CONNS"`
-	MaxIdleConns    int           `json:"max_idle_conns" envconfig:"BLNK_DATABASE_MAX_IDLE_CONNS"`
-	ConnMaxLifetime time.Duration `json:"conn_max_lifetime" envconfig:"BLNK_DATABASE_CONN_MAX_LIFETIME"`
+	Dns             string        `json:"dns"                envconfig:"BLNK_DATA_SOURCE_DNS"`
+	MaxOpenConns    int           `json:"max_open_conns"     envconfig:"BLNK_DATABASE_MAX_OPEN_CONNS"`
+	MaxIdleConns    int           `json:"max_idle_conns"     envconfig:"BLNK_DATABASE_MAX_IDLE_CONNS"`
+	ConnMaxLifetime time.Duration `json:"conn_max_lifetime"  envconfig:"BLNK_DATABASE_CONN_MAX_LIFETIME"`
 	ConnMaxIdleTime time.Duration `json:"conn_max_idle_time" envconfig:"BLNK_DATABASE_CONN_MAX_IDLE_TIME"`
 }
 
 type RedisConfig struct {
-	Dns           string `json:"dns" envconfig:"BLNK_REDIS_DNS"`
+	Dns           string `json:"dns"             envconfig:"BLNK_REDIS_DNS"`
 	SkipTLSVerify bool   `json:"skip_tls_verify" envconfig:"BLNK_REDIS_SKIP_TLS_VERIFY"`
-	PoolSize      int    `json:"pool_size" envconfig:"BLNK_REDIS_POOL_SIZE"`
-	MinIdleConns  int    `json:"min_idle_conns" envconfig:"BLNK_REDIS_MIN_IDLE_CONNS"`
+	PoolSize      int    `json:"pool_size"       envconfig:"BLNK_REDIS_POOL_SIZE"`
+	MinIdleConns  int    `json:"min_idle_conns"  envconfig:"BLNK_REDIS_MIN_IDLE_CONNS"`
 }
 
 type TypeSenseConfig struct {
@@ -154,8 +154,8 @@ type AccountNumberGenerationConfig struct {
 }
 
 type RateLimitConfig struct {
-	RequestsPerSecond  *float64 `json:"requests_per_second" envconfig:"BLNK_RATE_LIMIT_RPS"`
-	Burst              *int     `json:"burst" envconfig:"BLNK_RATE_LIMIT_BURST"`
+	RequestsPerSecond  *float64 `json:"requests_per_second"  envconfig:"BLNK_RATE_LIMIT_RPS"`
+	Burst              *int     `json:"burst"                envconfig:"BLNK_RATE_LIMIT_BURST"`
 	CleanupIntervalSec *int     `json:"cleanup_interval_sec" envconfig:"BLNK_RATE_LIMIT_CLEANUP_INTERVAL_SEC"`
 }
 
@@ -164,7 +164,7 @@ type SlackWebhook struct {
 }
 
 type WebhookConfig struct {
-	Url     string            `json:"url" envconfig:"BLNK_WEBHOOK_URL"`
+	Url     string            `json:"url"     envconfig:"BLNK_WEBHOOK_URL"`
 	Headers map[string]string `json:"headers" envconfig:"BLNK_WEBHOOK_HEADERS"`
 }
 
@@ -174,65 +174,65 @@ type Notification struct {
 }
 
 type TransactionConfig struct {
-	BatchSize                  int           `json:"batch_size" envconfig:"BLNK_TRANSACTION_BATCH_SIZE"`
-	MaxQueueSize               int           `json:"max_queue_size" envconfig:"BLNK_TRANSACTION_MAX_QUEUE_SIZE"`
-	MaxWorkers                 int           `json:"max_workers" envconfig:"BLNK_TRANSACTION_MAX_WORKERS"`
-	LockDuration               time.Duration `json:"lock_duration" envconfig:"BLNK_TRANSACTION_LOCK_DURATION"`
-	LockWaitTimeout            time.Duration `json:"lock_wait_timeout" envconfig:"BLNK_TRANSACTION_LOCK_WAIT_TIMEOUT"`
-	IndexQueuePrefix           string        `json:"index_queue_prefix" envconfig:"BLNK_TRANSACTION_INDEX_QUEUE_PREFIX"`
-	EnableCoalescing           bool          `json:"enable_coalescing" envconfig:"BLNK_TRANSACTION_ENABLE_COALESCING"`
-	EnableQueuedChecks         bool          `json:"enable_queued_checks" envconfig:"BLNK_TRANSACTION_ENABLE_QUEUED_CHECKS"`
-	DisableBatchReferenceCheck bool          `json:"disable_batch_reference_check" envconfig:"BLNK_TRANSACTION_DISABLE_BATCH_REFERENCE_CHECK"`
+	BatchSize                  int             `json:"batch_size"                    envconfig:"BLNK_TRANSACTION_BATCH_SIZE"`
+	MaxQueueSize               int             `json:"max_queue_size"                envconfig:"BLNK_TRANSACTION_MAX_QUEUE_SIZE"`
+	MaxWorkers                 int             `json:"max_workers"                   envconfig:"BLNK_TRANSACTION_MAX_WORKERS"`
+	LockDuration               time.Duration   `json:"lock_duration"                 envconfig:"BLNK_TRANSACTION_LOCK_DURATION"`
+	LockWaitTimeout            time.Duration   `json:"lock_wait_timeout"             envconfig:"BLNK_TRANSACTION_LOCK_WAIT_TIMEOUT"`
+	IndexQueuePrefix           string          `json:"index_queue_prefix"            envconfig:"BLNK_TRANSACTION_INDEX_QUEUE_PREFIX"`
+	EnableCoalescing           bool            `json:"enable_coalescing"             envconfig:"BLNK_TRANSACTION_ENABLE_COALESCING"`
+	EnableQueuedChecks         bool            `json:"enable_queued_checks"          envconfig:"BLNK_TRANSACTION_ENABLE_QUEUED_CHECKS"`
+	DisableBatchReferenceCheck bool            `json:"disable_batch_reference_check" envconfig:"BLNK_TRANSACTION_DISABLE_BATCH_REFERENCE_CHECK"`
 	HashChain                  HashChainConfig `json:"hash_chain"`
 }
 
 type ReconciliationConfig struct {
-	DefaultStrategy  string        `json:"default_strategy" envconfig:"BLNK_RECONCILIATION_DEFAULT_STRATEGY"`
+	DefaultStrategy  string        `json:"default_strategy"  envconfig:"BLNK_RECONCILIATION_DEFAULT_STRATEGY"`
 	ProgressInterval int           `json:"progress_interval" envconfig:"BLNK_RECONCILIATION_PROGRESS_INTERVAL"`
-	MaxRetries       int           `json:"max_retries" envconfig:"BLNK_RECONCILIATION_MAX_RETRIES"`
-	RetryDelay       time.Duration `json:"retry_delay" envconfig:"BLNK_RECONCILIATION_RETRY_DELAY"`
+	MaxRetries       int           `json:"max_retries"       envconfig:"BLNK_RECONCILIATION_MAX_RETRIES"`
+	RetryDelay       time.Duration `json:"retry_delay"       envconfig:"BLNK_RECONCILIATION_RETRY_DELAY"`
 }
 
 type QueueConfig struct {
-	TransactionQueue                string        `json:"transaction_queue" envconfig:"BLNK_QUEUE_TRANSACTION"`
-	WebhookQueue                    string        `json:"webhook_queue" envconfig:"BLNK_QUEUE_WEBHOOK"`
-	IndexQueue                      string        `json:"index_queue" envconfig:"BLNK_QUEUE_INDEX"`
-	InflightExpiryQueue             string        `json:"inflight_expiry_queue" envconfig:"BLNK_QUEUE_INFLIGHT_EXPIRY"`
-	InflightCommitQueue             string        `json:"inflight_commit_queue" envconfig:"BLNK_QUEUE_INFLIGHT_COMMIT"`
-	NumberOfQueues                  int           `json:"number_of_queues" envconfig:"BLNK_QUEUE_NUMBER_OF_QUEUES"`
-	EnableHotLane                   bool          `json:"enable_hot_lane" envconfig:"BLNK_QUEUE_ENABLE_HOT_LANE"`
-	HotQueueName                    string        `json:"hot_queue_name" envconfig:"BLNK_QUEUE_HOT_QUEUE_NAME"`
-	HotQueueConcurrency             int           `json:"hot_queue_concurrency" envconfig:"BLNK_QUEUE_HOT_QUEUE_CONCURRENCY"`
-	HotPairTTL                      time.Duration `json:"hot_pair_ttl" envconfig:"BLNK_QUEUE_HOT_PAIR_TTL"`
+	TransactionQueue                string        `json:"transaction_queue"                  envconfig:"BLNK_QUEUE_TRANSACTION"`
+	WebhookQueue                    string        `json:"webhook_queue"                      envconfig:"BLNK_QUEUE_WEBHOOK"`
+	IndexQueue                      string        `json:"index_queue"                        envconfig:"BLNK_QUEUE_INDEX"`
+	InflightExpiryQueue             string        `json:"inflight_expiry_queue"              envconfig:"BLNK_QUEUE_INFLIGHT_EXPIRY"`
+	InflightCommitQueue             string        `json:"inflight_commit_queue"              envconfig:"BLNK_QUEUE_INFLIGHT_COMMIT"`
+	NumberOfQueues                  int           `json:"number_of_queues"                   envconfig:"BLNK_QUEUE_NUMBER_OF_QUEUES"`
+	EnableHotLane                   bool          `json:"enable_hot_lane"                    envconfig:"BLNK_QUEUE_ENABLE_HOT_LANE"`
+	HotQueueName                    string        `json:"hot_queue_name"                     envconfig:"BLNK_QUEUE_HOT_QUEUE_NAME"`
+	HotQueueConcurrency             int           `json:"hot_queue_concurrency"              envconfig:"BLNK_QUEUE_HOT_QUEUE_CONCURRENCY"`
+	HotPairTTL                      time.Duration `json:"hot_pair_ttl"                       envconfig:"BLNK_QUEUE_HOT_PAIR_TTL"`
 	HotPairLockContentionThreshold  int           `json:"hot_pair_lock_contention_threshold" envconfig:"BLNK_QUEUE_HOT_PAIR_LOCK_CONTENTION_THRESHOLD"`
 	RejectLockContentionImmediately bool          `json:"reject_lock_contention_immediately" envconfig:"BLNK_QUEUE_REJECT_LOCK_CONTENTION_IMMEDIATELY"`
-	InsufficientFundRetries         bool          `json:"insufficient_fund_retries" envconfig:"BLNK_QUEUE_INSUFFICIENT_FUND_RETRIES"`
-	MaxRetryAttempts                int           `json:"max_retry_attempts" envconfig:"BLNK_QUEUE_MAX_RETRY_ATTEMPTS"`
-	MonitoringPort                  string        `json:"monitoring_port" envconfig:"BLNK_QUEUE_MONITORING_PORT"`
-	WebhookConcurrency              int           `json:"webhook_concurrency" envconfig:"BLNK_QUEUE_WEBHOOK_CONCURRENCY"`
-	TransactionWorkerConcurrency    int           `json:"transaction_worker_concurrency" envconfig:"BLNK_QUEUE_TRANSACTION_WORKER_CONCURRENCY"`
+	InsufficientFundRetries         bool          `json:"insufficient_fund_retries"          envconfig:"BLNK_QUEUE_INSUFFICIENT_FUND_RETRIES"`
+	MaxRetryAttempts                int           `json:"max_retry_attempts"                 envconfig:"BLNK_QUEUE_MAX_RETRY_ATTEMPTS"`
+	MonitoringPort                  string        `json:"monitoring_port"                    envconfig:"BLNK_QUEUE_MONITORING_PORT"`
+	WebhookConcurrency              int           `json:"webhook_concurrency"                envconfig:"BLNK_QUEUE_WEBHOOK_CONCURRENCY"`
+	TransactionWorkerConcurrency    int           `json:"transaction_worker_concurrency"     envconfig:"BLNK_QUEUE_TRANSACTION_WORKER_CONCURRENCY"`
 }
 
 type Configuration struct {
-	ProjectName             string                        `json:"project_name" envconfig:"BLNK_PROJECT_NAME"`
-	BackupDir               string                        `json:"backup_dir" envconfig:"BLNK_BACKUP_DIR"`
-	AwsAccessKeyId          string                        `json:"aws_access_key_id" envconfig:"BLNK_AWS_ACCESS_KEY_ID"`
-	S3Endpoint              string                        `json:"s3_endpoint" envconfig:"BLNK_S3_ENDPOINT"`
-	AwsSecretAccessKey      string                        `json:"aws_secret_access_key" envconfig:"BLNK_AWS_SECRET_ACCESS_KEY"`
-	S3BucketName            string                        `json:"s3_bucket_name" envconfig:"BLNK_S3_BUCKET_NAME"`
-	S3Region                string                        `json:"s3_region" envconfig:"BLNK_S3_REGION"`
+	ProjectName             string                        `json:"project_name"              envconfig:"BLNK_PROJECT_NAME"`
+	BackupDir               string                        `json:"backup_dir"                envconfig:"BLNK_BACKUP_DIR"`
+	AwsAccessKeyId          string                        `json:"aws_access_key_id"         envconfig:"BLNK_AWS_ACCESS_KEY_ID"`
+	S3Endpoint              string                        `json:"s3_endpoint"               envconfig:"BLNK_S3_ENDPOINT"`
+	AwsSecretAccessKey      string                        `json:"aws_secret_access_key"     envconfig:"BLNK_AWS_SECRET_ACCESS_KEY"`
+	S3BucketName            string                        `json:"s3_bucket_name"            envconfig:"BLNK_S3_BUCKET_NAME"`
+	S3Region                string                        `json:"s3_region"                 envconfig:"BLNK_S3_REGION"`
 	Server                  ServerConfig                  `json:"server"`
 	DataSource              DataSourceConfig              `json:"data_source"`
 	Redis                   RedisConfig                   `json:"redis"`
 	TypeSense               TypeSenseConfig               `json:"typesense"`
-	TypeSenseKey            string                        `json:"type_sense_key" envconfig:"BLNK_TYPESENSE_KEY"`
-	TokenizationSecret      string                        `json:"tokenization_secret" envconfig:"BLNK_TOKENIZATION_SECRET"`
+	TypeSenseKey            string                        `json:"type_sense_key"            envconfig:"BLNK_TYPESENSE_KEY"`
+	TokenizationSecret      string                        `json:"tokenization_secret"       envconfig:"BLNK_TOKENIZATION_SECRET"`
 	AccountNumberGeneration AccountNumberGenerationConfig `json:"account_number_generation"`
 	Notification            Notification                  `json:"notification"`
 	RateLimit               RateLimitConfig               `json:"rate_limit"`
-	EnableTelemetry         bool                          `json:"enable_telemetry" envconfig:"BLNK_ENABLE_TELEMETRY"`
-	EnableObservability     bool                          `json:"enable_observability" envconfig:"BLNK_ENABLE_OBSERVABILITY"`
-	MonitoringDSN           string                        `json:"monitoring_dsn" envconfig:"BLNK_MONITORING_DSN"`
+	EnableTelemetry         bool                          `json:"enable_telemetry"          envconfig:"BLNK_ENABLE_TELEMETRY"`
+	EnableObservability     bool                          `json:"enable_observability"      envconfig:"BLNK_ENABLE_OBSERVABILITY"`
+	MonitoringDSN           string                        `json:"monitoring_dsn"            envconfig:"BLNK_MONITORING_DSN"`
 	Transaction             TransactionConfig             `json:"transaction"`
 	Reconciliation          ReconciliationConfig          `json:"reconciliation"`
 	Queue                   QueueConfig                   `json:"queue"`
@@ -242,9 +242,9 @@ type Configuration struct {
 // history into a tamper-evident chain. It lives under transaction config and is
 // disabled by default.
 type HashChainConfig struct {
-	Enabled       bool          `json:"enabled" envconfig:"BLNK_TRANSACTION_HASHCHAIN_ENABLED"`
-	PollInterval  time.Duration `json:"poll_interval" envconfig:"BLNK_TRANSACTION_HASHCHAIN_POLL_INTERVAL"`
-	BatchSize     int           `json:"batch_size" envconfig:"BLNK_TRANSACTION_HASHCHAIN_BATCH_SIZE"`
+	Enabled       bool          `json:"enabled"        envconfig:"BLNK_TRANSACTION_HASHCHAIN_ENABLED"`
+	PollInterval  time.Duration `json:"poll_interval"  envconfig:"BLNK_TRANSACTION_HASHCHAIN_POLL_INTERVAL"`
+	BatchSize     int           `json:"batch_size"     envconfig:"BLNK_TRANSACTION_HASHCHAIN_BATCH_SIZE"`
 	TrailingDelay time.Duration `json:"trailing_delay" envconfig:"BLNK_TRANSACTION_HASHCHAIN_TRAILING_DELAY"`
 }
 
@@ -311,7 +311,9 @@ func (cnf *Configuration) validateAndAddDefaults() error {
 	cnf.setupRateLimiting()
 
 	if !cnf.Server.Secure {
-		logrus.Warn("SECURITY: server.secure is false — API authentication is DISABLED. Do not use this configuration in production.")
+		logrus.Warn(
+			"SECURITY: server.secure is false — API authentication is DISABLED. Do not use this configuration in production.",
+		)
 	}
 
 	// Validate tokenization secret length (AES-256 requires 32 bytes)
@@ -518,14 +520,14 @@ func (cnf *Configuration) trimWhitespace() {
 	cnf.Redis.Dns = strings.TrimSpace(cnf.Redis.Dns)
 }
 
-// UploadWhitelistHosts returns the parsed, trimmed, de-duplicated, lowercase
+// UploadDomainWhitelistHosts returns the parsed, trimmed, de-duplicated, lowercase
 // list of exact hostnames permitted as targets for URL-based reconciliation
 // uploads. Entries may be supplied as bare hostnames ("example.com") or full
 // URLs ("https://example.com/path"); the hostname is extracted either way.
 // An empty/unset whitelist yields an empty slice, which the upload handler
 // treats as deny-by-default.
-func (cnf *Configuration) UploadWhitelistHosts() []string {
-	raw := strings.TrimSpace(cnf.Server.UploadWhitelist)
+func (cnf *Configuration) UploadDomainWhitelistHosts() []string {
+	raw := strings.TrimSpace(cnf.Server.UploadDomainWhitelist)
 	if raw == "" {
 		return nil
 	}
@@ -587,7 +589,8 @@ func (cnf *Configuration) setupRateLimiting() {
 	if cnf.RateLimit.CleanupIntervalSec == nil {
 		defaultCleanup := DEFAULT_CLEANUP_SEC
 		cnf.RateLimit.CleanupIntervalSec = &defaultCleanup
-		logrus.WithField("cleanup_interval_sec", defaultCleanup).Warn("rate limit cleanup interval not specified, setting default")
+		logrus.WithField("cleanup_interval_sec", defaultCleanup).
+			Warn("rate limit cleanup interval not specified, setting default")
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -322,3 +322,80 @@ func TestInitConfig(t *testing.T) {
 		t.Errorf("Expected DataSource.Dns to be 'init-config-dns', got '%s'", loadedConfig.DataSource.Dns)
 	}
 }
+
+// TestUploadURLTimeoutDefault verifies that an unset/zero upload URL timeout is
+// defaulted to DEFAULT_UPLOAD_URL_TIMEOUT_SEC (30s).
+func TestUploadURLTimeoutDefault(t *testing.T) {
+	cnf := Configuration{
+		ProjectName: "Test Project",
+		DataSource: DataSourceConfig{Dns: "some-dns"},
+		Redis:       RedisConfig{Dns: "localhost:6379"},
+	}
+	cnf.Server.UploadURLTimeoutSec = 0
+	if err := cnf.validateAndAddDefaults(); err != nil {
+		t.Fatalf("validateAndAddDefaults failed: %v", err)
+	}
+	if cnf.Server.UploadURLTimeoutSec != DEFAULT_UPLOAD_URL_TIMEOUT_SEC {
+		t.Errorf("expected default timeout %d, got %d", DEFAULT_UPLOAD_URL_TIMEOUT_SEC, cnf.Server.UploadURLTimeoutSec)
+	}
+
+	// An explicitly-configured value must be preserved.
+	cnf2 := Configuration{
+		ProjectName: "Test Project",
+		DataSource: DataSourceConfig{Dns: "some-dns"},
+		Redis:       RedisConfig{Dns: "localhost:6379"},
+	}
+	cnf2.Server.UploadURLTimeoutSec = 7
+	if err := cnf2.validateAndAddDefaults(); err != nil {
+		t.Fatalf("validateAndAddDefaults failed: %v", err)
+	}
+	if cnf2.Server.UploadURLTimeoutSec != 7 {
+		t.Errorf("expected explicit timeout 7 to be preserved, got %d", cnf2.Server.UploadURLTimeoutSec)
+	}
+}
+
+// TestUploadWhitelistHostsParsing verifies parsing of the comma-separated
+// whitelist: trimming, scheme-tolerance, case-folding, de-duplication, and
+// deny-by-default (empty -> nil).
+func TestUploadWhitelistHostsParsing(t *testing.T) {
+	cases := []struct {
+		name   string
+		raw    string
+		expect []string
+	}{
+		{
+			name:   "mixed entries with schemes, empties, and dup",
+			raw:    "example.com, https://x.com/path, ,Foo.COM, example.com",
+			expect: []string{"example.com", "x.com", "foo.com"},
+		},
+		{
+			name:   "bare hostnames only",
+			raw:    "a.example.com, b.example.com",
+			expect: []string{"a.example.com", "b.example.com"},
+		},
+		{
+			name:   "empty whitelist is deny-by-default",
+			raw:    "",
+			expect: nil,
+		},
+		{
+			name:   "only whitespace and commas",
+			raw:    " , , ",
+			expect: nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cnf := Configuration{Server: ServerConfig{UploadWhitelist: tc.raw}}
+			got := cnf.UploadWhitelistHosts()
+			if len(got) != len(tc.expect) {
+				t.Fatalf("expected %v, got %v", tc.expect, got)
+			}
+			for i := range got {
+				if got[i] != tc.expect[i] {
+					t.Errorf("entry %d: expected %q, got %q", i, tc.expect[i], got[i])
+				}
+			}
+		})
+	}
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -328,7 +328,7 @@ func TestInitConfig(t *testing.T) {
 func TestUploadURLTimeoutDefault(t *testing.T) {
 	cnf := Configuration{
 		ProjectName: "Test Project",
-		DataSource: DataSourceConfig{Dns: "some-dns"},
+		DataSource:  DataSourceConfig{Dns: "some-dns"},
 		Redis:       RedisConfig{Dns: "localhost:6379"},
 	}
 	cnf.Server.UploadURLTimeoutSec = 0
@@ -342,7 +342,7 @@ func TestUploadURLTimeoutDefault(t *testing.T) {
 	// An explicitly-configured value must be preserved.
 	cnf2 := Configuration{
 		ProjectName: "Test Project",
-		DataSource: DataSourceConfig{Dns: "some-dns"},
+		DataSource:  DataSourceConfig{Dns: "some-dns"},
 		Redis:       RedisConfig{Dns: "localhost:6379"},
 	}
 	cnf2.Server.UploadURLTimeoutSec = 7
@@ -386,8 +386,8 @@ func TestUploadWhitelistHostsParsing(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			cnf := Configuration{Server: ServerConfig{UploadWhitelist: tc.raw}}
-			got := cnf.UploadWhitelistHosts()
+			cnf := Configuration{Server: ServerConfig{UploadDomainWhitelist: tc.raw}}
+			got := cnf.UploadDomainWhitelistHosts()
 			if len(got) != len(tc.expect) {
 				t.Fatalf("expected %v, got %v", tc.expect, got)
 			}

--- a/internal/apierror/codes.go
+++ b/internal/apierror/codes.go
@@ -103,6 +103,8 @@ const (
 	ErrReconRuleNotFound           ErrorCode = "RECON_RULE_NOT_FOUND"
 	ErrReconUploadFailed           ErrorCode = "RECON_UPLOAD_FAILED"
 	ErrReconUploadProcessingFailed ErrorCode = "RECON_UPLOAD_PROCESSING_FAILED"
+	ErrReconUploadURLInvalid       ErrorCode = "RECON_UPLOAD_URL_INVALID"
+	ErrReconUploadHostNotAllowed   ErrorCode = "RECON_UPLOAD_HOST_NOT_ALLOWED"
 	ErrReconRuleInvalid            ErrorCode = "RECON_RULE_INVALID"
 	ErrReconMatchingRulesRequired  ErrorCode = "RECON_MATCHING_RULES_REQUIRED"
 	ErrReconExternalTxnsRequired   ErrorCode = "RECON_EXTERNAL_TXNS_REQUIRED"
@@ -199,6 +201,8 @@ var statusByCode = map[ErrorCode]int{
 	ErrReconRuleNotFound:           http.StatusNotFound,
 	ErrReconUploadFailed:           http.StatusBadRequest,
 	ErrReconUploadProcessingFailed: http.StatusInternalServerError,
+	ErrReconUploadURLInvalid:       http.StatusBadRequest,
+	ErrReconUploadHostNotAllowed:   http.StatusBadRequest,
 	ErrReconRuleInvalid:            http.StatusBadRequest,
 	ErrReconMatchingRulesRequired:  http.StatusBadRequest,
 	ErrReconExternalTxnsRequired:   http.StatusBadRequest,

--- a/internal/apierror/codes_test.go
+++ b/internal/apierror/codes_test.go
@@ -87,6 +87,8 @@ func TestStatusForCode(t *testing.T) {
 		{ErrReconRuleNotFound, http.StatusNotFound},
 		{ErrReconUploadFailed, http.StatusBadRequest},
 		{ErrReconUploadProcessingFailed, http.StatusInternalServerError},
+		{ErrReconUploadURLInvalid, http.StatusBadRequest},
+		{ErrReconUploadHostNotAllowed, http.StatusBadRequest},
 		{ErrReconRuleInvalid, http.StatusBadRequest},
 		{ErrReconMatchingRulesRequired, http.StatusBadRequest},
 		{ErrReconExternalTxnsRequired, http.StatusBadRequest},


### PR DESCRIPTION
* Introduced support for URL-based uploads in the reconciliation API, allowing users to upload data from a specified URL or a file.
* Implemented a timeout for URL fetching to prevent hanging requests, with a default of 30 seconds.
* Added validation for upload URLs, ensuring only whitelisted hosts are permitted, enhancing security against SSRF attacks.
* Updated the configuration to include an upload whitelist and URL timeout settings.
* Added comprehensive tests for the new upload features, including various scenarios for URL validation and response handling.

---

Config Added

```go
// UploadWhitelist is a comma-separated list of exact hostnames permitted as
// targets for URL-based reconciliation uploads (BLNK_UPLOAD_DOMAIN_WHITELIST).
// Empty/unset means deny-by-default: every URL upload is rejected. Listing a
// bare IP literal or "localhost" is unsafe and defeats the SSRF guard.
UploadDomainWhitelist string `json:"upload_whitelist"       envconfig:"BLNK_UPLOAD_DOMAIN_WHITELIST"`
// UploadURLTimeoutSec caps the HTTP GET issued for a URL-based upload
// (BLNK_UPLOAD_URL_TIMEOUT_SEC). Defaults to DEFAULT_UPLOAD_URL_TIMEOUT_SEC.
UploadURLTimeoutSec int `json:"upload_url_timeout_sec" envconfig:"BLNK_UPLOAD_URL_TIMEOUT_SEC"`
```

---

Add Feature Upload via URL

```bash
curl --request POST \
  --url "https://localhost:5001/reconciliation/upload" \
  --header 'Content-Type: application/json' \
  --header 'X-blnk-key: <api-key>' \
  --data '{"url": "https://s3.aws.file/data.json", "source": "Stripe"}'
  
Response:
  
{
  "upload_id": "upload_8c700d1b-09c0-4ef4-9ab1-a0decf3d0aa3",
  "record_count": 1000,
  "source": "Stripe"
}
```

but still can upload via file directly

```bash
curl -X POST "https://localhost:5001/reconciliation/upload" \
  -H "X-blnk-key: <api-key>" \
  -F 'file=@"transactions.json"' \
  -F 'source="Stripe"'
```