### PR TITLE
fix: clear terminal inflight metadata

### DIFF
--- a/transaction_execution.go
+++ b/transaction_execution.go
@@ -728,11 +728,14 @@ func (l *Blnk) buildTransactionExecutionWork(ctx context.Context, transaction *m
 		}, true
 	}
 
+	outbox := l.prepareTransactionOutbox(ctx, transaction, sourceBalance, destinationBalance)
+	clearTerminalInflightMetadata(transaction)
+
 	return queuedBatchPostCommitWork{
 		transaction:        transaction,
 		sourceBalance:      sourceBalance,
 		destinationBalance: destinationBalance,
-		outbox:             l.prepareTransactionOutbox(ctx, transaction, sourceBalance, destinationBalance),
+		outbox:             outbox,
 	}, false
 }
 

--- a/transaction_inflight.go
+++ b/transaction_inflight.go
@@ -83,6 +83,17 @@ func IsInflightTransaction(transaction *model.Transaction) bool {
 			transaction.MetaData["inflight"] == true)
 }
 
+func clearTerminalInflightMetadata(transaction *model.Transaction) {
+	if transaction == nil || transaction.Status == StatusInflight {
+		return
+	}
+
+	transaction.Inflight = false
+	if transaction.MetaData != nil {
+		delete(transaction.MetaData, "inflight")
+	}
+}
+
 // CommitWorker processes commit transactions from the jobs channel and sends the results to the results channel.
 // It starts a tracing span, processes each transaction, and records relevant events and errors.
 //
@@ -394,6 +405,7 @@ func (l *Blnk) finalizeCommitment(ctx context.Context, transaction *model.Transa
 	defer span.End()
 
 	transaction.Status = StatusCommit
+	transaction.Inflight = false
 	transaction.ParentTransaction = transaction.TransactionID
 	transaction.CreatedAt = time.Now()
 	if transaction.EffectiveDate == nil {
@@ -422,6 +434,7 @@ func (l *Blnk) finalizeCommitment(ctx context.Context, transaction *model.Transa
 		return transaction, nil
 	}
 
+	clearTerminalInflightMetadata(transaction)
 	transaction.Status = StatusApplied
 
 	span.AddEvent("Commitment finalized", trace.WithAttributes(attribute.String("transaction.id", transaction.TransactionID)))
@@ -593,6 +606,7 @@ func (l *Blnk) finalizeVoidTransaction(ctx context.Context, transaction *model.T
 	defer span.End()
 
 	transaction.Status = StatusVoid
+	transaction.Inflight = false
 	transaction.PreciseAmount = amountLeft
 	transaction.CreatedAt = time.Now()
 	if transaction.EffectiveDate == nil {

--- a/transaction_inflight_async_test.go
+++ b/transaction_inflight_async_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package blnk
 
 import (
+	"context"
 	"errors"
 	"math/big"
 	"testing"
@@ -84,4 +85,63 @@ func TestShouldExpandInflightParent(t *testing.T) {
 	assert.True(t, shouldExpandInflightParent(errors.New("NOT_FOUND: Transaction with ID 'txn_x' not found")))
 	assert.False(t, shouldExpandInflightParent(errors.New("failed to acquire lock for inflight commit")))
 	assert.False(t, shouldExpandInflightParent(nil))
+}
+
+func TestClearTerminalInflightMetadata(t *testing.T) {
+	terminal := &model.Transaction{
+		Status:   StatusApplied,
+		Inflight: true,
+		MetaData: map[string]interface{}{
+			"inflight": true,
+			"source":   "checkout",
+		},
+	}
+
+	clearTerminalInflightMetadata(terminal)
+
+	assert.False(t, terminal.Inflight)
+	assert.NotContains(t, terminal.MetaData, "inflight")
+	assert.Equal(t, "checkout", terminal.MetaData["source"])
+
+	pending := &model.Transaction{Status: StatusInflight, Inflight: true, MetaData: map[string]interface{}{"inflight": true}}
+	clearTerminalInflightMetadata(pending)
+
+	assert.True(t, pending.Inflight)
+	assert.Contains(t, pending.MetaData, "inflight")
+
+	clearTerminalInflightMetadata(nil)
+}
+
+func TestBuildTransactionExecutionWorkClearsTerminalInflightMetadata(t *testing.T) {
+	l := &Blnk{}
+	source := &model.Balance{BalanceID: "source"}
+	destination := &model.Balance{BalanceID: "destination"}
+
+	for _, status := range []string{StatusCommit, StatusVoid} {
+		t.Run(status, func(t *testing.T) {
+			expectedStatus := StatusVoid
+			if status == StatusCommit {
+				expectedStatus = StatusApplied
+			}
+
+			transaction := &model.Transaction{
+				Status:            status,
+				PreciseAmount:     big.NewInt(100),
+				ParentTransaction: "txn_parent",
+				MetaData: map[string]interface{}{
+					"inflight": true,
+					"source":   "checkout",
+				},
+			}
+
+			work, discarded := l.buildTransactionExecutionWork(context.Background(), transaction, source, destination)
+
+			require.False(t, discarded)
+			assert.Equal(t, expectedStatus, work.transaction.Status)
+			assert.Nil(t, work.outbox)
+			assert.False(t, work.transaction.Inflight)
+			assert.NotContains(t, work.transaction.MetaData, "inflight")
+			assert.Equal(t, "checkout", work.transaction.MetaData["source"])
+		})
+	}
 }

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -1129,6 +1129,11 @@ func TestInflightTransactionFlowWithSkipQueueThenPartialCommit(t *testing.T) {
 	require.NoError(t, err, "Failed to partially commit transaction")
 	require.Equal(t, StatusApplied, partialCommitTxn.Status, "Partial commit transaction should have APPLIED status")
 	require.Equal(t, partialAmount, partialCommitTxn.Amount, "Partial commit amount should match specified amount")
+	require.False(t, partialCommitTxn.Inflight)
+	require.NotContains(t, partialCommitTxn.MetaData, "inflight")
+	persistedPartialCommit, err := ds.GetTransactionByRef(ctx, partialCommitTxn.Reference)
+	require.NoError(t, err)
+	require.NotContains(t, persistedPartialCommit.MetaData, "inflight")
 
 	// Verify balances were updated after partial commit
 	updatedSourceAfterPartialCommit, err := ds.GetBalanceByIDLite(source.BalanceID)
@@ -1359,6 +1364,11 @@ func TestInflightTransactionFlowWithSkipQueueThenPartialCommitThenVoid(t *testin
 	voidTxn, err := blnk.VoidInflightTransaction(ctx, inflightEntry.TransactionID)
 	require.NoError(t, err, "Failed to void remaining transaction amount")
 	require.Equal(t, StatusVoid, voidTxn.Status, "Void transaction should have VOID status")
+	require.False(t, voidTxn.Inflight)
+	require.NotContains(t, voidTxn.MetaData, "inflight")
+	persistedVoid, err := ds.GetTransactionByRef(ctx, voidTxn.Reference)
+	require.NoError(t, err)
+	require.NotContains(t, persistedVoid.MetaData, "inflight")
 
 	// Verify balances after void
 	updatedSourceAfterVoid, err := ds.GetBalanceByIDLite(source.BalanceID)


### PR DESCRIPTION
Clear the inflight marker from committed and voided transactions after outbox preparation.

Waiting until the outbox is prepared keeps the existing inflight lineage behavior intact while preventing terminal transactions from retaining the marker.

Fixes #293

Tests:
- `go test -run "TestClearTerminalInflightMetadata|TestBuildTransactionExecutionWorkClearsTerminalInflightMetadata" .`
- `go vet .`
- `go build .`