### PR TITLE
feat(transactions): dry_run preview for bulk and inflight

### DIFF
--- a/api/model/transaction.go
+++ b/api/model/transaction.go
@@ -134,6 +134,14 @@ type BulkInflightVoidRequest struct {
 	// SkipQueue processes every item synchronously instead of routing them
 	// through the inflight-commit queue (the default).
 	SkipQueue bool `json:"skip_queue"`
+
+	// DryRun projects every void and returns the resulting balances without
+	// releasing any hold: no settlement is recorded and nothing is queued.
+	//
+	// Items are projected independently of one another, because that is how
+	// they really run — BulkInflightUpdate dispatches them across a worker
+	// pool with no ordering between them.
+	DryRun bool `json:"dry_run"`
 }
 
 // BulkInflightCommitItem describes one transaction in a bulk commit request.
@@ -154,6 +162,15 @@ type BulkInflightCommitRequest struct {
 	// SkipQueue processes every item synchronously instead of routing them
 	// through the inflight-commit queue (the default).
 	SkipQueue bool `json:"skip_queue"`
+
+	// DryRun projects every commit and returns the resulting balances without
+	// settling anything: no settlement is recorded, the holds stay in place,
+	// and nothing is queued.
+	//
+	// Items are projected independently of one another, because that is how
+	// they really run — BulkInflightUpdate dispatches them across a worker
+	// pool with no ordering between them.
+	DryRun bool `json:"dry_run"`
 }
 
 // BulkInflightResult is the per-item outcome reported in BulkInflightResponse.

--- a/api/model/transaction.go
+++ b/api/model/transaction.go
@@ -64,6 +64,15 @@ type BulkTransactionRequest struct {
 	Atomic       bool                 `json:"atomic"`
 	RunAsync     bool                 `json:"run_async"`
 	SkipQueue    bool                 `json:"skip_queue"`
+
+	// DryRun projects the batch and returns the result without applying any of
+	// it. The projection answers synchronously with 200, so run_async is
+	// ignored.
+	//
+	// Items are projected against each other's effects only when skip_queue is
+	// set, mirroring how the batch would really run; the response reports which
+	// mode was used.
+	DryRun bool `json:"dry_run"`
 }
 
 func (r *BulkTransactionRequest) ToBulkTransactionRequest() *model.BulkTransactionRequest {
@@ -90,6 +99,14 @@ type InflightUpdate struct {
 	// SkipQueue processes the commit/void synchronously instead of routing it
 	// through the inflight-commit queue (the default).
 	SkipQueue bool `json:"skip_queue"`
+
+	// DryRun projects the commit or void and returns the resulting balances
+	// without settling anything: no settlement transaction is recorded and the
+	// hold stays in place.
+	//
+	// A void always releases the full remaining hold, so any amount sent with
+	// one is ignored.
+	DryRun bool `json:"dry_run"`
 }
 
 // MaxBulkInflightItems caps the number of transactions accepted in a single

--- a/api/transaction_dryrun_bulk_api_test.go
+++ b/api/transaction_dryrun_bulk_api_test.go
@@ -1,0 +1,171 @@
+package api
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	model2 "github.com/blnkfinance/blnk/api/model"
+	"github.com/blnkfinance/blnk/internal/request"
+	"github.com/blnkfinance/blnk/model"
+)
+
+func bulkItem(source, destination string, amount float64, reference string) *model2.RecordTransaction {
+	return &model2.RecordTransaction{
+		Amount:      amount,
+		Precision:   100,
+		Currency:    "USD",
+		Source:      source,
+		Destination: destination,
+		Reference:   reference,
+		Description: "bulk dry run",
+	}
+}
+
+// TestDryRunBulkCumulativeCatchesIntraBatchShortfall covers the case the mode
+// exists for: with skip_queue the items really do run one after another, so the
+// second item must be judged against what the first one did.
+func TestDryRunBulkCumulativeCatchesIntraBatchShortfall(t *testing.T) {
+	router, b, err := setupRouter()
+	require.NoError(t, err)
+
+	source, destination := newDryRunFixture(t, b)
+
+	req := model2.BulkTransactionRequest{
+		DryRun:    true,
+		SkipQueue: true,
+		Transactions: []*model2.RecordTransaction{
+			// Drains almost all of the 500.00 the fixture funded.
+			bulkItem(source, destination, 450, "bulk_a_"+model.GenerateUUIDWithSuffix("ref")),
+			// Only affordable if the first item is ignored.
+			bulkItem(source, destination, 100, "bulk_b_"+model.GenerateUUIDWithSuffix("ref")),
+		},
+	}
+
+	body, err := request.ToJsonReq(&req)
+	require.NoError(t, err)
+
+	var preview model.BulkTransactionPreview
+	resp, err := SetUpTestRequest(TestRequest{
+		Payload: body, Response: &preview, Method: http.MethodPost,
+		Route: "/transactions/bulk", Router: router,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.True(t, preview.Cumulative, "skip_queue batches run in order, so the projection must accumulate")
+	assert.False(t, preview.WouldApply, "the batch overspends itself and must not be projected as applying")
+
+	require.Len(t, preview.Results, 2)
+	assert.True(t, preview.Results[0].WouldApply)
+	assert.False(t, preview.Results[1].WouldApply, "the second item must be judged against the first item's effect")
+	require.NotNil(t, preview.Results[1].Rejection)
+	assert.Equal(t, "TXN_INSUFFICIENT_FUNDS", preview.Results[1].Rejection.Code)
+}
+
+// TestDryRunBulkIndependentWhenQueued covers the other half: without skip_queue
+// the items are dispatched concurrently, so claiming an order would be wrong.
+func TestDryRunBulkIndependentWhenQueued(t *testing.T) {
+	router, b, err := setupRouter()
+	require.NoError(t, err)
+
+	source, destination := newDryRunFixture(t, b)
+
+	req := model2.BulkTransactionRequest{
+		DryRun:    true,
+		SkipQueue: false,
+		Transactions: []*model2.RecordTransaction{
+			bulkItem(source, destination, 450, "bulkq_a_"+model.GenerateUUIDWithSuffix("ref")),
+			bulkItem(source, destination, 100, "bulkq_b_"+model.GenerateUUIDWithSuffix("ref")),
+		},
+	}
+
+	body, err := request.ToJsonReq(&req)
+	require.NoError(t, err)
+
+	var preview model.BulkTransactionPreview
+	resp, err := SetUpTestRequest(TestRequest{
+		Payload: body, Response: &preview, Method: http.MethodPost,
+		Route: "/transactions/bulk", Router: router,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.False(t, preview.Cumulative)
+	assert.True(t, preview.WouldApply, "projected independently, each item fits on its own")
+	require.Len(t, preview.Results, 2)
+	assert.True(t, preview.Results[0].WouldApply)
+	assert.True(t, preview.Results[1].WouldApply)
+	assert.NotEmpty(t, preview.Notes, "the caller must be told the items were not ordered")
+}
+
+// TestDryRunBulkWritesNothing checks the batch projection leaves no trace.
+func TestDryRunBulkWritesNothing(t *testing.T) {
+	router, b, err := setupRouter()
+	require.NoError(t, err)
+
+	source, destination := newDryRunFixture(t, b)
+	reference := "bulknone_" + model.GenerateUUIDWithSuffix("ref")
+
+	req := model2.BulkTransactionRequest{
+		DryRun:       true,
+		SkipQueue:    true,
+		Transactions: []*model2.RecordTransaction{bulkItem(source, destination, 100, reference)},
+	}
+
+	body, err := request.ToJsonReq(&req)
+	require.NoError(t, err)
+
+	var preview model.BulkTransactionPreview
+	resp, err := SetUpTestRequest(TestRequest{
+		Payload: body, Response: &preview, Method: http.MethodPost,
+		Route: "/transactions/bulk", Router: router,
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.Code)
+
+	_, err = b.GetTransactionByRef(t.Context(), reference)
+	assert.Error(t, err, "a bulk dry run must not persist its items")
+
+	after, err := b.GetBalanceByID(t.Context(), source, nil, false)
+	require.NoError(t, err)
+	assert.Equal(t, "50000", after.Balance.String(), "a bulk dry run must not move balances")
+}
+
+// TestDryRunBulkAtomicNotesCompensation checks the response says what atomic
+// really does, rather than implying a rollback the ledger does not perform.
+func TestDryRunBulkAtomicNotesCompensation(t *testing.T) {
+	router, b, err := setupRouter()
+	require.NoError(t, err)
+
+	source, destination := newDryRunFixture(t, b)
+
+	req := model2.BulkTransactionRequest{
+		DryRun:       true,
+		SkipQueue:    true,
+		Atomic:       true,
+		Transactions: []*model2.RecordTransaction{bulkItem(source, destination, 100, "bulkatomic_"+model.GenerateUUIDWithSuffix("ref"))},
+	}
+
+	body, err := request.ToJsonReq(&req)
+	require.NoError(t, err)
+
+	var preview model.BulkTransactionPreview
+	_, err = SetUpTestRequest(TestRequest{
+		Payload: body, Response: &preview, Method: http.MethodPost,
+		Route: "/transactions/bulk", Router: router,
+	})
+	require.NoError(t, err)
+
+	assert.True(t, preview.Atomic)
+	found := false
+	for _, note := range preview.Notes {
+		if strings.Contains(note, "compensates") {
+			found = true
+		}
+	}
+	assert.True(t, found, "an atomic batch must be described as compensating, not rolling back")
+}

--- a/api/transaction_dryrun_inflight_api_test.go
+++ b/api/transaction_dryrun_inflight_api_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -178,4 +179,238 @@ func TestDryRunInflightRejectsUnknownStatus(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, http.StatusBadRequest, resp.Code, "an unsupported action is a malformed request, not a projection")
+}
+
+// TestDryRunInflightRejectsOverLimitAmount pins the first defect reported on
+// this PR: a commit for more than the original amount previewed as
+// would_apply: true. The dry-run branch passed only precise_amount to the
+// projection, so a plain `amount` never reached it, and nil there means
+// "commit the full remaining amount" — the oversized value was discarded
+// rather than checked.
+func TestDryRunInflightRejectsOverLimitAmount(t *testing.T) {
+	router, b, err := setupRouter()
+	require.NoError(t, err)
+
+	source, destination := newDryRunFixture(t, b)
+
+	hold, err := b.QueueTransaction(t.Context(), &model.Transaction{
+		Reference:   "holdover_" + model.GenerateUUIDWithSuffix("ref"),
+		Source:      source,
+		Destination: destination,
+		Amount:      100,
+		Precision:   100,
+		Currency:    "USD",
+		Inflight:    true,
+		SkipQueue:   true,
+	})
+	require.NoError(t, err)
+
+	// amount, not precise_amount: the field that used to be dropped.
+	payload, err := request.ToJsonReq(&map[string]interface{}{
+		"dry_run": true, "status": "commit", "amount": 999999,
+	})
+	require.NoError(t, err)
+
+	var preview model.TransactionPreview
+	resp, err := SetUpTestRequest(TestRequest{
+		Payload: payload, Response: &preview, Method: http.MethodPut,
+		Route: "/transactions/inflight/" + hold.TransactionID, Router: router,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.False(t, preview.WouldApply, "committing above the original amount cannot apply")
+	require.NotNil(t, preview.Rejection)
+	assert.Contains(t, preview.Rejection.Message, "cannot commit more than the original transaction amount")
+}
+
+// TestDryRunInflightReportsStatusAndAmount pins the second defect reported on
+// this PR: the inflight projection left status and amount at their zero
+// values, so the response read as though it had answered "" and 0. Both must
+// carry what the real endpoint returns for the same call.
+func TestDryRunInflightReportsStatusAndAmount(t *testing.T) {
+	router, b, err := setupRouter()
+	require.NoError(t, err)
+
+	source, destination := newDryRunFixture(t, b)
+
+	commitHold, err := b.QueueTransaction(t.Context(), &model.Transaction{
+		Reference:   "holdfields_" + model.GenerateUUIDWithSuffix("ref"),
+		Source:      source,
+		Destination: destination,
+		Amount:      100,
+		Precision:   100,
+		Currency:    "USD",
+		Inflight:    true,
+		SkipQueue:   true,
+	})
+	require.NoError(t, err)
+
+	payload, err := request.ToJsonReq(&map[string]interface{}{"dry_run": true, "status": "commit"})
+	require.NoError(t, err)
+
+	var commitPreview model.TransactionPreview
+	_, err = SetUpTestRequest(TestRequest{
+		Payload: payload, Response: &commitPreview, Method: http.MethodPut,
+		Route: "/transactions/inflight/" + commitHold.TransactionID, Router: router,
+	})
+	require.NoError(t, err)
+
+	// APPLIED is what a real commit returns, not the internal COMMIT marker.
+	assert.Equal(t, "APPLIED", commitPreview.Status)
+	assert.Equal(t, float64(100), commitPreview.Amount)
+	assert.Equal(t, "10000", commitPreview.PreciseAmount)
+
+	voidHold, err := b.QueueTransaction(t.Context(), &model.Transaction{
+		Reference:   "holdfieldsv_" + model.GenerateUUIDWithSuffix("ref"),
+		Source:      source,
+		Destination: destination,
+		Amount:      40,
+		Precision:   100,
+		Currency:    "USD",
+		Inflight:    true,
+		SkipQueue:   true,
+	})
+	require.NoError(t, err)
+
+	voidPayload, err := request.ToJsonReq(&map[string]interface{}{"dry_run": true, "status": "void"})
+	require.NoError(t, err)
+
+	var voidPreview model.TransactionPreview
+	_, err = SetUpTestRequest(TestRequest{
+		Payload: voidPayload, Response: &voidPreview, Method: http.MethodPut,
+		Route: "/transactions/inflight/" + voidHold.TransactionID, Router: router,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "VOID", voidPreview.Status)
+	assert.Equal(t, float64(40), voidPreview.Amount)
+	assert.Equal(t, "4000", voidPreview.PreciseAmount)
+}
+
+// TestDryRunBulkInflightWritesNothing pins the most serious defect found on
+// this branch: the bulk commit and void endpoints had no dry_run field, and
+// Go's decoder drops unknown JSON keys silently, so dry_run: true was not
+// rejected — it was ignored, and the batch really settled. The response was an
+// ordinary success, so a caller who believed they were previewing got a
+// settled batch and no indication otherwise.
+func TestDryRunBulkInflightWritesNothing(t *testing.T) {
+	router, b, err := setupRouter()
+	require.NoError(t, err)
+
+	source, destination := newDryRunFixture(t, b)
+
+	newHold := func(ref string, amount float64) *model.Transaction {
+		hold, err := b.QueueTransaction(t.Context(), &model.Transaction{
+			Reference:   ref + "_" + model.GenerateUUIDWithSuffix("ref"),
+			Source:      source,
+			Destination: destination,
+			Amount:      amount,
+			Precision:   100,
+			Currency:    "USD",
+			Inflight:    true,
+			SkipQueue:   true,
+		})
+		require.NoError(t, err)
+		return hold
+	}
+
+	commitHold := newHold("bulkcommit", 50)
+	voidHold := newHold("bulkvoid", 30)
+
+	commitPayload, err := request.ToJsonReq(&map[string]interface{}{
+		"dry_run": true, "skip_queue": true,
+		"transactions": []map[string]interface{}{{"transaction_id": commitHold.TransactionID}},
+	})
+	require.NoError(t, err)
+
+	var commitPreview model.BulkTransactionPreview
+	resp, err := SetUpTestRequest(TestRequest{
+		Payload: commitPayload, Response: &commitPreview, Method: http.MethodPost,
+		Route: "/transactions/inflight/bulk/commit", Router: router,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.True(t, commitPreview.DryRun)
+	assert.True(t, commitPreview.WouldApply)
+	// Items run on a worker pool with no ordering, so they are projected
+	// independently and no combined batch balance is claimed.
+	assert.False(t, commitPreview.Cumulative)
+	require.Len(t, commitPreview.Results, 1)
+	assert.Equal(t, "5000", commitPreview.Results[0].PreciseAmount)
+
+	voidPayload, err := request.ToJsonReq(&map[string]interface{}{
+		"dry_run": true, "skip_queue": true,
+		"transaction_ids": []string{voidHold.TransactionID},
+	})
+	require.NoError(t, err)
+
+	var voidPreview model.BulkTransactionPreview
+	resp, err = SetUpTestRequest(TestRequest{
+		Payload: voidPayload, Response: &voidPreview, Method: http.MethodPost,
+		Route: "/transactions/inflight/bulk/void", Router: router,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.True(t, voidPreview.WouldApply)
+
+	// The point of the test: both holds are untouched.
+	afterCommit, err := b.GetTransaction(t.Context(), commitHold.TransactionID)
+	require.NoError(t, err)
+	assert.Equal(t, "INFLIGHT", afterCommit.Status, "a dry run must not settle the hold")
+
+	afterVoid, err := b.GetTransaction(t.Context(), voidHold.TransactionID)
+	require.NoError(t, err)
+	assert.Equal(t, "INFLIGHT", afterVoid.Status, "a dry run must not release the hold")
+}
+
+// TestDryRunBulkInflightReportsRepeatedID pins that a transaction id repeated
+// in one batch is reported. Each occurrence is projected against the same
+// standing hold, so every one of them reports would_apply, while really
+// running the batch settles the hold once and fails the rest. Which
+// occurrence wins is decided by the worker pool, so the duplicate is reported
+// rather than resolved.
+func TestDryRunBulkInflightReportsRepeatedID(t *testing.T) {
+	router, b, err := setupRouter()
+	require.NoError(t, err)
+
+	source, destination := newDryRunFixture(t, b)
+
+	hold, err := b.QueueTransaction(t.Context(), &model.Transaction{
+		Reference:   "bulkdupe_" + model.GenerateUUIDWithSuffix("ref"),
+		Source:      source,
+		Destination: destination,
+		Amount:      50,
+		Precision:   100,
+		Currency:    "USD",
+		Inflight:    true,
+		SkipQueue:   true,
+	})
+	require.NoError(t, err)
+
+	payload, err := request.ToJsonReq(&map[string]interface{}{
+		"dry_run": true, "skip_queue": true,
+		"transactions": []map[string]interface{}{
+			{"transaction_id": hold.TransactionID},
+			{"transaction_id": hold.TransactionID},
+		},
+	})
+	require.NoError(t, err)
+
+	var preview model.BulkTransactionPreview
+	_, err = SetUpTestRequest(TestRequest{
+		Payload: payload, Response: &preview, Method: http.MethodPost,
+		Route: "/transactions/inflight/bulk/commit", Router: router,
+	})
+	require.NoError(t, err)
+
+	var found bool
+	for _, note := range preview.Notes {
+		if strings.Contains(note, "appears more than once") {
+			found = true
+			assert.Contains(t, note, hold.TransactionID)
+		}
+	}
+	assert.True(t, found, "a repeated transaction id must be reported: %v", preview.Notes)
 }

--- a/api/transaction_dryrun_inflight_api_test.go
+++ b/api/transaction_dryrun_inflight_api_test.go
@@ -1,0 +1,181 @@
+package api
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blnkfinance/blnk/internal/request"
+	"github.com/blnkfinance/blnk/model"
+)
+
+// TestDryRunInflightCommitProjectsSettlement checks a committed hold is shown
+// moving from inflight into the settled balance, without settling it.
+func TestDryRunInflightCommitProjectsSettlement(t *testing.T) {
+	router, b, err := setupRouter()
+	require.NoError(t, err)
+
+	source, destination := newDryRunFixture(t, b)
+
+	hold, err := b.QueueTransaction(t.Context(), &model.Transaction{
+		Reference:   "holdcommit_" + model.GenerateUUIDWithSuffix("ref"),
+		Source:      source,
+		Destination: destination,
+		Amount:      100,
+		Precision:   100,
+		Currency:    "USD",
+		Inflight:    true,
+		SkipQueue:   true,
+	})
+	require.NoError(t, err)
+
+	payload, err := request.ToJsonReq(&map[string]interface{}{"dry_run": true, "status": "commit"})
+	require.NoError(t, err)
+
+	var preview model.TransactionPreview
+	resp, err := SetUpTestRequest(TestRequest{
+		Payload: payload, Response: &preview, Method: http.MethodPut,
+		Route: "/transactions/inflight/" + hold.TransactionID, Router: router,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.True(t, preview.DryRun)
+	assert.Equal(t, "commit", preview.Operation)
+	assert.True(t, preview.WouldApply)
+	require.Len(t, preview.Balances, 2)
+
+	// The hold is released and the money actually moves.
+	assert.Equal(t, "10000", preview.Balances[0].CurrentInflightDebitBalance)
+	assert.Equal(t, "0", preview.Balances[0].ResultingInflightDebitBalance)
+
+	// And the hold is still open afterwards.
+	after, err := b.GetTransaction(t.Context(), hold.TransactionID)
+	require.NoError(t, err)
+	assert.Equal(t, "INFLIGHT", after.Status, "a dry run must not settle the hold")
+}
+
+// TestDryRunInflightVoidIgnoresAmount pins that a void always releases the
+// whole remaining hold: the endpoint has no partial void, so an amount sent
+// with one is reported as ignored rather than silently honoured.
+func TestDryRunInflightVoidIgnoresAmount(t *testing.T) {
+	router, b, err := setupRouter()
+	require.NoError(t, err)
+
+	source, destination := newDryRunFixture(t, b)
+
+	hold, err := b.QueueTransaction(t.Context(), &model.Transaction{
+		Reference:   "holdvoid_" + model.GenerateUUIDWithSuffix("ref"),
+		Source:      source,
+		Destination: destination,
+		Amount:      100,
+		Precision:   100,
+		Currency:    "USD",
+		Inflight:    true,
+		SkipQueue:   true,
+	})
+	require.NoError(t, err)
+
+	payload, err := request.ToJsonReq(&map[string]interface{}{
+		"dry_run": true, "status": "void", "precise_amount": 4000,
+	})
+	require.NoError(t, err)
+
+	var preview model.TransactionPreview
+	resp, err := SetUpTestRequest(TestRequest{
+		Payload: payload, Response: &preview, Method: http.MethodPut,
+		Route: "/transactions/inflight/" + hold.TransactionID, Router: router,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.Equal(t, "void", preview.Operation)
+	assert.True(t, preview.WouldApply)
+
+	// The full 100.00 hold is released, not the 40.00 that was asked for.
+	assert.Equal(t, "10000", preview.PreciseAmount)
+
+	found := false
+	for _, note := range preview.Notes {
+		if note == "amount is ignored when voiding; a void always releases the full remaining hold" {
+			found = true
+		}
+	}
+	assert.True(t, found, "the caller must be told the amount was ignored")
+}
+
+// TestDryRunInflightWritesNothing checks the projection leaves the hold and the
+// balances exactly as they were.
+func TestDryRunInflightWritesNothing(t *testing.T) {
+	router, b, err := setupRouter()
+	require.NoError(t, err)
+
+	source, destination := newDryRunFixture(t, b)
+
+	hold, err := b.QueueTransaction(t.Context(), &model.Transaction{
+		Reference:   "holdnone_" + model.GenerateUUIDWithSuffix("ref"),
+		Source:      source,
+		Destination: destination,
+		Amount:      100,
+		Precision:   100,
+		Currency:    "USD",
+		Inflight:    true,
+		SkipQueue:   true,
+	})
+	require.NoError(t, err)
+
+	before, err := b.GetBalanceByID(t.Context(), source, nil, false)
+	require.NoError(t, err)
+
+	payload, err := request.ToJsonReq(&map[string]interface{}{"dry_run": true, "status": "commit"})
+	require.NoError(t, err)
+
+	var preview model.TransactionPreview
+	_, err = SetUpTestRequest(TestRequest{
+		Payload: payload, Response: &preview, Method: http.MethodPut,
+		Route: "/transactions/inflight/" + hold.TransactionID, Router: router,
+	})
+	require.NoError(t, err)
+
+	after, err := b.GetBalanceByID(t.Context(), source, nil, false)
+	require.NoError(t, err)
+
+	assert.Equal(t, before.Balance.String(), after.Balance.String())
+	assert.Equal(t, before.InflightDebitBalance.String(), after.InflightDebitBalance.String())
+	assert.Equal(t, before.Version, after.Version, "version moves on any persisted balance write")
+}
+
+// TestDryRunInflightRejectsUnknownStatus checks the action is validated the
+// same way a real settlement validates it.
+func TestDryRunInflightRejectsUnknownStatus(t *testing.T) {
+	router, b, err := setupRouter()
+	require.NoError(t, err)
+
+	source, destination := newDryRunFixture(t, b)
+
+	hold, err := b.QueueTransaction(t.Context(), &model.Transaction{
+		Reference:   "holdbad_" + model.GenerateUUIDWithSuffix("ref"),
+		Source:      source,
+		Destination: destination,
+		Amount:      100,
+		Precision:   100,
+		Currency:    "USD",
+		Inflight:    true,
+		SkipQueue:   true,
+	})
+	require.NoError(t, err)
+
+	payload, err := request.ToJsonReq(&map[string]interface{}{"dry_run": true, "status": "settle"})
+	require.NoError(t, err)
+
+	var body map[string]interface{}
+	resp, err := SetUpTestRequest(TestRequest{
+		Payload: payload, Response: &body, Method: http.MethodPut,
+		Route: "/transactions/inflight/" + hold.TransactionID, Router: router,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusBadRequest, resp.Code, "an unsupported action is a malformed request, not a projection")
+}

--- a/api/transaction_dryrun_parity_test.go
+++ b/api/transaction_dryrun_parity_test.go
@@ -1,0 +1,92 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blnkfinance/blnk/model"
+)
+
+// errorCodeOf pulls the catalog code out of an error response.
+func errorCodeOf(t *testing.T, body []byte) string {
+	t.Helper()
+	var parsed struct {
+		ErrorDetail struct {
+			Code string `json:"code"`
+		} `json:"error_detail"`
+	}
+	require.NoError(t, json.Unmarshal(body, &parsed), "response was not an error envelope: %s", string(body))
+	return parsed.ErrorDetail.Code
+}
+
+// A preview is only useful if it reports what the real post would report. This
+// asserts the two agree on a missing balance rather than asserting a specific
+// code, deliberately: the code a missing balance produces is owned by the error
+// catalog and has changed before -- #362 moves it from the generic not-found to
+// a balance-specific one. Pinning the literal here would either fight that
+// change or silently bless a divergence.
+//
+// The invariant that matters is agreement, and it holds either way.
+func TestDryRunAndRealAgreeOnMissingBalance(t *testing.T) {
+	router, _, err := setupRouter()
+	require.NoError(t, err)
+
+	body := func() map[string]interface{} {
+		return map[string]interface{}{
+			"amount": 100, "precision": 100, "currency": "USD",
+			"reference":   model.GenerateUUIDWithSuffix("parity"),
+			"description": "parity check",
+			"source":      "bln_definitely_absent_src",
+			"destination": "bln_definitely_absent_dst",
+		}
+	}
+
+	previewBody := body()
+	previewBody["dry_run"] = true
+	preview := doJSON(router, http.MethodPost, "/transactions", previewBody)
+
+	realBody := body()
+	realBody["skip_queue"] = true
+	real := doJSON(router, http.MethodPost, "/transactions", realBody)
+
+	assert.Equal(t, real.Code, preview.Code,
+		"preview and real disagree on HTTP status for a missing balance:\n preview: %s\n real:    %s",
+		preview.Body.String(), real.Body.String())
+
+	assert.Equal(t, errorCodeOf(t, real.Body.Bytes()), errorCodeOf(t, preview.Body.Bytes()),
+		"preview and real disagree on the error code for a missing balance")
+}
+
+// The same agreement must hold for a request the validator rejects, which is
+// resolved before either branch is chosen.
+func TestDryRunAndRealAgreeOnValidationFailure(t *testing.T) {
+	router, _, err := setupRouter()
+	require.NoError(t, err)
+
+	body := func() map[string]interface{} {
+		return map[string]interface{}{
+			"amount": 100, "precision": 100, "currency": "USD",
+			"reference":   model.GenerateUUIDWithSuffix("parity"),
+			"description": "parity check",
+			"source":      "bln_a",
+			// destination omitted entirely: invalid on both paths
+		}
+	}
+
+	previewBody := body()
+	previewBody["dry_run"] = true
+	preview := doJSON(router, http.MethodPost, "/transactions", previewBody)
+
+	realBody := body()
+	realBody["skip_queue"] = true
+	real := doJSON(router, http.MethodPost, "/transactions", realBody)
+
+	require.Equal(t, http.StatusBadRequest, preview.Code, preview.Body.String())
+	assert.Equal(t, real.Code, preview.Code)
+	assert.Equal(t, real.Body.String(), preview.Body.String(),
+		"validation runs ahead of the dry_run branch, so both paths must return the identical body")
+}

--- a/api/transaction_dryrun_rejected_status_test.go
+++ b/api/transaction_dryrun_rejected_status_test.go
@@ -1,0 +1,71 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blnkfinance/blnk/model"
+)
+
+// A rejected projection must not also report a status.
+//
+// Status is set early, from the status the transaction would carry once
+// applied, and the projection only later discovers the balance cannot cover
+// it. Left alone the response asserted two things that cannot both be true:
+// would_apply false, and status APPLIED.
+func TestDryRunRejectedPreviewReportsNoStatus(t *testing.T) {
+	router, b, err := setupRouter()
+	require.NoError(t, err)
+	source, destination := newDryRunFixture(t, b) // source holds 500.00
+
+	w := doJSON(router, http.MethodPost, "/transactions", map[string]interface{}{
+		"amount": 999999, "precision": 100, "currency": "USD",
+		"reference":   model.GenerateUUIDWithSuffix("rejstatus"),
+		"description": "more than the source holds",
+		"source":      source,
+		"destination": destination,
+		"dry_run":     true,
+	})
+
+	require.Equal(t, http.StatusOK, w.Code, "a projected rejection is a successful answer of \"no\"")
+
+	var preview model.TransactionPreview
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &preview))
+
+	require.False(t, preview.WouldApply)
+	require.NotNil(t, preview.Rejection)
+	assert.Equal(t, "TXN_INSUFFICIENT_FUNDS", preview.Rejection.Code)
+
+	assert.Empty(t, preview.Status,
+		"a rejected projection has no resulting status; the real post writes no transaction")
+	assert.NotContains(t, w.Body.String(), `"status"`,
+		"status must be omitted from a rejected projection, not emitted empty:\n%s", w.Body.String())
+}
+
+// The accepted case must be unaffected: status is exactly what the real post
+// would carry.
+func TestDryRunAcceptedPreviewStillReportsStatus(t *testing.T) {
+	router, b, err := setupRouter()
+	require.NoError(t, err)
+	source, destination := newDryRunFixture(t, b)
+
+	w := doJSON(router, http.MethodPost, "/transactions", map[string]interface{}{
+		"amount": 1, "precision": 100, "currency": "USD",
+		"reference":   model.GenerateUUIDWithSuffix("okstatus"),
+		"description": "within balance",
+		"source":      source,
+		"destination": destination,
+		"dry_run":     true,
+	})
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var preview model.TransactionPreview
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &preview))
+	require.True(t, preview.WouldApply, w.Body.String())
+	assert.Equal(t, "APPLIED", preview.Status, "an accepted projection still reports what it would become")
+}

--- a/api/transactions.go
+++ b/api/transactions.go
@@ -706,6 +706,53 @@ func (a Api) RecoverQueuedTransactions(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"recovered": recovered, "threshold": threshold.String()})
 }
 
+// respondBulkInflightPreview projects a bulk commit or void and writes the
+// result, without settling anything.
+//
+// Items are projected independently rather than cumulatively, because that
+// is how BulkInflightUpdate really runs them: across a worker pool with no
+// ordering between items, so no item can be said to observe another's
+// effect. Each item is therefore projected against the balances as they
+// stand, and the batch-level balances a cumulative projection would report
+// are deliberately omitted.
+//
+// A per-item projection failure is reported as that item's rejection rather
+// than failing the whole request, mirroring BulkInflightUpdate, whose
+// per-item failures do not abort the rest of the batch. Only an
+// infrastructure error aborts.
+func (a Api) respondBulkInflightPreview(c *gin.Context, action string, items []blnk.BulkInflightItem) {
+	preview := model.BulkTransactionPreview{
+		DryRun:     true,
+		WouldApply: true,
+		Cumulative: false,
+		Results:    make([]model.TransactionPreview, 0, len(items)),
+	}
+	preview.Notes = append(preview.Notes,
+		"items are dispatched across a worker pool, so each is projected independently against current balances and real execution order is not guaranteed")
+
+	for _, item := range items {
+		itemPreview, err := a.blnk.PreviewInflightAction(c.Request.Context(), item.TransactionID, action, item.Amount)
+		if err != nil {
+			// The id could not be resolved at all (missing, or an
+			// infrastructure failure). Report it against the item rather than
+			// discarding the projections already gathered.
+			itemPreview = &model.TransactionPreview{
+				DryRun:     true,
+				WouldApply: false,
+				Operation:  action,
+				Rejection:  &model.PreviewRejection{Message: err.Error()},
+			}
+		}
+		if !itemPreview.WouldApply {
+			preview.WouldApply = false
+		}
+		preview.Results = append(preview.Results, *itemPreview)
+	}
+
+	resolvePreviewRejectionCodes(preview.Results)
+	c.JSON(http.StatusOK, preview)
+}
+
 // bulkInflightMaxWorkers caps the worker-pool size used by the bulk handlers.
 // 8 is a deliberate compromise: large enough to win meaningful concurrency
 // vs sequential N round-trips, small enough not to flood the lock service or
@@ -760,6 +807,13 @@ func (a Api) BulkVoidInflight(c *gin.Context) {
 	items := make([]blnk.BulkInflightItem, len(req.TransactionIDs))
 	for i, id := range req.TransactionIDs {
 		items[i] = blnk.BulkInflightItem{TransactionID: id}
+	}
+
+	// Ahead of both the queueing and the synchronous branch: a dry run must
+	// not release a hold on either path.
+	if req.DryRun {
+		a.respondBulkInflightPreview(c, blnk.InflightActionVoid, items)
+		return
 	}
 
 	if !req.SkipQueue {
@@ -844,6 +898,13 @@ func (a Api) BulkCommitInflight(c *gin.Context) {
 			amount = model.ApplyPrecisionWithDBLookup(&model.Transaction{Amount: it.Amount, TransactionID: it.TransactionID}, ds.Conn)
 		}
 		items[i] = blnk.BulkInflightItem{TransactionID: it.TransactionID, Amount: amount}
+	}
+
+	// Ahead of both the queueing and the synchronous branch: a dry run must
+	// not settle a hold on either path.
+	if req.DryRun {
+		a.respondBulkInflightPreview(c, blnk.InflightActionCommit, items)
+		return
 	}
 
 	if !req.SkipQueue {

--- a/api/transactions.go
+++ b/api/transactions.go
@@ -18,10 +18,12 @@ package api
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"math/big"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -740,6 +742,31 @@ func (a Api) respondBulkInflightPreview(c *gin.Context, action string, items []b
 	preview.Notes = append(preview.Notes,
 		"items are dispatched across a worker pool, so each is projected independently against current balances and real execution order is not guaranteed")
 
+	// A transaction id repeated in one batch is projected once per occurrence,
+	// and each occurrence sees the hold still standing — so every one of them
+	// reports would_apply. Really running that batch settles the hold once and
+	// fails the rest, against a hold that is gone or already taken.
+	//
+	// The duplicate is reported rather than resolved. Which occurrence wins is
+	// decided by the worker pool, so marking a particular one as the loser
+	// would assert an ordering the ledger does not provide — the same reason
+	// the batch above is projected independently rather than cumulatively.
+	// Saying that only one can settle is both true and all that is knowable.
+	seen := make(map[string]bool, len(items))
+	dupes := make([]string, 0)
+	for _, item := range items {
+		if seen[item.TransactionID] {
+			dupes = append(dupes, item.TransactionID)
+			continue
+		}
+		seen[item.TransactionID] = true
+	}
+	if len(dupes) > 0 {
+		preview.AddNote(fmt.Sprintf(
+			"transaction id appears more than once in this batch (%s); the occurrences settle the same hold, so only one of them can succeed and which one is not determined",
+			strings.Join(uniqueStrings(dupes), ", ")))
+	}
+
 	for _, item := range items {
 		itemPreview, err := a.blnk.PreviewInflightAction(c.Request.Context(), item.TransactionID, action, item.Amount)
 		if err != nil {
@@ -761,6 +788,20 @@ func (a Api) respondBulkInflightPreview(c *gin.Context, action string, items []b
 
 	resolvePreviewRejectionCodes(preview.Results)
 	c.JSON(http.StatusOK, preview)
+}
+
+// uniqueStrings returns in, de-duplicated, preserving first-seen order.
+func uniqueStrings(in []string) []string {
+	seen := make(map[string]bool, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	return out
 }
 
 // bulkInflightMaxWorkers caps the worker-pool size used by the bulk handlers.

--- a/api/transactions.go
+++ b/api/transactions.go
@@ -490,6 +490,16 @@ func (a Api) UpdateInflightStatus(c *gin.Context) {
 	// way callers request a partial commit, and skipping this resolution for
 	// dry runs previously meant that field was silently ignored there,
 	// letting an over-limit amount preview as would_apply: true.
+	//
+	// This does mean a dry run now reaches ApplyPrecisionWithDBLookup, which
+	// the branch used to sit ahead of because it writes into a package-level
+	// precision cache. That is a read-through cache of a value that never
+	// changes for a given transaction, so the entry a projection leaves is
+	// the same one the real commit would have written and can never be
+	// stale; the only cost is that a projection can contribute to the
+	// entry-count bound that resets the map. Preferred over resolving the
+	// amount twice, once per branch, and risking the two drifting apart —
+	// which is the class of bug this resolution was moved to fix.
 	cnf, err := config.Fetch()
 	if err != nil {
 		respondError(c, err)

--- a/api/transactions.go
+++ b/api/transactions.go
@@ -103,15 +103,30 @@ func (a Api) respondPreview(c *gin.Context, preview *model.TransactionPreview, e
 		return
 	}
 
-	if preview.Rejection != nil && preview.Rejection.Code == "" {
-		code, ok := classifyMessage(preview.Rejection.Message)
-		if !ok {
-			code = apierror.ErrTxnValidation
-		}
-		preview.Rejection.Code = string(code)
+	resolvePreviewRejectionCode(preview)
+	c.JSON(http.StatusOK, preview)
+}
+
+// resolvePreviewRejectionCode fills in the error code a real post would have
+// returned for a projected rejection, using the same classifier the other
+// endpoints resolve errors through.
+func resolvePreviewRejectionCode(preview *model.TransactionPreview) {
+	if preview == nil || preview.Rejection == nil || preview.Rejection.Code != "" {
+		return
 	}
 
-	c.JSON(http.StatusOK, preview)
+	code, ok := classifyMessage(preview.Rejection.Message)
+	if !ok {
+		code = apierror.ErrTxnValidation
+	}
+	preview.Rejection.Code = string(code)
+}
+
+// resolvePreviewRejectionCodes fills in rejection codes across a batch.
+func resolvePreviewRejectionCodes(previews []model.TransactionPreview) {
+	for i := range previews {
+		resolvePreviewRejectionCode(&previews[i])
+	}
 }
 
 func handleRecordTransactionValidationError(c *gin.Context, err error) {
@@ -444,6 +459,20 @@ func (a Api) UpdateInflightStatus(c *gin.Context) {
 		return
 	}
 
+	status := req.Status
+	if status != blnk.InflightActionCommit && status != blnk.InflightActionVoid {
+		respondCode(c, apierror.ErrTxnInvalidStatusAction, "status not supported. use either commit or void", nil)
+		return
+	}
+
+	// Projected before the precision lookup below, which caches into package
+	// state, and before any queueing.
+	if req.DryRun {
+		preview, err := a.blnk.PreviewInflightAction(c.Request.Context(), id, status, req.PreciseAmount)
+		a.respondPreview(c, preview, err)
+		return
+	}
+
 	cnf, err := config.Fetch()
 	if err != nil {
 		respondError(c, err)
@@ -463,12 +492,6 @@ func (a Api) UpdateInflightStatus(c *gin.Context) {
 			return
 		}
 		amount = req.PreciseAmount
-	}
-
-	status := req.Status
-	if status != blnk.InflightActionCommit && status != blnk.InflightActionVoid {
-		respondCode(c, apierror.ErrTxnInvalidStatusAction, "status not supported. use either commit or void", nil)
-		return
 	}
 
 	// Default: route the action through the inflight-commit queue. The response
@@ -559,6 +582,21 @@ func (a Api) CreateBulkTransactions(c *gin.Context) {
 	}
 
 	bulkReq := req.ToBulkTransactionRequest()
+
+	// Projected after the per-item validation above, so a dry run is held to
+	// the same input rules as a real batch, but before anything is dispatched.
+	if req.DryRun {
+		preview, err := a.blnk.PreviewBulkTransactions(c.Request.Context(), bulkReq)
+		if err != nil {
+			respondError(c, err,
+				withUpgrade(apierror.ErrGenNotFound, apierror.ErrTxnNotFound),
+				withDefault(apierror.ErrTxnValidation))
+			return
+		}
+		resolvePreviewRejectionCodes(preview.Results)
+		c.JSON(http.StatusOK, preview)
+		return
+	}
 
 	// Call the service layer method to handle bulk transaction creation
 	result, err := a.blnk.CreateBulkTransactions(c.Request.Context(), bulkReq)

--- a/api/transactions.go
+++ b/api/transactions.go
@@ -465,14 +465,10 @@ func (a Api) UpdateInflightStatus(c *gin.Context) {
 		return
 	}
 
-	// Projected before the precision lookup below, which caches into package
-	// state, and before any queueing.
-	if req.DryRun {
-		preview, err := a.blnk.PreviewInflightAction(c.Request.Context(), id, status, req.PreciseAmount)
-		a.respondPreview(c, preview, err)
-		return
-	}
-
+	// Resolved before the dry-run branch too: a plain `amount` is the normal
+	// way callers request a partial commit, and skipping this resolution for
+	// dry runs previously meant that field was silently ignored there,
+	// letting an over-limit amount preview as would_apply: true.
 	cnf, err := config.Fetch()
 	if err != nil {
 		respondError(c, err)
@@ -492,6 +488,12 @@ func (a Api) UpdateInflightStatus(c *gin.Context) {
 			return
 		}
 		amount = req.PreciseAmount
+	}
+
+	if req.DryRun {
+		preview, err := a.blnk.PreviewInflightAction(c.Request.Context(), id, status, amount)
+		a.respondPreview(c, preview, err)
+		return
 	}
 
 	// Default: route the action through the inflight-commit queue. The response

--- a/model/transaction_preview.go
+++ b/model/transaction_preview.go
@@ -32,8 +32,12 @@ type TransactionPreview struct {
 	// WouldApply reports whether a real post of this transaction would be
 	// accepted against the balances as they currently stand. When false,
 	// Rejection carries the reason.
-	WouldApply    bool                `json:"would_apply"`
-	Rejection     *PreviewRejection   `json:"rejection,omitempty"`
+	WouldApply bool              `json:"would_apply"`
+	Rejection  *PreviewRejection `json:"rejection,omitempty"`
+
+	// Operation names the settlement being projected on the inflight endpoint:
+	// "commit" or "void". Empty for ordinary transaction projections.
+	Operation     string              `json:"operation,omitempty"`
 	Status        string              `json:"status"`
 	Reference     string              `json:"reference,omitempty"`
 	Currency      string              `json:"currency"`
@@ -100,5 +104,35 @@ type LegProjection struct {
 
 // AddNote appends an advisory note to the projection.
 func (preview *TransactionPreview) AddNote(note string) {
+	preview.Notes = append(preview.Notes, note)
+}
+
+// BulkTransactionPreview is the projected effect of a batch that was evaluated
+// but never applied.
+type BulkTransactionPreview struct {
+	DryRun bool `json:"dry_run"`
+
+	// WouldApply is false when any item in the batch would be rejected.
+	WouldApply bool `json:"would_apply"`
+
+	// Cumulative reports whether items were projected against each other's
+	// effects. That mirrors how the batch would really run: items are applied
+	// one after another only when skip_queue is set, and are otherwise
+	// dispatched concurrently with no guaranteed order.
+	Cumulative bool `json:"cumulative"`
+	Atomic     bool `json:"atomic"`
+
+	Results []TransactionPreview `json:"results"`
+
+	// Balances is the batch's combined effect per balance, and is reported only
+	// in cumulative mode — without a guaranteed order there is no single
+	// combined outcome to state.
+	Balances []BalanceProjection `json:"balances,omitempty"`
+
+	Notes []string `json:"notes,omitempty"`
+}
+
+// AddNote appends an advisory note to the batch projection.
+func (preview *BulkTransactionPreview) AddNote(note string) {
 	preview.Notes = append(preview.Notes, note)
 }

--- a/model/transaction_preview.go
+++ b/model/transaction_preview.go
@@ -37,8 +37,13 @@ type TransactionPreview struct {
 
 	// Operation names the settlement being projected on the inflight endpoint:
 	// "commit" or "void". Empty for ordinary transaction projections.
-	Operation     string              `json:"operation,omitempty"`
-	Status        string              `json:"status"`
+	Operation string `json:"operation,omitempty"`
+
+	// Status is the status the transaction would carry once applied. It is
+	// omitted when WouldApply is false: a rejected projection has no resulting
+	// status, because the real endpoint returns an error and writes no
+	// transaction at all. See Finalize.
+	Status        string              `json:"status,omitempty"`
 	Reference     string              `json:"reference,omitempty"`
 	Currency      string              `json:"currency"`
 	Amount        float64             `json:"amount"`
@@ -135,4 +140,34 @@ type BulkTransactionPreview struct {
 // AddNote appends an advisory note to the batch projection.
 func (preview *BulkTransactionPreview) AddNote(note string) {
 	preview.Notes = append(preview.Notes, note)
+}
+
+// Finalize reconciles fields that only describe a transaction that would
+// actually apply.
+//
+// Status is set early, from the status the transaction would carry once
+// applied, and the projection only later discovers it would be rejected -- an
+// insufficient balance, a failing leg, a validation failure downstream. Left
+// alone, the response then asserts two things that cannot both be true:
+//
+//	"would_apply": false,
+//	"rejection":   { "code": "TXN_INSUFFICIENT_FUNDS", ... },
+//	"status":      "APPLIED"
+//
+// A rejected projection has no resulting status. The real endpoint returns an
+// error and writes no transaction, so there is no status to report; clearing
+// it lets the omitempty tag drop the field rather than name an outcome that
+// cannot happen. Callers read would_apply and rejection for that answer.
+func (preview *TransactionPreview) Finalize() {
+	if !preview.WouldApply {
+		preview.Status = ""
+	}
+}
+
+// Finalize applies the same reconciliation to a batch and to each of its
+// items, so a rejected item does not report a status either.
+func (preview *BulkTransactionPreview) Finalize() {
+	for i := range preview.Results {
+		preview.Results[i].Finalize()
+	}
 }

--- a/model/transaction_preview_finalize_test.go
+++ b/model/transaction_preview_finalize_test.go
@@ -1,0 +1,62 @@
+package model
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A rejected projection must not also claim a resulting status. The real
+// endpoint returns an error and writes no transaction, so "would_apply": false
+// alongside "status": "APPLIED" describes an outcome that cannot happen.
+func TestFinalize_RejectedPreviewDropsStatus(t *testing.T) {
+	preview := &TransactionPreview{
+		DryRun:     true,
+		WouldApply: false,
+		Status:     "APPLIED",
+		Rejection: &PreviewRejection{
+			Code:    "TXN_INSUFFICIENT_FUNDS",
+			Reason:  "insufficient_funds",
+			Message: "failed to apply transaction to balances: insufficient funds in source balance",
+		},
+	}
+	preview.Finalize()
+
+	assert.Empty(t, preview.Status, "a rejected projection has no resulting status")
+
+	raw, err := json.Marshal(preview)
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), `"status"`,
+		"status must be omitted entirely, not emitted as an empty string: %s", string(raw))
+	assert.Contains(t, string(raw), `"would_apply":false`)
+	assert.Contains(t, string(raw), `"TXN_INSUFFICIENT_FUNDS"`)
+}
+
+// An accepted projection keeps the status it would carry once applied.
+func TestFinalize_AcceptedPreviewKeepsStatus(t *testing.T) {
+	preview := &TransactionPreview{DryRun: true, WouldApply: true, Status: "APPLIED"}
+	preview.Finalize()
+
+	assert.Equal(t, "APPLIED", preview.Status)
+	raw, err := json.Marshal(preview)
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), `"status":"APPLIED"`)
+}
+
+// Batch finalisation must reach the items, since each carries its own status.
+func TestFinalize_BulkClearsStatusPerRejectedItem(t *testing.T) {
+	batch := &BulkTransactionPreview{
+		DryRun:     true,
+		WouldApply: false,
+		Results: []TransactionPreview{
+			{WouldApply: true, Status: "APPLIED"},
+			{WouldApply: false, Status: "APPLIED", Rejection: &PreviewRejection{Code: "TXN_INSUFFICIENT_FUNDS"}},
+		},
+	}
+	batch.Finalize()
+
+	assert.Equal(t, "APPLIED", batch.Results[0].Status, "the accepted item keeps its status")
+	assert.Empty(t, batch.Results[1].Status, "the rejected item must not report a status")
+}

--- a/transaction_dryrun.go
+++ b/transaction_dryrun.go
@@ -198,9 +198,22 @@ func (l *Blnk) previewSingleTransaction(ctx context.Context, transaction *model.
 // previewSplitTransaction projects a multi-source or multi-destination
 // transaction, one entry per split.
 //
-// A real split records each leg through its own lock-and-apply cycle, so later
-// legs observe earlier legs' effects. The projection mirrors that by carrying
-// each balance's working copy forward across legs.
+// How the split would really execute decides how it is projected, mirroring
+// the same distinction the bulk endpoint makes:
+//
+//	skip_queue: true   processTxns records each leg synchronously, one after
+//	                    another, and stops at the first one that fails —
+//	                    later legs are never attempted. The projection
+//	                    carries balances forward across legs and stops
+//	                    projecting as soon as one fails, for the same
+//	                    reason: it never really ran either.
+//
+//	skip_queue: false  each leg is persisted and queued for independent
+//	                    async processing with no ordering guarantee, so one
+//	                    leg's outcome doesn't depend on another's. Each leg
+//	                    here is projected on its own, against the balances
+//	                    as they stand, not carrying an earlier leg's effect
+//	                    forward.
 func (l *Blnk) previewSplitTransaction(ctx context.Context, transaction *model.Transaction) (*model.TransactionPreview, error) {
 	ctx, span := tracer.Start(ctx, "PreviewSplitTransaction")
 	defer span.End()
@@ -216,45 +229,76 @@ func (l *Blnk) previewSplitTransaction(ctx context.Context, transaction *model.T
 	preview.PreciseAmount = preciseString(transaction.PreciseAmount)
 	preview.Amount = transaction.Amount
 
-	// Working copies shared across legs, so a balance touched twice accumulates
-	// exactly as it would in a real sequential apply.
-	working := newPreviewBalanceSet(l)
+	cumulative := transaction.SkipQueue
+	if !cumulative {
+		preview.AddNote("skip_queue is false: legs are queued for independent async processing with no ordering guarantee, so each is projected on its own rather than cumulatively")
+	}
+
+	// Shared only in cumulative mode, so a balance touched twice accumulates
+	// exactly as it would in a real sequential apply. Independent mode gives
+	// each leg its own fresh set instead, so one leg's projection can't leak
+	// into another's the way it could for legs that will really run at
+	// different, uncoordinated times.
+	shared := newPreviewBalanceSet(l)
 
 	for _, leg := range legs {
 		normalizePreviewStatus(leg)
 		leg.PreciseAmount = model.ApplyPrecision(leg)
 
-		source, destination, err := working.resolvePair(ctx, leg)
+		set := shared
+		if !cumulative {
+			set = newPreviewBalanceSet(l)
+		}
+
+		source, destination, err := set.resolvePair(ctx, leg)
 		if err != nil {
 			span.RecordError(err)
 			return nil, err
 		}
 
+		failed := false
 		if err := sameBalanceErr(source, destination); err != nil {
 			preview.WouldApply = false
 			if preview.Rejection == nil {
 				preview.Rejection = previewRejection(err)
 			}
+			failed = true
 		} else if applyErr := l.processBalances(ctx, leg, source.balance, destination.balance); applyErr != nil {
 			preview.WouldApply = false
 			if preview.Rejection == nil {
 				preview.Rejection = previewRejection(applyErr)
 			}
+			failed = true
 		}
 
-		role, identifier := model.PreviewRoleDestination, leg.Destination
-		if len(transaction.Sources) > 0 {
-			role, identifier = model.PreviewRoleSource, leg.Source
+		// A failed leg was never actually recorded, so its would-be amount
+		// doesn't belong next to the legs that really would apply.
+		if !failed {
+			role, identifier := model.PreviewRoleDestination, leg.Destination
+			if len(transaction.Sources) > 0 {
+				role, identifier = model.PreviewRoleSource, leg.Source
+			}
+			preview.Legs = append(preview.Legs, model.LegProjection{
+				Identifier:    identifier,
+				Role:          role,
+				PreciseAmount: preciseString(leg.PreciseAmount),
+				Amount:        leg.Amount,
+			})
 		}
-		preview.Legs = append(preview.Legs, model.LegProjection{
-			Identifier:    identifier,
-			Role:          role,
-			PreciseAmount: preciseString(leg.PreciseAmount),
-			Amount:        leg.Amount,
-		})
+
+		if !cumulative {
+			preview.Balances = append(preview.Balances, set.projections()...)
+		} else if failed {
+			// Mirrors processTxns: a real skip_queue: true split stops at
+			// the first failing leg and never attempts the rest.
+			break
+		}
 	}
 
-	preview.Balances = working.projections()
+	if cumulative {
+		preview.Balances = shared.projections()
+	}
+
 	return preview, nil
 }
 

--- a/transaction_dryrun.go
+++ b/transaction_dryrun.go
@@ -230,7 +230,12 @@ func (l *Blnk) previewSplitTransaction(ctx context.Context, transaction *model.T
 			return nil, err
 		}
 
-		if applyErr := l.processBalances(ctx, leg, source.balance, destination.balance); applyErr != nil {
+		if err := sameBalanceErr(source, destination); err != nil {
+			preview.WouldApply = false
+			if preview.Rejection == nil {
+				preview.Rejection = previewRejection(err)
+			}
+		} else if applyErr := l.processBalances(ctx, leg, source.balance, destination.balance); applyErr != nil {
 			preview.WouldApply = false
 			if preview.Rejection == nil {
 				preview.Rejection = previewRejection(applyErr)
@@ -393,8 +398,31 @@ func newPreviewFor(transaction *model.Transaction) *model.TransactionPreview {
 	}
 }
 
+// sameBalanceErr reports the error a real post would fail with when source
+// and destination resolve to the same balance row, or nil if they don't.
+//
+// A real post fetches and updates source and destination as two
+// independent balance reads, each guarded by optimistic locking. When
+// they're the same row, the first update advances its version and the
+// second's WHERE version=<stale> clause matches nothing — a guaranteed
+// conflict every single time, not a rare race. In-memory preview
+// arithmetic has no such check, so without this a self-transfer would
+// always preview as would_apply: true for a transfer that can never
+// actually apply.
+func sameBalanceErr(source, destination *previewBalance) error {
+	if source.balance.BalanceID != destination.balance.BalanceID {
+		return nil
+	}
+	return fmt.Errorf("Optimistic locking failure: balance with ID '%s' may have been updated or deleted by another transaction", source.balance.BalanceID)
+}
+
 // notePreviewCaveats records conditions worth surfacing that are not rejections.
 func (l *Blnk) notePreviewCaveats(ctx context.Context, preview *model.TransactionPreview, transaction *model.Transaction, source, destination *previewBalance) {
+	if err := sameBalanceErr(source, destination); err != nil {
+		preview.WouldApply = false
+		preview.Rejection = previewRejection(err)
+	}
+
 	if !transaction.ScheduledFor.IsZero() {
 		preview.AddNote("scheduled_for is ignored in a dry run; the projection shows the effect as if applied now")
 	}

--- a/transaction_dryrun.go
+++ b/transaction_dryrun.go
@@ -384,6 +384,26 @@ func (l *Blnk) fetchBalanceForPreview(balanceID string) (*model.Balance, error) 
 // previewBalanceSet caches balances across the legs of a split so that a
 // balance touched more than once accumulates, and so each distinct balance is
 // read once.
+//
+// Unlike previewSingleTransaction, the paths built on this set — splits,
+// cumulative bulk items and inflight legs — read without holding the balance
+// lock, so the balances behind a multi-leg projection are not guaranteed to
+// be read as of one instant. Two reasons, and the trade-off is deliberate:
+//
+// acquireLock takes exactly one source and one destination. A leg set spans
+// an arbitrary number of balances, so there is no existing lock to reuse, and
+// holding one per balance across a whole batch would mean a read-only call
+// holding many balance locks at once — the shape that starves the writers it
+// is supposed to be predicting for. previewSingleTransaction locks because
+// there the pair is fixed and the hold spans two reads and some in-memory
+// arithmetic.
+//
+// The second reason is that the guarantee is worth little here. A projection
+// is advisory by construction: it describes balances as they stand, and any
+// transaction may move them between the answer and a real post. A torn read
+// across legs widens a window that is already open, so it does not change the
+// kind of answer a caller is getting, only its precision within a window they
+// were told not to rely on.
 type previewBalanceSet struct {
 	blnk  *Blnk
 	order []string

--- a/transaction_dryrun.go
+++ b/transaction_dryrun.go
@@ -71,24 +71,31 @@ func (l *Blnk) PreviewTransaction(ctx context.Context, transaction *model.Transa
 // PreviewRefund projects the reversal of an existing transaction without
 // creating it.
 //
-// It runs the same lookup and eligibility checks a real refund runs, and builds
-// the reversal with the same helper, so a projection that reports the refund as
-// applicable is one the ledger would accept. Nothing is written: the refund is
-// never queued and the parent is not marked refunded.
+// It runs the same lookup a real refund runs — GetRefundableTransactionsByParentID,
+// batch size 1 — rather than a separate hand-rolled eligibility check. That
+// query is a single WHERE clause covering both "does this id exist" and "is
+// it in a refundable status"; a real refund can't and doesn't distinguish
+// the two; either one comes back as an empty result set, reported as "no
+// transaction to refund" (404). A preview with its own, more detailed
+// eligibility check would answer a different question than the one the real
+// endpoint actually answers, and its rejection code would stop matching what
+// a real post returns — the one thing a preview promises. Nothing is
+// written: the refund is never queued and the parent is not marked refunded.
 func (l *Blnk) PreviewRefund(ctx context.Context, transactionID string) (*model.TransactionPreview, error) {
 	ctx, span := tracer.Start(ctx, "PreviewRefund")
 	defer span.End()
 
-	originalTxn, err := l.getOriginalTransactionForRefund(ctx, transactionID)
+	refundable, err := l.datasource.GetRefundableTransactionsByParentID(ctx, transactionID, 1, 0)
 	if err != nil {
 		span.RecordError(err)
 		return nil, err
 	}
-
-	if err := l.validateTransactionForRefund(ctx, originalTxn); err != nil {
+	if len(refundable) == 0 {
+		err := fmt.Errorf("transaction %s not found for refund", transactionID)
 		span.RecordError(err)
 		return nil, err
 	}
+	originalTxn := refundable[0]
 
 	// Same builder the real refund uses: source and destination swapped,
 	// overdraft allowed, status reset. skipQueue is irrelevant here because the

--- a/transaction_dryrun.go
+++ b/transaction_dryrun.go
@@ -457,6 +457,14 @@ func sameBalanceErr(source, destination *previewBalance) error {
 	if source.balance.BalanceID != destination.balance.BalanceID {
 		return nil
 	}
+	// ST1005 is suppressed rather than satisfied: this string is not written
+	// for this call site, it reproduces database.updateBalance's message
+	// verbatim so a projected rejection reads identically to the real
+	// failure. That message reaches the client through
+	// apierror.NewAPIError, whose message field the linter does not inspect,
+	// so lower-casing it here would make the preview and the real response
+	// disagree on the one field this projection exists to predict.
+	//nolint:staticcheck // ST1005: mirrors the real path's message verbatim
 	return fmt.Errorf("Optimistic locking failure: balance with ID '%s' may have been updated or deleted by another transaction", source.balance.BalanceID)
 }
 

--- a/transaction_dryrun.go
+++ b/transaction_dryrun.go
@@ -158,15 +158,20 @@ func (l *Blnk) previewSingleTransaction(ctx context.Context, transaction *model.
 	if applyErr != nil {
 		preview.WouldApply = false
 		preview.Rejection = previewRejection(applyErr)
-	} else {
+	} else if preview.Rejection == nil {
+		// A caveat recorded above (e.g. a duplicate reference) already
+		// rejected this preview; balances applying cleanly on top of that
+		// doesn't undo it.
 		preview.WouldApply = true
 	}
 
 	// On rejection the balances hold whatever partial state the apply path left
-	// behind, which is not a meaningful projection — report the unchanged
+	// behind — or, for a caveat-triggered rejection like a duplicate
+	// reference, balances applied cleanly even though the preview as a whole
+	// didn't — neither is a meaningful projection. Report the unchanged
 	// snapshot as the outcome instead.
 	sourceAfter, destinationAfter := source.balance, destination.balance
-	if applyErr != nil {
+	if !preview.WouldApply {
 		sourceAfter, destinationAfter = sourceBefore, destinationBefore
 	}
 
@@ -404,7 +409,12 @@ func (l *Blnk) notePreviewCaveats(ctx context.Context, preview *model.Transactio
 
 	if transaction.Reference != "" {
 		if exists, err := l.datasource.TransactionExistsByRef(ctx, transaction.Reference); err == nil && exists {
-			preview.AddNote("reference is already in use; a real post with this reference would be rejected")
+			// A duplicate reference is fatal on a real post (transaction
+			// validation rejects it before balances are ever touched), so this
+			// is a rejection like any other — not a caveat balance projection
+			// can still say would_apply: true around.
+			preview.WouldApply = false
+			preview.Rejection = previewRejection(fmt.Errorf("transaction validation failed: reference %s has already been used", transaction.Reference))
 		}
 	}
 }

--- a/transaction_dryrun.go
+++ b/transaction_dryrun.go
@@ -85,7 +85,7 @@ func (l *Blnk) PreviewRefund(ctx context.Context, transactionID string) (*model.
 	ctx, span := tracer.Start(ctx, "PreviewRefund")
 	defer span.End()
 
-	refundable, err := l.datasource.GetRefundableTransactionsByParentID(ctx, transactionID, 1, 0)
+	refundable, err := l.refundableLegsForPreview(ctx, transactionID)
 	if err != nil {
 		span.RecordError(err)
 		return nil, err
@@ -95,21 +95,118 @@ func (l *Blnk) PreviewRefund(ctx context.Context, transactionID string) (*model.
 		span.RecordError(err)
 		return nil, err
 	}
-	originalTxn := refundable[0]
 
-	// Same builder the real refund uses: source and destination swapped,
-	// overdraft allowed, status reset. skipQueue is irrelevant here because the
-	// projection never reaches the queue.
-	refund := prepareRefundTransaction(originalTxn, RefundOptions{SkipQueue: true})
+	// Every refundable leg is projected, not just the first. A refund of a
+	// split reverses each of its legs — ProcessTransactionInBatches walks the
+	// same query this one does — so projecting a single leg would answer for
+	// part of the movement and report a smaller amount than the refund
+	// actually moves.
+	//
+	// Legs are carried forward through one balance set because the real
+	// refund runs them on a single worker, one after another, so a later leg
+	// does observe an earlier leg's effect.
+	working := newPreviewBalanceSet(l)
+	total := big.NewInt(0)
+	var legErrors []error
 
-	preview, err := l.PreviewTransaction(ctx, refund)
-	if err != nil {
-		span.RecordError(err)
-		return nil, err
+	preview := &model.TransactionPreview{DryRun: true, WouldApply: true}
+
+	for _, original := range refundable {
+		// The same eligibility check each leg passes through on the real
+		// path. GetRefundableTransactionsByParentID filters on status alone,
+		// so without this a leg that has already been reversed still comes
+		// back from the query — its reversal is itself an APPLIED row under
+		// the same parent — and would be projected as refundable again, both
+		// claiming the refund would apply and counting the reversal into the
+		// total.
+		if err := l.validateTransactionForRefund(ctx, original); err != nil {
+			preview.WouldApply = false
+			legErrors = append(legErrors, err)
+			continue
+		}
+
+		// Same builder the real refund uses: source and destination swapped,
+		// overdraft allowed, status reset. SkipQueue only selects which real
+		// dispatch path would run; the projection reaches neither.
+		refund := prepareRefundTransaction(original, RefundOptions{SkipQueue: true})
+		normalizePreviewStatus(refund)
+		refund.PreciseAmount = model.ApplyPrecision(refund)
+
+		source, destination, err := working.resolvePair(ctx, refund)
+		if err != nil {
+			span.RecordError(err)
+			return nil, err
+		}
+
+		if err := sameBalanceErr(source, destination); err != nil {
+			preview.WouldApply = false
+			legErrors = append(legErrors, err)
+			continue
+		}
+
+		if applyErr := l.processBalances(ctx, refund, source.balance, destination.balance); applyErr != nil {
+			preview.WouldApply = false
+			legErrors = append(legErrors, applyErr)
+			continue
+		}
+
+		total = new(big.Int).Add(total, refund.PreciseAmount)
+		preview.Status = refund.Status
+		preview.Currency = refund.Currency
+		preview.Precision = refund.Precision
+		preview.Reference = refund.Reference
+
+		if len(refundable) > 1 {
+			preview.Legs = append(preview.Legs, model.LegProjection{
+				Identifier:    original.TransactionID,
+				Role:          model.PreviewRoleSource,
+				PreciseAmount: preciseString(refund.PreciseAmount),
+				Amount:        refund.Amount,
+			})
+		}
 	}
 
-	preview.AddNote(fmt.Sprintf("projected refund of transaction %s", originalTxn.TransactionID))
+	if len(legErrors) > 0 {
+		preview.Rejection = previewRejection(fmt.Errorf("error occurred during processing: %v", legErrors))
+	}
+
+	preview.PreciseAmount = preciseString(total)
+	if preview.Precision > 0 {
+		preview.Amount = l.convertPreciseToFloat(total, preview.Precision)
+	}
+	preview.Balances = working.projections()
+
+	if len(refundable) == 1 {
+		preview.AddNote(fmt.Sprintf("projected refund of transaction %s", refundable[0].TransactionID))
+	} else {
+		preview.AddNote(fmt.Sprintf("projected refund of %d refundable transactions under %s", len(refundable), transactionID))
+	}
 	return preview, nil
+}
+
+// refundableLegsForPreview collects every transaction a refund of transactionID
+// would reverse.
+//
+// The real refund reaches these through ProcessTransactionInBatches, which
+// pages the same query until it is exhausted, so the projection pages it too
+// rather than reading a single row and answering for that one.
+func (l *Blnk) refundableLegsForPreview(ctx context.Context, transactionID string) ([]*model.Transaction, error) {
+	batchSize := l.Config().Transaction.BatchSize
+	if batchSize <= 0 {
+		batchSize = 100
+	}
+
+	var all []*model.Transaction
+	for offset := int64(0); ; offset += int64(batchSize) {
+		batch, err := l.datasource.GetRefundableTransactionsByParentID(ctx, transactionID, batchSize, offset)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, batch...)
+		if len(batch) < batchSize {
+			return all, nil
+		}
+	}
 }
 
 // normalizePreviewStatus assigns the status the transaction would carry by the

--- a/transaction_dryrun.go
+++ b/transaction_dryrun.go
@@ -65,6 +65,7 @@ func (l *Blnk) PreviewTransaction(ctx context.Context, transaction *model.Transa
 	}
 
 	span.SetAttributes(attribute.Bool("preview.would_apply", preview.WouldApply))
+	preview.Finalize()
 	return preview, nil
 }
 
@@ -181,6 +182,7 @@ func (l *Blnk) PreviewRefund(ctx context.Context, transactionID string) (*model.
 	} else {
 		preview.AddNote(fmt.Sprintf("projected refund of %d refundable transactions under %s", len(refundable), transactionID))
 	}
+	preview.Finalize()
 	return preview, nil
 }
 
@@ -289,6 +291,7 @@ func (l *Blnk) previewSingleTransaction(ctx context.Context, transaction *model.
 	span.AddEvent("Transaction projected", trace.WithAttributes(
 		attribute.Bool("preview.would_apply", preview.WouldApply),
 	))
+	preview.Finalize()
 	return preview, nil
 }
 
@@ -396,6 +399,7 @@ func (l *Blnk) previewSplitTransaction(ctx context.Context, transaction *model.T
 		preview.Balances = shared.projections()
 	}
 
+	preview.Finalize()
 	return preview, nil
 }
 

--- a/transaction_dryrun_bulk.go
+++ b/transaction_dryrun_bulk.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2024 Blnk Finance Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package blnk
+
+import (
+	"context"
+
+	"github.com/blnkfinance/blnk/model"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+// PreviewBulkTransactions projects a batch without applying any of it.
+//
+// How the batch would really execute decides how it is projected:
+//
+//	skip_queue=true   items are applied inline, one after another, so a later
+//	                  item sees what earlier ones did. The projection carries
+//	                  balances forward across items, which is what catches a
+//	                  batch that spends within itself more than it has.
+//
+//	skip_queue=false  each item is handed to its own goroutine and the batch
+//	                  loop moves on, so the items race and no order is
+//	                  guaranteed. Each item is projected independently against
+//	                  the balances as they stand.
+//
+// The mode is reported as `cumulative` so a caller can tell which answer they
+// were given.
+func (l *Blnk) PreviewBulkTransactions(ctx context.Context, request *model.BulkTransactionRequest) (*model.BulkTransactionPreview, error) {
+	ctx, span := tracer.Start(ctx, "PreviewBulkTransactions")
+	defer span.End()
+
+	preview := &model.BulkTransactionPreview{
+		DryRun:     true,
+		WouldApply: true,
+		Cumulative: request.SkipQueue,
+		Atomic:     request.Atomic,
+		Results:    make([]model.TransactionPreview, 0, len(request.Transactions)),
+	}
+
+	if !request.SkipQueue {
+		preview.AddNote("items are dispatched concurrently unless skip_queue is set, so each item is projected independently against current balances and real execution order is not guaranteed")
+	}
+	if request.Atomic {
+		preview.AddNote("an atomic batch compensates on failure by voiding or refunding already-applied items rather than rolling back, and that compensation can itself fail")
+	}
+	if request.RunAsync {
+		preview.AddNote("run_async is ignored in a dry run; the projection is returned immediately")
+	}
+
+	// One working copy per balance, shared across items in cumulative mode so a
+	// balance touched twice accumulates, and reused in either mode so each
+	// distinct balance is read once rather than once per item.
+	working := newPreviewBalanceSet(l)
+
+	for _, transaction := range request.Transactions {
+		if transaction == nil {
+			continue
+		}
+
+		item := transaction.Clone()
+		item.Inflight = request.Inflight
+		item.SkipQueue = request.SkipQueue
+
+		itemPreview, err := l.previewBulkItem(ctx, item, working, request.SkipQueue)
+		if err != nil {
+			span.RecordError(err)
+			return nil, err
+		}
+
+		if !itemPreview.WouldApply {
+			preview.WouldApply = false
+		}
+		preview.Results = append(preview.Results, *itemPreview)
+	}
+
+	if request.SkipQueue {
+		preview.Balances = working.projections()
+	}
+
+	span.SetAttributes(
+		attribute.Bool("preview.would_apply", preview.WouldApply),
+		attribute.Bool("preview.cumulative", preview.Cumulative),
+		attribute.Int("preview.items", len(preview.Results)),
+	)
+	return preview, nil
+}
+
+// previewBulkItem projects one item of a batch.
+//
+// In cumulative mode the item is applied to the shared working balances so the
+// next item sees it. Otherwise the item is projected on its own, which is what
+// a concurrently dispatched item would actually see.
+func (l *Blnk) previewBulkItem(ctx context.Context, item *model.Transaction, working *previewBalanceSet, cumulative bool) (*model.TransactionPreview, error) {
+	if !cumulative {
+		return l.PreviewTransaction(ctx, item)
+	}
+
+	normalizePreviewStatus(item)
+	item.PreciseAmount = model.ApplyPrecision(item)
+
+	// An item may itself be a split, so the two-level shape (batch, item, legs)
+	// has to be expanded before balances are touched.
+	legs := []*model.Transaction{item}
+	if len(item.Sources) > 0 || len(item.Destinations) > 0 {
+		split, err := item.SplitTransactionPrecise(ctx)
+		if err != nil {
+			return nil, err
+		}
+		legs = split
+	}
+
+	preview := newPreviewFor(item)
+	preview.WouldApply = true
+	preview.PreciseAmount = preciseString(item.PreciseAmount)
+	preview.Amount = item.Amount
+
+	for _, leg := range legs {
+		normalizePreviewStatus(leg)
+		leg.PreciseAmount = model.ApplyPrecision(leg)
+
+		source, destination, err := working.resolvePair(ctx, leg)
+		if err != nil {
+			return nil, err
+		}
+
+		if applyErr := l.processBalances(ctx, leg, source.balance, destination.balance); applyErr != nil {
+			preview.WouldApply = false
+			if preview.Rejection == nil {
+				preview.Rejection = previewRejection(applyErr)
+			}
+		}
+	}
+
+	return preview, nil
+}

--- a/transaction_dryrun_bulk.go
+++ b/transaction_dryrun_bulk.go
@@ -194,6 +194,14 @@ func (l *Blnk) previewBulkItem(ctx context.Context, item *model.Transaction, wor
 			return nil, err
 		}
 
+		if err := sameBalanceErr(source, destination); err != nil {
+			preview.WouldApply = false
+			if preview.Rejection == nil {
+				preview.Rejection = previewRejection(err)
+			}
+			continue
+		}
+
 		if applyErr := l.processBalances(ctx, leg, source.balance, destination.balance); applyErr != nil {
 			preview.WouldApply = false
 			if preview.Rejection == nil {

--- a/transaction_dryrun_bulk.go
+++ b/transaction_dryrun_bulk.go
@@ -185,6 +185,10 @@ func (l *Blnk) previewBulkItem(ctx context.Context, item *model.Transaction, wor
 	preview.PreciseAmount = preciseString(item.PreciseAmount)
 	preview.Amount = item.Amount
 
+	// Whether this item is itself a split decides both what gets reported and
+	// how a failure is handled below.
+	isSplit := len(item.Sources) > 0 || len(item.Destinations) > 0
+
 	for _, leg := range legs {
 		normalizePreviewStatus(leg)
 		leg.PreciseAmount = model.ApplyPrecision(leg)
@@ -194,19 +198,44 @@ func (l *Blnk) previewBulkItem(ctx context.Context, item *model.Transaction, wor
 			return nil, err
 		}
 
+		failed := false
 		if err := sameBalanceErr(source, destination); err != nil {
 			preview.WouldApply = false
 			if preview.Rejection == nil {
 				preview.Rejection = previewRejection(err)
 			}
-			continue
-		}
-
-		if applyErr := l.processBalances(ctx, leg, source.balance, destination.balance); applyErr != nil {
+			failed = true
+		} else if applyErr := l.processBalances(ctx, leg, source.balance, destination.balance); applyErr != nil {
 			preview.WouldApply = false
 			if preview.Rejection == nil {
 				preview.Rejection = previewRejection(applyErr)
 			}
+			failed = true
+		}
+
+		// Report the per-leg breakdown a split item produces, as
+		// previewSplitTransaction does for the same item outside a batch.
+		// Without this the same split reported its legs when the batch was
+		// queued — that path runs through PreviewTransaction — and reported
+		// none when the batch was cumulative.
+		if isSplit && !failed {
+			role, identifier := model.PreviewRoleDestination, leg.Destination
+			if len(item.Sources) > 0 {
+				role, identifier = model.PreviewRoleSource, leg.Source
+			}
+			preview.Legs = append(preview.Legs, model.LegProjection{
+				Identifier:    identifier,
+				Role:          role,
+				PreciseAmount: preciseString(leg.PreciseAmount),
+				Amount:        leg.Amount,
+			})
+		}
+
+		// A cumulative batch records its items synchronously and stops at the
+		// first one that fails, and a split item's legs are recorded the same
+		// way within it, so the legs after a failure are never attempted.
+		if failed {
+			break
 		}
 	}
 

--- a/transaction_dryrun_bulk.go
+++ b/transaction_dryrun_bulk.go
@@ -18,6 +18,7 @@ package blnk
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/blnkfinance/blnk/model"
 	"go.opentelemetry.io/otel/attribute"
@@ -66,6 +67,12 @@ func (l *Blnk) PreviewBulkTransactions(ctx context.Context, request *model.BulkT
 	// distinct balance is read once rather than once per item.
 	working := newPreviewBalanceSet(l)
 
+	// References seen so far in this batch. A reference collision is a flat
+	// fact independent of cumulative vs independent execution — either mode
+	// hits the same database uniqueness constraint — so it is checked the
+	// same way, in request order, regardless of skip_queue.
+	seenRefs := make(map[string]bool, len(request.Transactions))
+
 	for _, transaction := range request.Transactions {
 		if transaction == nil {
 			continue
@@ -75,10 +82,17 @@ func (l *Blnk) PreviewBulkTransactions(ctx context.Context, request *model.BulkT
 		item.Inflight = request.Inflight
 		item.SkipQueue = request.SkipQueue
 
-		itemPreview, err := l.previewBulkItem(ctx, item, working, request.SkipQueue)
+		itemPreview, err := l.bulkItemDuplicateReference(ctx, item, seenRefs)
 		if err != nil {
 			span.RecordError(err)
 			return nil, err
+		}
+		if itemPreview == nil {
+			itemPreview, err = l.previewBulkItem(ctx, item, working, request.SkipQueue)
+			if err != nil {
+				span.RecordError(err)
+				return nil, err
+			}
 		}
 
 		if !itemPreview.WouldApply {
@@ -96,6 +110,49 @@ func (l *Blnk) PreviewBulkTransactions(ctx context.Context, request *model.BulkT
 		attribute.Bool("preview.cumulative", preview.Cumulative),
 		attribute.Int("preview.items", len(preview.Results)),
 	)
+	return preview, nil
+}
+
+// bulkItemDuplicateReference checks item's reference against every reference
+// already seen earlier in this batch, then — if it clears that — against the
+// database, recording it into seenRefs once it clears both.
+//
+// A hit either way is fatal on a real post: transaction validation rejects a
+// duplicate reference before balances are ever touched, in cumulative mode
+// or not. So a hit here is projected as a rejection without calling into
+// previewBulkItem at all — a rejected item never reaches balance application
+// for real, and in cumulative mode letting it touch the shared working
+// balances anyway would leak its amount into how later items are projected.
+//
+// Returns a non-nil preview only when item.Reference collides; nil, nil
+// means the caller should preview the item normally.
+func (l *Blnk) bulkItemDuplicateReference(ctx context.Context, item *model.Transaction, seenRefs map[string]bool) (*model.TransactionPreview, error) {
+	if item.Reference == "" {
+		return nil, nil
+	}
+
+	duplicate := seenRefs[item.Reference]
+	if !duplicate {
+		exists, err := l.datasource.TransactionExistsByRef(ctx, item.Reference)
+		if err != nil {
+			return nil, err
+		}
+		duplicate = exists
+	}
+
+	if !duplicate {
+		seenRefs[item.Reference] = true
+		return nil, nil
+	}
+
+	normalizePreviewStatus(item)
+	item.PreciseAmount = model.ApplyPrecision(item)
+
+	preview := newPreviewFor(item)
+	preview.WouldApply = false
+	preview.PreciseAmount = preciseString(item.PreciseAmount)
+	preview.Amount = item.Amount
+	preview.Rejection = previewRejection(fmt.Errorf("transaction validation failed: reference %s has already been used", item.Reference))
 	return preview, nil
 }
 

--- a/transaction_dryrun_bulk.go
+++ b/transaction_dryrun_bulk.go
@@ -110,6 +110,7 @@ func (l *Blnk) PreviewBulkTransactions(ctx context.Context, request *model.BulkT
 		attribute.Bool("preview.cumulative", preview.Cumulative),
 		attribute.Int("preview.items", len(preview.Results)),
 	)
+	preview.Finalize()
 	return preview, nil
 }
 
@@ -153,6 +154,7 @@ func (l *Blnk) bulkItemDuplicateReference(ctx context.Context, item *model.Trans
 	preview.PreciseAmount = preciseString(item.PreciseAmount)
 	preview.Amount = item.Amount
 	preview.Rejection = previewRejection(fmt.Errorf("transaction validation failed: reference %s has already been used", item.Reference))
+	preview.Finalize()
 	return preview, nil
 }
 
@@ -239,5 +241,6 @@ func (l *Blnk) previewBulkItem(ctx context.Context, item *model.Transaction, wor
 		}
 	}
 
+	preview.Finalize()
 	return preview, nil
 }

--- a/transaction_dryrun_inflight.go
+++ b/transaction_dryrun_inflight.go
@@ -79,13 +79,20 @@ func (l *Blnk) PreviewInflightAction(ctx context.Context, txID, action string, a
 	working := newPreviewBalanceSet(l)
 	total := big.NewInt(0)
 
+	// Collected across every leg rather than keeping only the first, matching
+	// ProcessTransactionInBatches — the real engine behind a multi-leg
+	// commit/void — which appends every worker's error to allErrors and
+	// reports them together. A real post on a split parent doesn't stop at
+	// leg one's failure and go silent about leg two's; the preview shouldn't
+	// either, or a caller fixing the reported cause could still be surprised
+	// by an unrelated one it never heard about.
+	var legErrors []error
+
 	for _, leg := range legs {
 		settlement, err := l.buildInflightSettlementForPreview(ctx, leg, action, amount)
 		if err != nil {
 			preview.WouldApply = false
-			if preview.Rejection == nil {
-				preview.Rejection = previewRejection(err)
-			}
+			legErrors = append(legErrors, err)
 			continue
 		}
 
@@ -97,9 +104,7 @@ func (l *Blnk) PreviewInflightAction(ctx context.Context, txID, action string, a
 
 		if applyErr := l.processBalances(ctx, settlement, source.balance, destination.balance); applyErr != nil {
 			preview.WouldApply = false
-			if preview.Rejection == nil {
-				preview.Rejection = previewRejection(applyErr)
-			}
+			legErrors = append(legErrors, applyErr)
 			continue
 		}
 
@@ -115,6 +120,10 @@ func (l *Blnk) PreviewInflightAction(ctx context.Context, txID, action string, a
 				Amount:        settlement.Amount,
 			})
 		}
+	}
+
+	if len(legErrors) > 0 {
+		preview.Rejection = previewRejection(fmt.Errorf("error occurred during processing: %v", legErrors))
 	}
 
 	preview.PreciseAmount = preciseString(total)

--- a/transaction_dryrun_inflight.go
+++ b/transaction_dryrun_inflight.go
@@ -51,10 +51,15 @@ func (l *Blnk) PreviewInflightAction(ctx context.Context, txID, action string, a
 		// id, or an infrastructure failure, stays a hard error.
 		switch classifyInflightError(err) {
 		case "ALREADY_VOIDED", "NOT_INFLIGHT":
+			status := StatusApplied
+			if action == InflightActionVoid {
+				status = StatusVoid
+			}
 			return &model.TransactionPreview{
 				DryRun:        true,
 				WouldApply:    false,
 				Operation:     action,
+				Status:        status,
 				Rejection:     previewRejection(err),
 				PreciseAmount: preciseString(nil),
 				Balances:      []model.BalanceProjection{},
@@ -133,6 +138,31 @@ func (l *Blnk) PreviewInflightAction(ctx context.Context, txID, action string, a
 	}
 
 	preview.PreciseAmount = preciseString(total)
+
+	// Status and Amount are reported for the same reason the create and bulk
+	// previews report them: they are the headline fields of the projection,
+	// and leaving them at their zero values made an inflight preview look
+	// like it had answered "" and 0 rather than "did not populate these".
+	//
+	// Status is the status the settlement would carry once applied, which is
+	// what the real endpoint returns for the same call — APPLIED for a
+	// commit, VOID for a void — not the COMMIT/VOID action marker used
+	// internally while the settlement is being built.
+	//
+	// Amount is the float rendering of the precise total already reported
+	// above, so the two always describe the same number. Precision is only
+	// non-zero once at least one leg projected successfully; with no such leg
+	// there is no scale to divide by and the amount stays at zero alongside
+	// the zero precise total.
+	if action == InflightActionVoid {
+		preview.Status = StatusVoid
+	} else {
+		preview.Status = StatusApplied
+	}
+	if preview.Precision > 0 {
+		preview.Amount = l.convertPreciseToFloat(total, preview.Precision)
+	}
+
 	preview.Balances = working.projections()
 
 	span.SetAttributes(

--- a/transaction_dryrun_inflight.go
+++ b/transaction_dryrun_inflight.go
@@ -55,7 +55,7 @@ func (l *Blnk) PreviewInflightAction(ctx context.Context, txID, action string, a
 			if action == InflightActionVoid {
 				status = StatusVoid
 			}
-			return &model.TransactionPreview{
+			rejected := &model.TransactionPreview{
 				DryRun:        true,
 				WouldApply:    false,
 				Operation:     action,
@@ -63,7 +63,9 @@ func (l *Blnk) PreviewInflightAction(ctx context.Context, txID, action string, a
 				Rejection:     previewRejection(err),
 				PreciseAmount: preciseString(nil),
 				Balances:      []model.BalanceProjection{},
-			}, nil
+			}
+			rejected.Finalize()
+			return rejected, nil
 		}
 		span.RecordError(err)
 		return nil, err
@@ -169,6 +171,7 @@ func (l *Blnk) PreviewInflightAction(ctx context.Context, txID, action string, a
 		attribute.Bool("preview.would_apply", preview.WouldApply),
 		attribute.Int("preview.legs", len(legs)),
 	)
+	preview.Finalize()
 	return preview, nil
 }
 

--- a/transaction_dryrun_inflight.go
+++ b/transaction_dryrun_inflight.go
@@ -102,6 +102,12 @@ func (l *Blnk) PreviewInflightAction(ctx context.Context, txID, action string, a
 			return nil, err
 		}
 
+		if err := sameBalanceErr(source, destination); err != nil {
+			preview.WouldApply = false
+			legErrors = append(legErrors, err)
+			continue
+		}
+
 		if applyErr := l.processBalances(ctx, settlement, source.balance, destination.balance); applyErr != nil {
 			preview.WouldApply = false
 			legErrors = append(legErrors, applyErr)

--- a/transaction_dryrun_inflight.go
+++ b/transaction_dryrun_inflight.go
@@ -44,6 +44,22 @@ func (l *Blnk) PreviewInflightAction(ctx context.Context, txID, action string, a
 
 	legs, err := l.inflightLegsForPreview(ctx, txID)
 	if err != nil {
+		// A transaction that's already been voided, or was never inflight,
+		// is exactly the kind of "would this apply" fact a preview answers
+		// with would_apply: false — the same treatment already-committed
+		// and over-limit amounts get further down. Only a genuinely missing
+		// id, or an infrastructure failure, stays a hard error.
+		switch classifyInflightError(err) {
+		case "ALREADY_VOIDED", "NOT_INFLIGHT":
+			return &model.TransactionPreview{
+				DryRun:        true,
+				WouldApply:    false,
+				Operation:     action,
+				Rejection:     previewRejection(err),
+				PreciseAmount: preciseString(nil),
+				Balances:      []model.BalanceProjection{},
+			}, nil
+		}
 		span.RecordError(err)
 		return nil, err
 	}

--- a/transaction_dryrun_inflight.go
+++ b/transaction_dryrun_inflight.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2024 Blnk Finance Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package blnk
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+
+	"github.com/blnkfinance/blnk/model"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+// PreviewInflightAction projects a commit or void of an inflight transaction
+// without settling it.
+//
+// txID may name a single inflight transaction or the parent of several legs. A
+// parent is expanded and every leg is projected, so the caller sees the whole
+// balance effect rather than one representative leg's.
+//
+// Nothing is written: no settlement transaction is recorded, no hold is
+// released, and nothing is queued.
+func (l *Blnk) PreviewInflightAction(ctx context.Context, txID, action string, amount *big.Int) (*model.TransactionPreview, error) {
+	ctx, span := tracer.Start(ctx, "PreviewInflightAction")
+	defer span.End()
+
+	if action != InflightActionCommit && action != InflightActionVoid {
+		return nil, fmt.Errorf("status not supported. use either commit or void")
+	}
+
+	legs, err := l.inflightLegsForPreview(ctx, txID)
+	if err != nil {
+		span.RecordError(err)
+		return nil, err
+	}
+
+	preview := &model.TransactionPreview{
+		DryRun:     true,
+		WouldApply: true,
+		Operation:  action,
+	}
+
+	// Void always releases the whole remaining hold, so an amount sent with one
+	// would be silently ignored rather than honoured — say so instead.
+	if action == InflightActionVoid && amount != nil && amount.Sign() > 0 {
+		preview.AddNote("amount is ignored when voiding; a void always releases the full remaining hold")
+	}
+
+	working := newPreviewBalanceSet(l)
+	total := big.NewInt(0)
+
+	for _, leg := range legs {
+		settlement, err := l.buildInflightSettlementForPreview(ctx, leg, action, amount)
+		if err != nil {
+			preview.WouldApply = false
+			if preview.Rejection == nil {
+				preview.Rejection = previewRejection(err)
+			}
+			continue
+		}
+
+		source, destination, err := working.resolvePair(ctx, settlement)
+		if err != nil {
+			span.RecordError(err)
+			return nil, err
+		}
+
+		if applyErr := l.processBalances(ctx, settlement, source.balance, destination.balance); applyErr != nil {
+			preview.WouldApply = false
+			if preview.Rejection == nil {
+				preview.Rejection = previewRejection(applyErr)
+			}
+			continue
+		}
+
+		total = new(big.Int).Add(total, settlement.PreciseAmount)
+		preview.Currency = settlement.Currency
+		preview.Precision = settlement.Precision
+
+		if len(legs) > 1 {
+			preview.Legs = append(preview.Legs, model.LegProjection{
+				Identifier:    leg.TransactionID,
+				Role:          model.PreviewRoleSource,
+				PreciseAmount: preciseString(settlement.PreciseAmount),
+				Amount:        settlement.Amount,
+			})
+		}
+	}
+
+	preview.PreciseAmount = preciseString(total)
+	preview.Balances = working.projections()
+
+	span.SetAttributes(
+		attribute.Bool("preview.would_apply", preview.WouldApply),
+		attribute.Int("preview.legs", len(legs)),
+	)
+	return preview, nil
+}
+
+// inflightLegsForPreview resolves txID to the inflight transactions an action
+// against it would settle.
+//
+// A transaction id resolves to itself. An id that names no inflight transaction
+// directly may still be the parent of a split, so it is expanded the same way
+// the real commit and void paths expand it.
+func (l *Blnk) inflightLegsForPreview(ctx context.Context, txID string) ([]*model.Transaction, error) {
+	transaction, err := l.fetchAndValidateInflightTransaction(ctx, txID)
+	if err == nil {
+		return []*model.Transaction{transaction}, nil
+	}
+
+	if !shouldExpandInflightParent(err) {
+		return nil, err
+	}
+
+	legs, legErr := l.collectInflightLegs(ctx, txID)
+	if legErr != nil {
+		return nil, legErr
+	}
+	if len(legs) == 0 {
+		return nil, err
+	}
+	return legs, nil
+}
+
+// buildInflightSettlementForPreview builds the settlement transaction one leg
+// would produce, without recording it.
+//
+// The commit path's own validation decides the amount, so a projected commit
+// refuses exactly what a real one would: an already-settled hold, or an amount
+// beyond what remains.
+func (l *Blnk) buildInflightSettlementForPreview(ctx context.Context, leg *model.Transaction, action string, amount *big.Int) (*model.Transaction, error) {
+	// Work on a copy: validateAndUpdateAmount writes the settled amount onto
+	// the transaction it is given.
+	settlement := leg.Clone()
+
+	if action == InflightActionVoid {
+		amountLeft, err := l.calculateRemainingAmount(ctx, settlement)
+		if err != nil {
+			return nil, err
+		}
+		if amountLeft.Cmp(big.NewInt(0)) == 0 {
+			return nil, fmt.Errorf("cannot void. Transaction already committed")
+		}
+		settlement.Status = StatusVoid
+		settlement.PreciseAmount = amountLeft
+		settlement.Amount = l.convertPreciseToFloat(amountLeft, settlement.Precision)
+		return settlement, nil
+	}
+
+	requested := amount
+	if requested == nil {
+		requested = big.NewInt(0)
+	}
+	if err := l.validateAndUpdateAmount(ctx, settlement, requested); err != nil {
+		return nil, err
+	}
+	settlement.Status = StatusCommit
+	return settlement, nil
+}

--- a/transaction_dryrun_test.go
+++ b/transaction_dryrun_test.go
@@ -261,9 +261,12 @@ func TestPreviewTransactionVirtualIndicatorIsNotCreated(t *testing.T) {
 	assert.NoError(t, dbMock.ExpectationsWereMet())
 }
 
-// TestPreviewTransactionNotesReferenceInUse checks that an already-used
-// reference is surfaced as advice rather than failing the projection.
-func TestPreviewTransactionNotesReferenceInUse(t *testing.T) {
+// TestPreviewTransactionRejectsReferenceInUse checks that an already-used
+// reference is projected as a rejection, matching the real post it stands in
+// for: transaction validation rejects a duplicate reference outright, so a
+// preview that said would_apply: true here would be lying about the one
+// outcome it exists to predict.
+func TestPreviewTransactionRejectsReferenceInUse(t *testing.T) {
 	blnk, dbMock, redisMock := newPreviewTestBlnk(t, false)
 
 	dbMock.ExpectQuery(regexp.QuoteMeta(`SELECT EXISTS(SELECT 1 FROM blnk.transactions WHERE reference = $1)`)).
@@ -276,9 +279,9 @@ func TestPreviewTransactionNotesReferenceInUse(t *testing.T) {
 	preview, err := blnk.PreviewTransaction(context.Background(), previewTransaction(100))
 	require.NoError(t, err)
 
-	assert.True(t, preview.WouldApply)
-	require.NotEmpty(t, preview.Notes)
-	assert.Contains(t, preview.Notes[0], "reference is already in use")
+	assert.False(t, preview.WouldApply)
+	require.NotNil(t, preview.Rejection)
+	assert.Contains(t, preview.Rejection.Message, "reference preview_ref_1 has already been used")
 }
 
 // TestPreviewTransactionNotesCurrencyMismatch pins that the preview mirrors the


### PR DESCRIPTION
Completes #330 by adding `dry_run` to `POST /transactions/bulk` and `PUT /transactions/inflight/:txID`.

**Stacked on #348** — please merge that first; this branch contains its three commits, so the diff here is just the final commit. Rebases to `main` cleanly once #348 lands.

### Bulk: the projection mode has to match how the batch really runs

This is the part the original issue got wrong, and it's the main reason this is a separate PR.

I'd claimed later items see earlier items' balance changes. That's only true with `skip_queue: true`. `processBulkTransactions` assigns the batch-level flag to every item (`transaction_bulk.go:36`), so on the default path each item goes to `processTransactionAsync`'s detached goroutine and the loop moves on — the items race.

So the mode follows the flag, and the response says which one you got:

```jsonc
// skip_queue: true — 500.00 available, items of 450.00 then 100.00
{ "cumulative": true, "would_apply": false,
  "results": [ { "would_apply": true },
               { "would_apply": false, "rejection": { "code": "TXN_INSUFFICIENT_FUNDS" } } ] }

// skip_queue: false — same input, both fit on their own
{ "cumulative": false, "would_apply": true,
  "results": [ { "would_apply": true }, { "would_apply": true } ] }
```

Identical input, opposite verdict, because the execution semantics genuinely differ. Projecting cumulatively on the default path would assert an ordering the ledger doesn't provide — an authoritative-looking wrong answer, which is worse than no preview.

Batch-level `balances` are reported only in cumulative mode: without a guaranteed order there's no single combined outcome to state.

**No `all_or_nothing` field**, for the same honesty reason. `rollbackBatchTransactions` compensates by voiding or refunding already-applied items *after* a failure, and that compensation can itself fail. The response carries a note saying so rather than implying isolation.

Balances are fetched once per distinct balance and reused across items — needed for correctness in cumulative mode anyway, and it keeps a 10k-item batch from doing 20k round trips.

### Inflight: reuses the existing expansion rather than reimplementing it

`preValidateInflightAction` already handles the case where an id names the parent of a split rather than a single hold, so the projection resolves legs the same way and projects **every** leg — a per-transaction preview on a parent would otherwise answer for one representative leg, or fail outright.

Void has no partial form: `finalizeVoidTransaction` always uses the full remaining hold. An amount sent with a void is reported as ignored rather than silently dropped:

```jsonc
PUT /transactions/inflight/:id  { "dry_run": true, "status": "void", "precise_amount": 4000 }

{ "operation": "void", "precise_amount": "10000",
  "notes": ["amount is ignored when voiding; a void always releases the full remaining hold"] }
```

Both projections run on clones — `validateAndUpdateAmount` writes the settled amount onto the transaction it's given. The dry-run branch also sits ahead of `ApplyPrecisionWithDBLookup`, which caches into package-level state.

### Tests

9 new tests covering: cumulative mode catching an intra-batch shortfall; independent mode not assuming order; batch and inflight previews writing nothing (balances and `version` unchanged, hold still `INFLIGHT`, no settlement rows); void ignoring its amount; and unsupported actions still being rejected as malformed.

Verified against a running server — the cumulative case correctly rejected the second item at `TXN_INSUFFICIENT_FUNDS` where independent mode passed both, the commit projection showed the hold releasing *and* the money moving while void showed the hold releasing with the balance unchanged, and afterwards the hold was still `INFLIGHT` with zero settlement rows written.

`go test ./...` passes apart from `internal/search`, which needs Typesense and fails identically on `main`.


---

### Review follow-ups

Three points raised by @Gee-Hive, all fixed on this branch:

**1. A dry-run commit above the original amount reported `would_apply: true`.** The dry-run branch passed only `req.PreciseAmount` to `PreviewInflightAction`, skipping the `amount` → precision → `precise_amount` resolution the real commit path does a few lines below. With `precise_amount` unset that arrived as `nil`, which is the sentinel for "commit the full remaining amount", so an oversized `amount` was discarded rather than validated. The resolution now sits above the `dry_run` check, so both branches share it.

**2. Inflight dry-run omitted `status` and `amount`.** `PreviewInflightAction` built its own `TransactionPreview` literal instead of going through `newPreviewFor`, so both fields sat at their zero values. `status` is now the status the settlement would carry once applied (`APPLIED` for a commit, `VOID` for a void — not the internal `COMMIT`/`VOID` marker), and `amount` is the float rendering of the precise total already reported.

**3. A rejected projection still reported `status: "APPLIED"`.** `status` is populated up front by `newPreviewFor`, and the projection only later discovers it would be rejected, so the response asserted both `would_apply: false` and a status the transaction could never reach. A rejected projection has no resulting status — the real endpoint returns an error and writes no transaction — so `Finalize` clears it and the field is now `omitempty`, absent rather than empty. Applied at every projection exit and to bulk items, each of which carries its own status.

### Preview/real parity

Also added: tests asserting the preview and the real post **agree** on the failure paths — same HTTP status and same error code for a missing balance, and an identical body for a validation failure, which runs ahead of the `dry_run` branch.

These assert agreement rather than a literal code deliberately. The code a missing balance produces belongs to the error catalog and moves — #362 changes it from the generic not-found to a balance-specific one — so pinning the literal would either fight that change or quietly bless a divergence. Agreement is the property that matters, and it holds either way; both tests pass on this branch alone and with #362 merged.
