### PR TITLE
fix(inflight): accept queued commit against multi-leg parent ids.

### DIFF
--- a/api/inflight_queue_test.go
+++ b/api/inflight_queue_test.go
@@ -18,6 +18,7 @@ package api
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"math/big"
 	"net/http"
 	"testing"
@@ -26,9 +27,162 @@ import (
 	"github.com/blnkfinance/blnk/internal/request"
 	"github.com/blnkfinance/blnk/model"
 	"github.com/brianvoe/gofakeit/v6"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestInflightCommit_QueuedMultiSourceParent reproduces the bisect failure:
+// a multi-source inflight created with skip_queue:true returns a parent
+// transaction_id that sync commit (skip_queue:true) can expand via
+// GetInflightTransactionsByParentID, but the default queued commit path
+// (PUT {"status":"commit"} with no skip_queue) must also accept that same
+// parent id — today QueueInflightAction pre-validates via
+// fetchAndValidateInflightTransaction and 404s because the parent row itself
+// is never persisted (only the split legs are).
+func TestInflightCommit_QueuedMultiSourceParent(t *testing.T) {
+	router, b, err := setupRouter()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	ledger, err := b.CreateLedger(model.Ledger{Name: gofakeit.Name()})
+	require.NoError(t, err)
+	srcA, err := b.CreateBalance(ctx, model.Balance{LedgerID: ledger.LedgerID, Currency: "USD"})
+	require.NoError(t, err)
+	srcB, err := b.CreateBalance(ctx, model.Balance{LedgerID: ledger.LedgerID, Currency: "USD"})
+	require.NoError(t, err)
+	dst, err := b.CreateBalance(ctx, model.Balance{LedgerID: ledger.LedgerID, Currency: "USD"})
+	require.NoError(t, err)
+
+	createPayload := model2.RecordTransaction{
+		Amount:      20,
+		Precision:   100,
+		Reference:   "queued_ms_" + gofakeit.UUID(),
+		Description: "queued multi-source inflight parent commit",
+		Currency:    "USD",
+		Sources: []model.Distribution{
+			{Identifier: srcA.BalanceID, Distribution: "50%"},
+			{Identifier: srcB.BalanceID, Distribution: "left"},
+		},
+		Destination:    dst.BalanceID,
+		AllowOverDraft: true,
+		Inflight:       true,
+		SkipQueue:      true,
+	}
+	createRec := doJSON(router, "POST", "/transactions", createPayload)
+	require.Equal(t, http.StatusCreated, createRec.Code, "create body: %s", createRec.Body.String())
+	var created model.Transaction
+	require.NoError(t, json.Unmarshal(createRec.Body.Bytes(), &created))
+	require.Equal(t, "INFLIGHT", created.Status)
+	require.NotEmpty(t, created.TransactionID, "create must return a parent id to commit against")
+
+	assertQueuedInflightCommitAccepted(t, router, created.TransactionID)
+}
+
+// TestInflightCommit_QueuedMultiDestinationParent is the multi-destination
+// counterpart of TestInflightCommit_QueuedMultiSourceParent: commit the create
+// response's parent id via the default queued path.
+func TestInflightCommit_QueuedMultiDestinationParent(t *testing.T) {
+	router, b, err := setupRouter()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	ledger, err := b.CreateLedger(model.Ledger{Name: gofakeit.Name()})
+	require.NoError(t, err)
+	src, err := b.CreateBalance(ctx, model.Balance{LedgerID: ledger.LedgerID, Currency: "USD"})
+	require.NoError(t, err)
+	dstA, err := b.CreateBalance(ctx, model.Balance{LedgerID: ledger.LedgerID, Currency: "USD"})
+	require.NoError(t, err)
+	dstB, err := b.CreateBalance(ctx, model.Balance{LedgerID: ledger.LedgerID, Currency: "USD"})
+	require.NoError(t, err)
+
+	createPayload := model2.RecordTransaction{
+		Amount:      20,
+		Precision:   100,
+		Reference:   "queued_md_" + gofakeit.UUID(),
+		Description: "queued multi-destination inflight parent commit",
+		Currency:    "USD",
+		Source:      src.BalanceID,
+		Destinations: []model.Distribution{
+			{Identifier: dstA.BalanceID, Distribution: "50%"},
+			{Identifier: dstB.BalanceID, Distribution: "left"},
+		},
+		AllowOverDraft: true,
+		Inflight:       true,
+		SkipQueue:      true,
+	}
+	createRec := doJSON(router, "POST", "/transactions", createPayload)
+	require.Equal(t, http.StatusCreated, createRec.Code, "create body: %s", createRec.Body.String())
+	var created model.Transaction
+	require.NoError(t, json.Unmarshal(createRec.Body.Bytes(), &created))
+	require.Equal(t, "INFLIGHT", created.Status)
+	require.NotEmpty(t, created.TransactionID, "create must return a parent id to commit against")
+
+	assertQueuedInflightCommitAccepted(t, router, created.TransactionID)
+}
+
+// TestInflightCommit_QueuedBulkBatchParent commits a sync bulk inflight batch
+// by its batch_id on the default queued path. batch_id is never a transaction
+// row — only the per-item legs (parent_transaction = batch_id) are.
+func TestInflightCommit_QueuedBulkBatchParent(t *testing.T) {
+	router, b, err := setupRouter()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	ledger, err := b.CreateLedger(model.Ledger{Name: gofakeit.Name()})
+	require.NoError(t, err)
+	srcA, err := b.CreateBalance(ctx, model.Balance{LedgerID: ledger.LedgerID, Currency: "USD"})
+	require.NoError(t, err)
+	srcB, err := b.CreateBalance(ctx, model.Balance{LedgerID: ledger.LedgerID, Currency: "USD"})
+	require.NoError(t, err)
+	dstA, err := b.CreateBalance(ctx, model.Balance{LedgerID: ledger.LedgerID, Currency: "USD"})
+	require.NoError(t, err)
+	dstB, err := b.CreateBalance(ctx, model.Balance{LedgerID: ledger.LedgerID, Currency: "USD"})
+	require.NoError(t, err)
+
+	ref := gofakeit.UUID()
+	createPayload := model2.BulkTransactionRequest{
+		Atomic:    true,
+		Inflight:  true,
+		RunAsync:  false,
+		SkipQueue: true,
+		Transactions: []*model2.RecordTransaction{
+			{
+				Amount: 7, Precision: 100, Reference: "queued_bulk_" + ref + "_1",
+				Description: "queued bulk inflight batch commit 1", Currency: "USD",
+				Source: srcA.BalanceID, Destination: dstA.BalanceID, AllowOverDraft: true,
+			},
+			{
+				Amount: 8, Precision: 100, Reference: "queued_bulk_" + ref + "_2",
+				Description: "queued bulk inflight batch commit 2", Currency: "USD",
+				Source: srcB.BalanceID, Destination: dstB.BalanceID, AllowOverDraft: true,
+			},
+		},
+	}
+	createRec := doJSON(router, "POST", "/transactions/bulk", createPayload)
+	require.Equal(t, http.StatusCreated, createRec.Code, "create body: %s", createRec.Body.String())
+	var created map[string]interface{}
+	require.NoError(t, json.Unmarshal(createRec.Body.Bytes(), &created))
+	batchID, _ := created["batch_id"].(string)
+	require.NotEmpty(t, batchID, "bulk create must return batch_id")
+	require.Equal(t, "inflight", created["status"], "bulk create status: %v", created["status"])
+
+	assertQueuedInflightCommitAccepted(t, router, batchID)
+}
+
+// assertQueuedInflightCommitAccepted PUTs {"status":"commit"} (no skip_queue)
+// and requires HTTP 200 with queued:true — the bisect COMMIT_MODE=queued contract.
+func assertQueuedInflightCommitAccepted(t *testing.T, router *gin.Engine, commitID string) {
+	t.Helper()
+	commitRec := doJSON(router, "PUT", "/transactions/inflight/"+commitID,
+		model2.InflightUpdate{Status: "commit"})
+	require.Equal(t, http.StatusOK, commitRec.Code,
+		"queued commit of parent/batch %s must be accepted (got %d: %s)",
+		commitID, commitRec.Code, commitRec.Body.String())
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(commitRec.Body.Bytes(), &resp))
+	assert.Equal(t, true, resp["queued"], "queued commit must be marked queued")
+}
 
 // TestInflightCommit_QueuedByDefault proves the default (no skip_queue) commit is
 // enqueued, not applied: the response is the still-inflight parent with

--- a/transaction_inflight.go
+++ b/transaction_inflight.go
@@ -737,12 +737,82 @@ func (l *Blnk) RunInflightActionByParent(ctx context.Context, parentTransactionI
 // would perform, without mutating or persisting anything. It lets the API reject
 // an obviously-invalid request (not inflight, already finalized, amount too high)
 // synchronously before enqueuing, while the worker remains the authority.
+//
+// When transactionID is a multi-source / multi-destination parent or a bulk
+// batch_id, there is often no INFLIGHT row for that id itself — only child legs.
+// Sync commit already expands via GetInflightTransactionsByParentID; this
+// pre-check does the same so queued commit does not 404 on a valid parent.
 func (l *Blnk) preValidateInflightAction(ctx context.Context, transactionID, action string, amount *big.Int) (*model.Transaction, error) {
 	transaction, err := l.fetchAndValidateInflightTransaction(ctx, transactionID)
-	if err != nil {
+	if err == nil {
+		return l.validateInflightActionAmount(ctx, transaction, action, amount)
+	}
+
+	if !shouldExpandInflightParent(err) {
 		return nil, err
 	}
 
+	legs, legErr := l.collectInflightLegs(ctx, transactionID)
+	if legErr != nil {
+		return nil, legErr
+	}
+	if len(legs) == 0 {
+		return nil, err
+	}
+
+	remaining, remErr := l.anyInflightLegRemaining(ctx, legs)
+	if remErr != nil {
+		return nil, remErr
+	}
+	if !remaining {
+		if action == InflightActionVoid {
+			return nil, errors.New("cannot void. Transaction already committed")
+		}
+		return nil, errors.New("cannot commit. Transaction already committed")
+	}
+
+	// Response stand-in: first leg's fields, but the id the client committed
+	// against (parent / batch id) so the queued payload matches the request.
+	representative := *legs[0]
+	representative.TransactionID = transactionID
+	return &representative, nil
+}
+
+// shouldExpandInflightParent reports whether a fetch/validate failure should
+// fall back to looking up inflight legs under transactionID as a parent.
+func shouldExpandInflightParent(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return true
+	}
+	switch classifyInflightError(err) {
+	case "NOT_FOUND", "NOT_INFLIGHT":
+		return true
+	default:
+		return false
+	}
+}
+
+// anyInflightLegRemaining reports whether at least one leg still has an
+// uncommitted amount left.
+func (l *Blnk) anyInflightLegRemaining(ctx context.Context, legs []*model.Transaction) (bool, error) {
+	for _, leg := range legs {
+		amountLeft, err := l.calculateRemainingAmount(ctx, leg)
+		if err != nil {
+			return false, err
+		}
+		if amountLeft.Sign() != 0 {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// validateInflightActionAmount runs the single-transaction amount checks used
+// when the commit/void target is itself an INFLIGHT row.
+func (l *Blnk) validateInflightActionAmount(ctx context.Context, transaction *model.Transaction, action string, amount *big.Int) (*model.Transaction, error) {
 	amountLeft, err := l.calculateRemainingAmount(ctx, transaction)
 	if err != nil {
 		return nil, err

--- a/transaction_inflight_async_test.go
+++ b/transaction_inflight_async_test.go
@@ -54,3 +54,11 @@ func TestIsTerminalInflightError(t *testing.T) {
 		assert.Falsef(t, l.isTerminalInflightError(err), "expected transient: %v", err)
 	}
 }
+
+func TestShouldExpandInflightParent(t *testing.T) {
+	assert.True(t, shouldExpandInflightParent(errors.New("transaction not found")))
+	assert.True(t, shouldExpandInflightParent(errors.New("transaction is not in inflight status")))
+	assert.True(t, shouldExpandInflightParent(errors.New("NOT_FOUND: Transaction with ID 'txn_x' not found")))
+	assert.False(t, shouldExpandInflightParent(errors.New("failed to acquire lock for inflight commit")))
+	assert.False(t, shouldExpandInflightParent(nil))
+}


### PR DESCRIPTION
## Summary

### Issue
Multi-source, multi-destination, and bulk inflight creates return a parent id (or `batch_id`) that clients use to commit. Only the child legs are saved in the database — that parent id usually has no row of its own.

Sync commit (`skip_queue: true`) already handles this: it looks up every inflight leg under that parent and commits them.

Queued commit (the default — `{"status":"commit"}` with no `skip_queue`) did not. Before putting the job on the queue, it tried to load the parent id as a single transaction. That lookup failed, so the API returned **404 Transaction not found**, and the commit never reached the worker.

Single-leg inflights were fine. Multi-source, multi-destination, and bulk all failed the same way.

### Fix
When queued-commit pre-validation cannot find an INFLIGHT row for the given id, it now looks for child legs under that id — the same expansion sync commit and the worker already use.

- Legs found → accept the request and enqueue the commit.
- No legs → keep returning not found.

No change to how commits are applied.

## Test plan
- [x] `go test -v -count=1 ./api/ -run 'TestInflightCommit_QueuedMultiSourceParent'`
- [x] `go test -v -count=1 ./api/ -run 'TestInflightCommit_QueuedMultiDestinationParent'`
- [x] `go test -v -count=1 ./api/ -run 'TestInflightCommit_QueuedBulkBatchParent'`
- [x] `go test -v -count=1 ./api/ -run 'TestInflightCommit_QueuedByDefault'`
- [x] `go test -v -count=1 . -run 'TestShouldExpandInflightParent'`
- [x] Manual: multi-source, multi-destination, and bulk inflight create (`skip_queue: true`) then queued commit (`{"status":"commit"}`) → HTTP 200 + `queued: true` for all three