### PR TITLE
compose: bootstrap blnk.json via init service

### DIFF
--- a/blnk-init.sh
+++ b/blnk-init.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+# Copyright 2024 Blnk Finance Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Creates blnk.json with docker-compose defaults when missing. Edit blnk.json
+# directly for custom configuration.
+
+set -eu
+
+ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CONFIG_FILE="${ROOT_DIR}/blnk.json"
+
+if [ -f "${CONFIG_FILE}" ]; then
+    exit 0
+fi
+
+# Docker creates a directory when the bind-mount source file is missing.
+if [ -d "${CONFIG_FILE}" ]; then
+    rm -rf "${CONFIG_FILE}"
+fi
+
+cat > "${CONFIG_FILE}" <<'EOF'
+{
+  "project_name": "Blnk",
+  "data_source": {
+    "dns": "postgres://postgres:password@postgres:5432/blnk?sslmode=disable"
+  },
+  "redis": {
+    "dns": "redis:6379"
+  },
+  "server": {
+    "port": "5001"
+  }
+}
+EOF
+
+echo "Created ${CONFIG_FILE} with compose defaults."
+echo "Edit ${CONFIG_FILE} to customize your Blnk configuration."

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -14,6 +14,15 @@
 version: "3.8"
 
 services:
+  init:
+    image: alpine:3.19
+    container_name: init
+    working_dir: /workspace
+    volumes:
+      - .:/workspace
+    entrypoint: ["/bin/sh", "/workspace/blnk-init.sh"]
+    restart: "no"
+
   server:
     build: .
     container_name: server
@@ -26,6 +35,7 @@ services:
       - "80:80"
       - "443:443"
     depends_on:
+      - init
       - redis
       - postgres
       - jaeger
@@ -42,6 +52,7 @@ services:
     ports:
       - "5004:5004"
     depends_on:
+      - init
       - redis
       - postgres
       - jaeger
@@ -53,6 +64,7 @@ services:
     entrypoint: ["blnk", "migrate", "up"]
     restart: on-failure
     depends_on:
+      - init
       - postgres
     volumes:
       - ./blnk.json:/blnk.json

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,6 +14,15 @@
 version: "3.8"
 
 services:
+  init:
+    image: alpine:3.19
+    container_name: init
+    working_dir: /workspace
+    volumes:
+      - .:/workspace
+    entrypoint: ["/bin/sh", "/workspace/blnk-init.sh"]
+    restart: "no"
+
   server:
     image: ${BLNK_IMAGE:-jerryenebeli/blnk:0.15.0}
     container_name: server
@@ -29,6 +38,7 @@ services:
       - "80:80"
       - "443:443"
     depends_on:
+      - init
       - redis
       - postgres
       - jaeger
@@ -45,6 +55,7 @@ services:
     ports:
       - "5004:5004"
     depends_on:
+      - init
       - redis
       - postgres
       - jaeger


### PR DESCRIPTION
## Summary

- Adds an `init` compose service that runs `blnk-init.sh` before Blnk starts.
- Creates a local `./blnk.json` with docker-compose defaults when the file is missing (and removes the bogus directory Docker creates for missing bind-mount files).
- Wires `server`, `worker`, and dev `migration` to depend on `init`, so `docker compose up` works without manual config setup.

## Test plan

- [x] Remove `blnk.json` and run `docker compose up -d` — file is created at repo root with compose defaults
- [x] Confirm `server` reads config, runs migrations, and starts on port 5001
- [x] Re-run compose with existing `blnk.json` — init is a no-op and local edits are preserved
- [ ] Run `docker compose -f docker-compose.dev.yaml up` and confirm the same bootstrap behavior