### PR TITLE
fix(reindex): include parent_transaction, precise_amount, precision in GetAllTransactions

### DIFF
--- a/database/transaction_queries.go
+++ b/database/transaction_queries.go
@@ -270,7 +270,7 @@ func (d Datasource) GetAllTransactions(ctx context.Context, limit, offset int) (
 
 	// Execute the query to retrieve all transactions
 	rows, err := d.Conn.QueryContext(ctx, `
-		SELECT transaction_id, source, reference, amount, currency, destination, description, status, hash, created_at, meta_data
+		SELECT transaction_id, source, reference, amount, precise_amount, precision, currency, destination, description, status, hash, created_at, meta_data, parent_transaction
 		FROM blnk.transactions
 		ORDER BY created_at DESC
 		LIMIT $1 OFFSET $2
@@ -292,6 +292,7 @@ func (d Datasource) GetAllTransactions(ctx context.Context, limit, offset int) (
 	for rows.Next() {
 		transaction := model.Transaction{}
 		var metaDataJSON []byte
+		var preciseAmountStr string
 
 		// Scan each row into the Transaction struct
 		err = rows.Scan(
@@ -299,6 +300,8 @@ func (d Datasource) GetAllTransactions(ctx context.Context, limit, offset int) (
 			&transaction.Source,
 			&transaction.Reference,
 			&transaction.Amount,
+			&preciseAmountStr,
+			&transaction.Precision,
 			&transaction.Currency,
 			&transaction.Destination,
 			&transaction.Description,
@@ -306,10 +309,19 @@ func (d Datasource) GetAllTransactions(ctx context.Context, limit, offset int) (
 			&transaction.Hash,
 			&transaction.CreatedAt,
 			&metaDataJSON,
+			&transaction.ParentTransaction,
 		)
 		if err != nil {
 			span.RecordError(err)
 			return nil, apierror.NewAPIError(apierror.ErrInternalServer, "Failed to scan transaction data", err)
+		}
+
+		// Parse the precise amount (NUMERIC) into a big.Int, mirroring the other
+		// transaction row scans in this package.
+		transaction.PreciseAmount, err = parseBigInt(preciseAmountStr)
+		if err != nil {
+			span.RecordError(err)
+			return nil, apierror.NewAPIError(apierror.ErrInternalServer, "Failed to parse precise_amount", err)
 		}
 
 		// Unmarshal metadata into the transaction's MetaData field

--- a/database/transactions_test.go
+++ b/database/transactions_test.go
@@ -927,7 +927,7 @@ func TestGetAllTransactions_Success(t *testing.T) {
 	metaDataJSON, _ := json.Marshal(metaData)
 
 	query := `
-		SELECT transaction_id, source, reference, amount, currency, destination, description, status, hash, created_at, meta_data
+		SELECT transaction_id, source, reference, amount, precise_amount, precision, currency, destination, description, status, hash, created_at, meta_data, parent_transaction
 		FROM blnk.transactions
 		ORDER BY created_at DESC
 		LIMIT $1 OFFSET $2
@@ -936,17 +936,23 @@ func TestGetAllTransactions_Success(t *testing.T) {
 	mock.ExpectQuery(regexp.QuoteMeta(query)).
 		WithArgs(10, 0).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"transaction_id", "source", "reference", "amount", "currency",
-			"destination", "description", "status", "hash", "created_at", "meta_data",
+			"transaction_id", "source", "reference", "amount", "precise_amount", "precision", "currency",
+			"destination", "description", "status", "hash", "created_at", "meta_data", "parent_transaction",
 		}).
-			AddRow("txn_1", "bln_src1", "ref_1", 1000.0, "USD", "bln_dest1", "Txn 1", "APPLIED", "hash1", time.Now(), metaDataJSON).
-			AddRow("txn_2", "bln_src2", "ref_2", 2000.0, "EUR", "bln_dest2", "Txn 2", "PENDING", "hash2", time.Now(), metaDataJSON))
+			AddRow("txn_1", "bln_src1", "ref_1", 1000.0, "1000", 100.0, "USD", "bln_dest1", "Txn 1", "APPLIED", "hash1", time.Now(), metaDataJSON, "txn_parent_1").
+			AddRow("txn_2", "bln_src2", "ref_2", 2000.0, "2000", 100.0, "EUR", "bln_dest2", "Txn 2", "PENDING", "hash2", time.Now(), metaDataJSON, ""))
 
 	transactions, err := ds.GetAllTransactions(ctx, 10, 0)
 	assert.NoError(t, err)
 	assert.Len(t, transactions, 2)
 	assert.Equal(t, "txn_1", transactions[0].TransactionID)
 	assert.Equal(t, "txn_2", transactions[1].TransactionID)
+	// Regression guard for the reindex field-loss bug (blnk#326): the query
+	// previously omitted these, so reindexed docs lost them in Typesense.
+	assert.Equal(t, "txn_parent_1", transactions[0].ParentTransaction)
+	assert.Equal(t, "1000", transactions[0].PreciseAmount.String())
+	assert.Equal(t, 100.0, transactions[0].Precision)
+	assert.Equal(t, "2000", transactions[1].PreciseAmount.String())
 
 	err = mock.ExpectationsWereMet()
 	assert.NoError(t, err)
@@ -961,7 +967,7 @@ func TestGetAllTransactions_Empty(t *testing.T) {
 	ctx := context.Background()
 
 	query := `
-		SELECT transaction_id, source, reference, amount, currency, destination, description, status, hash, created_at, meta_data
+		SELECT transaction_id, source, reference, amount, precise_amount, precision, currency, destination, description, status, hash, created_at, meta_data, parent_transaction
 		FROM blnk.transactions
 		ORDER BY created_at DESC
 		LIMIT $1 OFFSET $2
@@ -970,8 +976,8 @@ func TestGetAllTransactions_Empty(t *testing.T) {
 	mock.ExpectQuery(regexp.QuoteMeta(query)).
 		WithArgs(10, 0).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"transaction_id", "source", "reference", "amount", "currency",
-			"destination", "description", "status", "hash", "created_at", "meta_data",
+			"transaction_id", "source", "reference", "amount", "precise_amount", "precision", "currency",
+			"destination", "description", "status", "hash", "created_at", "meta_data", "parent_transaction",
 		}))
 
 	transactions, err := ds.GetAllTransactions(ctx, 10, 0)
@@ -991,7 +997,7 @@ func TestGetAllTransactions_QueryError(t *testing.T) {
 	ctx := context.Background()
 
 	query := `
-		SELECT transaction_id, source, reference, amount, currency, destination, description, status, hash, created_at, meta_data
+		SELECT transaction_id, source, reference, amount, precise_amount, precision, currency, destination, description, status, hash, created_at, meta_data, parent_transaction
 		FROM blnk.transactions
 		ORDER BY created_at DESC
 		LIMIT $1 OFFSET $2


### PR DESCRIPTION
## What

`GetAllTransactions` (`database/transaction_queries.go`) — the query the Postgres→Typesense reindex uses (`ReindexService.indexTransactions`) — omitted `parent_transaction`, `precise_amount`, and `precision` from its `SELECT` and row scan. This adds them, mirroring the existing single-row scan pattern in the package (`precise_amount` parsed via `parseBigInt`).

## Why

Because those columns weren't selected/scanned, every **reindexed** transaction document is written to Typesense with empty `parent_transaction` and `precise_amount`, even though Postgres has them and the live per-transaction indexing path sets them.

Impact:
- **Transaction lineage in search breaks** — a committed inflight's resolving record has `parent_transaction` in the DB but not in the index, so an inflight can't be linked to its commit/void via search.
- **`precise_amount` filter/facet returns nothing** — the field is declared `string` in the transaction schema but stored empty.

It's especially severe where Typesense storage is ephemeral (e.g. Cloud Run with an in-memory volume): the index is rebuilt from Postgres on every restart, so the fields are *permanently* empty there — not just after a manual reindex.

Fixes #326.

## How tested

- `go build ./...` — passes.
- `gofmt` — clean on both changed files.
- `go test -short -run GetAllTransactions ./database/` — passes. Updated the `TestGetAllTransactions_*` sqlmock rows to the new columns and added assertions that `ParentTransaction`, `PreciseAmount`, and `Precision` are now populated.
- Reproduced end-to-end on 0.14.5: with a persistent Typesense the fields are populated; after `POST /search/reindex` they drop to empty, confirming the reindex query as the cause.

_(The only failures in a full `go test -short ./database/` run are `TestConnectDB_Success` / `TestGetDBConnection_Singleton`, which need a live Postgres and are unrelated to this change.)_
