### PR TITLE
fix(inflight): format overcommit amounts as currency values.

### DIFF
--- a/transaction_inflight.go
+++ b/transaction_inflight.go
@@ -318,7 +318,7 @@ func (l *Blnk) checkTransactionCommitStatus(amountLeft *big.Int) error {
 //
 // Parameters:
 // - transaction *model.Transaction: The transaction being validated.
-// - amount float64: The requested amount to commit.
+// - amount *big.Int: The requested precise amount to commit.
 // - amountLeft *big.Int: The remaining amount that can be committed.
 //
 // Returns:
@@ -333,16 +333,17 @@ func (l *Blnk) validateRequestedAmount(transaction *model.Transaction, amount *b
 	}
 
 	requestedAmount := amount
+	requestedValue := l.convertPreciseToFloat(requestedAmount, transaction.Precision)
 
 	if requestedAmount.Cmp(transaction.PreciseAmount) > 0 {
 		return fmt.Errorf("cannot commit more than the original transaction amount. Original: %s%.2f, Requested: %s%.2f",
-			transaction.Currency, transaction.Amount, transaction.Currency, amount)
+			transaction.Currency, transaction.Amount, transaction.Currency, requestedValue)
 	}
 
 	if requestedAmount.Cmp(amountLeft) > 0 {
 		amountLeftValue := l.convertPreciseToFloat(amountLeft, transaction.Precision)
 		return fmt.Errorf("cannot commit more than the remaining amount. Available: %s%.2f, Requested: %s%.2f",
-			transaction.Currency, amountLeftValue, transaction.Currency, amount)
+			transaction.Currency, amountLeftValue, transaction.Currency, requestedValue)
 	}
 
 	return nil

--- a/transaction_inflight_async_test.go
+++ b/transaction_inflight_async_test.go
@@ -18,9 +18,12 @@ package blnk
 
 import (
 	"errors"
+	"math/big"
 	"testing"
 
+	"github.com/blnkfinance/blnk/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestInflightActionReference(t *testing.T) {
@@ -53,4 +56,24 @@ func TestIsTerminalInflightError(t *testing.T) {
 	for _, err := range transient {
 		assert.Falsef(t, l.isTerminalInflightError(err), "expected transient: %v", err)
 	}
+}
+
+func TestValidateRequestedAmountErrorFormatting(t *testing.T) {
+	l := &Blnk{}
+	txn := &model.Transaction{
+		Currency:      "USD",
+		Amount:        100,
+		PreciseAmount: big.NewInt(10000),
+		Precision:     100,
+	}
+
+	err := l.validateRequestedAmount(txn, big.NewInt(7000), big.NewInt(6000))
+	require.Error(t, err)
+	assert.Equal(t, "cannot commit more than the remaining amount. Available: USD60.00, Requested: USD70.00", err.Error())
+	assert.NotContains(t, err.Error(), "%!")
+
+	err = l.validateRequestedAmount(txn, big.NewInt(11000), big.NewInt(10000))
+	require.Error(t, err)
+	assert.Equal(t, "cannot commit more than the original transaction amount. Original: USD100.00, Requested: USD110.00", err.Error())
+	assert.NotContains(t, err.Error(), "%!")
 }


### PR DESCRIPTION
## Summary
- Fix garbled `Requested` amount in inflight overcommit errors (`USD%!f(big.Int=7000)` → `USD70.00`) by converting `*big.Int` via `convertPreciseToFloat` before `%.2f` formatting.
- Cover both the remaining-amount and original-amount error paths.
- Add `TestValidateRequestedAmountErrorFormatting` to lock in readable messages.

## Test plan
- [x] `go test -run TestValidateRequestedAmountErrorFormatting`
- [ ] Create inflight hold of 100, partial commit 40, then commit 70
- [ ] Confirm HTTP 400 message shows `Available: USD60.00, Requested: USD70.00` with no `%!f(big.Int=...)`