### PR TITLE
fix(database): include meta_data in GetBalanceByIDLite

### DIFF
--- a/account_test.go
+++ b/account_test.go
@@ -53,8 +53,8 @@ func TestCreateAccount(t *testing.T) {
 	}
 	metaDataJSON, _ := json.Marshal(account.MetaData)
 
-	rows := sqlmock.NewRows([]string{"balance_id", "indicator", "currency", "ledger_id", "balance", "credit_balance", "debit_balance", "inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id"}).
-		AddRow(account.BalanceID, "", "NGN", account.LedgerID, 100, 50, 50, 0, 0, 0, time.Now(), 0, false, "FIFO", "")
+	rows := sqlmock.NewRows([]string{"balance_id", "indicator", "currency", "ledger_id", "balance", "credit_balance", "debit_balance", "inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id", "meta_data"}).
+		AddRow(account.BalanceID, "", "NGN", account.LedgerID, 100, 50, 50, 0, 0, 0, time.Now(), 0, false, "FIFO", "", nil)
 
 	mock.ExpectQuery("SELECT .* FROM blnk.balances WHERE balance_id =").
 		WithArgs(account.BalanceID).
@@ -104,8 +104,8 @@ func TestCreateAccountWithExternalGenerator(t *testing.T) {
 	}
 	metaDataJSON, _ := json.Marshal(account.MetaData)
 
-	rows := sqlmock.NewRows([]string{"balance_id", "indicator", "currency", "ledger_id", "balance", "credit_balance", "debit_balance", "inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id"}).
-		AddRow(account.BalanceID, "", "NGN", account.LedgerID, 100, 50, 50, 0, 0, 0, time.Now(), 0, false, "FIFO", "")
+	rows := sqlmock.NewRows([]string{"balance_id", "indicator", "currency", "ledger_id", "balance", "credit_balance", "debit_balance", "inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id", "meta_data"}).
+		AddRow(account.BalanceID, "", "NGN", account.LedgerID, 100, 50, 50, 0, 0, 0, time.Now(), 0, false, "FIFO", "", nil)
 
 	mock.ExpectQuery("SELECT .* FROM blnk.balances WHERE balance_id =").
 		WithArgs(account.BalanceID).

--- a/database/balance.go
+++ b/database/balance.go
@@ -340,10 +340,11 @@ func (d Datasource) GetBalanceByIDLite(id string) (*model.Balance, error) {
 	var inflightBalanceValue, inflightCreditBalanceValue, inflightDebitBalanceValue string
 	var indicator sql.NullString
 	var allocationStrategy sql.NullString
+	var metaDataJSON []byte
 
 	// Execute the query
 	row := d.Conn.QueryRowContext(context.Background(), `
-       SELECT balance_id, indicator, currency, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version, track_fund_lineage, COALESCE(allocation_strategy, 'FIFO') as allocation_strategy, COALESCE(identity_id, '') as identity_id
+       SELECT balance_id, indicator, currency, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version, track_fund_lineage, COALESCE(allocation_strategy, 'FIFO') as allocation_strategy, COALESCE(identity_id, '') as identity_id, meta_data
        FROM blnk.balances
        WHERE balance_id = $1
     `, id)
@@ -365,6 +366,7 @@ func (d Datasource) GetBalanceByIDLite(id string) (*model.Balance, error) {
 		&balance.TrackFundLineage,
 		&allocationStrategy,
 		&balance.IdentityID,
+		&metaDataJSON,
 	)
 
 	// Handle null indicator field
@@ -414,6 +416,13 @@ func (d Datasource) GetBalanceByIDLite(id string) (*model.Balance, error) {
 	balance.InflightDebitBalance, err = parseBigInt(inflightDebitBalanceValue)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse inflight_debit_balance: %w", err)
+	}
+
+	// Parse the metadata JSON into the MetaData map field (may be NULL)
+	if len(metaDataJSON) > 0 {
+		if err := json.Unmarshal(metaDataJSON, &balance.MetaData); err != nil {
+			return nil, fmt.Errorf("failed to parse meta_data: %w", err)
+		}
 	}
 
 	return &balance, nil

--- a/database/balance_test.go
+++ b/database/balance_test.go
@@ -650,10 +650,13 @@ func TestGetBalanceByIDLite_Success(t *testing.T) {
 	ds := Datasource{Conn: db}
 
 	query := `
-       SELECT balance_id, indicator, currency, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version, track_fund_lineage, COALESCE(allocation_strategy, 'FIFO') as allocation_strategy, COALESCE(identity_id, '') as identity_id
+       SELECT balance_id, indicator, currency, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version, track_fund_lineage, COALESCE(allocation_strategy, 'FIFO') as allocation_strategy, COALESCE(identity_id, '') as identity_id, meta_data
        FROM blnk.balances
        WHERE balance_id = $1
     `
+
+	metaDataJSON, err := json.Marshal(map[string]interface{}{"field": "test_value"})
+	assert.NoError(t, err)
 
 	mock.ExpectQuery(regexp.QuoteMeta(query)).
 		WithArgs("bln_123").
@@ -661,12 +664,12 @@ func TestGetBalanceByIDLite_Success(t *testing.T) {
 			"balance_id", "indicator", "currency", "ledger_id",
 			"balance", "credit_balance", "debit_balance",
 			"inflight_balance", "inflight_credit_balance", "inflight_debit_balance",
-			"created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id",
+			"created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id", "meta_data",
 		}).AddRow(
 			"bln_123", "ACC001", "USD", "ldg_001",
 			"100000", "60000", "40000",
 			"5000", "3000", "2000",
-			time.Now(), 1, false, "FIFO", "",
+			time.Now(), 1, false, "FIFO", "", metaDataJSON,
 		))
 
 	balance, err := ds.GetBalanceByIDLite("bln_123")
@@ -679,6 +682,46 @@ func TestGetBalanceByIDLite_Success(t *testing.T) {
 	assert.Equal(t, "60000", balance.CreditBalance.String())
 	assert.Equal(t, "40000", balance.DebitBalance.String())
 	assert.Equal(t, "5000", balance.InflightBalance.String())
+	// Regression test for #256: meta_data must be populated from the query,
+	// not silently dropped, since callers persist this struct back to the
+	// search index and would otherwise overwrite existing metadata with nil.
+	assert.Equal(t, "test_value", balance.MetaData["field"])
+
+	err = mock.ExpectationsWereMet()
+	assert.NoError(t, err)
+}
+
+func TestGetBalanceByIDLite_NilMetaData(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	ds := Datasource{Conn: db}
+
+	query := `
+       SELECT balance_id, indicator, currency, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version, track_fund_lineage, COALESCE(allocation_strategy, 'FIFO') as allocation_strategy, COALESCE(identity_id, '') as identity_id, meta_data
+       FROM blnk.balances
+       WHERE balance_id = $1
+    `
+
+	mock.ExpectQuery(regexp.QuoteMeta(query)).
+		WithArgs("bln_123").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"balance_id", "indicator", "currency", "ledger_id",
+			"balance", "credit_balance", "debit_balance",
+			"inflight_balance", "inflight_credit_balance", "inflight_debit_balance",
+			"created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id", "meta_data",
+		}).AddRow(
+			"bln_123", "ACC001", "USD", "ldg_001",
+			"100000", "60000", "40000",
+			"5000", "3000", "2000",
+			time.Now(), 1, false, "FIFO", "", nil,
+		))
+
+	balance, err := ds.GetBalanceByIDLite("bln_123")
+	assert.NoError(t, err)
+	assert.NotNil(t, balance)
+	assert.Nil(t, balance.MetaData)
 
 	err = mock.ExpectationsWereMet()
 	assert.NoError(t, err)
@@ -692,7 +735,7 @@ func TestGetBalanceByIDLite_NotFound(t *testing.T) {
 	ds := Datasource{Conn: db}
 
 	query := `
-       SELECT balance_id, indicator, currency, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version, track_fund_lineage, COALESCE(allocation_strategy, 'FIFO') as allocation_strategy, COALESCE(identity_id, '') as identity_id
+       SELECT balance_id, indicator, currency, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version, track_fund_lineage, COALESCE(allocation_strategy, 'FIFO') as allocation_strategy, COALESCE(identity_id, '') as identity_id, meta_data
        FROM blnk.balances
        WHERE balance_id = $1
     `
@@ -720,7 +763,7 @@ func TestGetBalanceByIDLite_NullIndicator(t *testing.T) {
 	ds := Datasource{Conn: db}
 
 	query := `
-       SELECT balance_id, indicator, currency, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version, track_fund_lineage, COALESCE(allocation_strategy, 'FIFO') as allocation_strategy, COALESCE(identity_id, '') as identity_id
+       SELECT balance_id, indicator, currency, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version, track_fund_lineage, COALESCE(allocation_strategy, 'FIFO') as allocation_strategy, COALESCE(identity_id, '') as identity_id, meta_data
        FROM blnk.balances
        WHERE balance_id = $1
     `
@@ -731,12 +774,12 @@ func TestGetBalanceByIDLite_NullIndicator(t *testing.T) {
 			"balance_id", "indicator", "currency", "ledger_id",
 			"balance", "credit_balance", "debit_balance",
 			"inflight_balance", "inflight_credit_balance", "inflight_debit_balance",
-			"created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id",
+			"created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id", "meta_data",
 		}).AddRow(
 			"bln_123", nil, "USD", "ldg_001",
 			"100000", "60000", "40000",
 			"5000", "3000", "2000",
-			time.Now(), 1, false, "FIFO", "",
+			time.Now(), 1, false, "FIFO", "", nil,
 		))
 
 	balance, err := ds.GetBalanceByIDLite("bln_123")

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -167,14 +167,14 @@ func TestRecordTransaction(t *testing.T) {
     `)).WithArgs(txn.Reference).WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
 
 	// Set up source balance response
-	sourceBalanceRows := sqlmock.NewRows([]string{"balance_id", "indicator", "currency", "ledger_id", "balance", "credit_balance", "debit_balance", "inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id"}).
-		AddRow(source, "NGN", "", "ledger-id-source", int64(10000), int64(10000), 0, 0, 0, 0, time.Now(), 0, false, "FIFO", "")
+	sourceBalanceRows := sqlmock.NewRows([]string{"balance_id", "indicator", "currency", "ledger_id", "balance", "credit_balance", "debit_balance", "inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id", "meta_data"}).
+		AddRow(source, "NGN", "", "ledger-id-source", int64(10000), int64(10000), 0, 0, 0, 0, time.Now(), 0, false, "FIFO", "", nil)
 
 	// Set up destination balance response
-	destinationBalanceRows := sqlmock.NewRows([]string{"balance_id", "indicator", "currency", "ledger_id", "balance", "credit_balance", "debit_balance", "inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id"}).
-		AddRow(destination, "", "NGN", "ledger-id-destination", 0, 0, 0, 0, 0, 0, time.Now(), 0, false, "FIFO", "")
+	destinationBalanceRows := sqlmock.NewRows([]string{"balance_id", "indicator", "currency", "ledger_id", "balance", "credit_balance", "debit_balance", "inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id", "meta_data"}).
+		AddRow(destination, "", "NGN", "ledger-id-destination", 0, 0, 0, 0, 0, 0, time.Now(), 0, false, "FIFO", "", nil)
 
-	balanceQuery := `SELECT balance_id, indicator, currency, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version, track_fund_lineage, COALESCE\(allocation_strategy, 'FIFO'\) as allocation_strategy, COALESCE\(identity_id, ''\) as identity_id FROM blnk.balances WHERE balance_id = \$1`
+	balanceQuery := `SELECT balance_id, indicator, currency, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version, track_fund_lineage, COALESCE\(allocation_strategy, 'FIFO'\) as allocation_strategy, COALESCE\(identity_id, ''\) as identity_id, meta_data FROM blnk.balances WHERE balance_id = \$1`
 	balanceQueryPattern := regexp.MustCompile(`\s+`).ReplaceAllString(balanceQuery, `\s*`)
 
 	// Expect balance queries with the source/destination IDs (order can vary)
@@ -306,13 +306,13 @@ func TestRecordTransaction_AtomicRollback_InsertFails(t *testing.T) {
         SELECT EXISTS(SELECT 1 FROM blnk.transactions WHERE reference = $1)
     `)).WithArgs(txn.Reference).WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
 
-	sourceBalanceRows := sqlmock.NewRows([]string{"balance_id", "indicator", "currency", "ledger_id", "balance", "credit_balance", "debit_balance", "inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id"}).
-		AddRow(source, "", "NGN", "ledger-id-source", int64(100000), int64(100000), 0, 0, 0, 0, time.Now(), 0, false, "FIFO", "")
+	sourceBalanceRows := sqlmock.NewRows([]string{"balance_id", "indicator", "currency", "ledger_id", "balance", "credit_balance", "debit_balance", "inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id", "meta_data"}).
+		AddRow(source, "", "NGN", "ledger-id-source", int64(100000), int64(100000), 0, 0, 0, 0, time.Now(), 0, false, "FIFO", "", nil)
 
-	destinationBalanceRows := sqlmock.NewRows([]string{"balance_id", "indicator", "currency", "ledger_id", "balance", "credit_balance", "debit_balance", "inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id"}).
-		AddRow(destination, "", "NGN", "ledger-id-destination", 0, 0, 0, 0, 0, 0, time.Now(), 0, false, "FIFO", "")
+	destinationBalanceRows := sqlmock.NewRows([]string{"balance_id", "indicator", "currency", "ledger_id", "balance", "credit_balance", "debit_balance", "inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id", "meta_data"}).
+		AddRow(destination, "", "NGN", "ledger-id-destination", 0, 0, 0, 0, 0, 0, time.Now(), 0, false, "FIFO", "", nil)
 
-	balanceQuery := `SELECT balance_id, indicator, currency, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version, track_fund_lineage, COALESCE\(allocation_strategy, 'FIFO'\) as allocation_strategy, COALESCE\(identity_id, ''\) as identity_id FROM blnk.balances WHERE balance_id = \$1`
+	balanceQuery := `SELECT balance_id, indicator, currency, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version, track_fund_lineage, COALESCE\(allocation_strategy, 'FIFO'\) as allocation_strategy, COALESCE\(identity_id, ''\) as identity_id, meta_data FROM blnk.balances WHERE balance_id = \$1`
 	balanceQueryPattern := regexp.MustCompile(`\s+`).ReplaceAllString(balanceQuery, `\s*`)
 
 	mock.ExpectQuery(balanceQueryPattern).WithArgs(source).WillReturnRows(sourceBalanceRows)
@@ -408,13 +408,13 @@ func TestRecordTransaction_AtomicRollback_SecondBalanceUpdateFails(t *testing.T)
         SELECT EXISTS(SELECT 1 FROM blnk.transactions WHERE reference = $1)
     `)).WithArgs(txn.Reference).WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
 
-	sourceBalanceRows := sqlmock.NewRows([]string{"balance_id", "indicator", "currency", "ledger_id", "balance", "credit_balance", "debit_balance", "inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id"}).
-		AddRow(source, "", "NGN", "ledger-id-source", int64(100000), int64(100000), 0, 0, 0, 0, time.Now(), 0, false, "FIFO", "")
+	sourceBalanceRows := sqlmock.NewRows([]string{"balance_id", "indicator", "currency", "ledger_id", "balance", "credit_balance", "debit_balance", "inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id", "meta_data"}).
+		AddRow(source, "", "NGN", "ledger-id-source", int64(100000), int64(100000), 0, 0, 0, 0, time.Now(), 0, false, "FIFO", "", nil)
 
-	destinationBalanceRows := sqlmock.NewRows([]string{"balance_id", "indicator", "currency", "ledger_id", "balance", "credit_balance", "debit_balance", "inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id"}).
-		AddRow(destination, "", "NGN", "ledger-id-destination", 0, 0, 0, 0, 0, 0, time.Now(), 0, false, "FIFO", "")
+	destinationBalanceRows := sqlmock.NewRows([]string{"balance_id", "indicator", "currency", "ledger_id", "balance", "credit_balance", "debit_balance", "inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id", "meta_data"}).
+		AddRow(destination, "", "NGN", "ledger-id-destination", 0, 0, 0, 0, 0, 0, time.Now(), 0, false, "FIFO", "", nil)
 
-	balanceQuery := `SELECT balance_id, indicator, currency, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version, track_fund_lineage, COALESCE\(allocation_strategy, 'FIFO'\) as allocation_strategy, COALESCE\(identity_id, ''\) as identity_id FROM blnk.balances WHERE balance_id = \$1`
+	balanceQuery := `SELECT balance_id, indicator, currency, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version, track_fund_lineage, COALESCE\(allocation_strategy, 'FIFO'\) as allocation_strategy, COALESCE\(identity_id, ''\) as identity_id, meta_data FROM blnk.balances WHERE balance_id = \$1`
 	balanceQueryPattern := regexp.MustCompile(`\s+`).ReplaceAllString(balanceQuery, `\s*`)
 
 	mock.ExpectQuery(balanceQueryPattern).WithArgs(source).WillReturnRows(sourceBalanceRows)
@@ -502,13 +502,13 @@ func TestRecordTransaction_AtomicRollback_FirstBalanceUpdateFails(t *testing.T) 
         SELECT EXISTS(SELECT 1 FROM blnk.transactions WHERE reference = $1)
     `)).WithArgs(txn.Reference).WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
 
-	sourceBalanceRows := sqlmock.NewRows([]string{"balance_id", "indicator", "currency", "ledger_id", "balance", "credit_balance", "debit_balance", "inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id"}).
-		AddRow(source, "", "NGN", "ledger-id-source", int64(100000), int64(100000), 0, 0, 0, 0, time.Now(), 0, false, "FIFO", "")
+	sourceBalanceRows := sqlmock.NewRows([]string{"balance_id", "indicator", "currency", "ledger_id", "balance", "credit_balance", "debit_balance", "inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id", "meta_data"}).
+		AddRow(source, "", "NGN", "ledger-id-source", int64(100000), int64(100000), 0, 0, 0, 0, time.Now(), 0, false, "FIFO", "", nil)
 
-	destinationBalanceRows := sqlmock.NewRows([]string{"balance_id", "indicator", "currency", "ledger_id", "balance", "credit_balance", "debit_balance", "inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id"}).
-		AddRow(destination, "", "NGN", "ledger-id-destination", 0, 0, 0, 0, 0, 0, time.Now(), 0, false, "FIFO", "")
+	destinationBalanceRows := sqlmock.NewRows([]string{"balance_id", "indicator", "currency", "ledger_id", "balance", "credit_balance", "debit_balance", "inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "created_at", "version", "track_fund_lineage", "allocation_strategy", "identity_id", "meta_data"}).
+		AddRow(destination, "", "NGN", "ledger-id-destination", 0, 0, 0, 0, 0, 0, time.Now(), 0, false, "FIFO", "", nil)
 
-	balanceQuery := `SELECT balance_id, indicator, currency, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version, track_fund_lineage, COALESCE\(allocation_strategy, 'FIFO'\) as allocation_strategy, COALESCE\(identity_id, ''\) as identity_id FROM blnk.balances WHERE balance_id = \$1`
+	balanceQuery := `SELECT balance_id, indicator, currency, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version, track_fund_lineage, COALESCE\(allocation_strategy, 'FIFO'\) as allocation_strategy, COALESCE\(identity_id, ''\) as identity_id, meta_data FROM blnk.balances WHERE balance_id = \$1`
 	balanceQueryPattern := regexp.MustCompile(`\s+`).ReplaceAllString(balanceQuery, `\s*`)
 
 	mock.ExpectQuery(balanceQueryPattern).WithArgs(source).WillReturnRows(sourceBalanceRows)


### PR DESCRIPTION
## Bug

`GetBalanceByIDLite` (`database/balance.go`) selects `balance_id, indicator, currency, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version, track_fund_lineage, allocation_strategy, identity_id` — `meta_data` is not in the list, so every `*model.Balance` it returns has `MetaData == nil`, no matter what's stored in Postgres.

This function is the default path in `getSourceAndDestination` (`transaction_execution.go`) used to look up the source/destination balance for a transaction when `EnableQueuedChecks` is off. `postTransactionActions` then hands that balance straight to `search.NewIndexBatch` / `batch.AddDependency("balances", ...)`, which re-upserts it into Typesense. Because `MetaData` is nil on the struct (not because it was actually cleared in the DB), the balance's real metadata gets wiped from the search index on every transaction touching that balance.

Repro from the issue:
1. Create a balance with `meta_data`.
2. Confirm it's indexed correctly via `/search/balances`.
3. Run any transaction against that balance.
4. Search again — `meta_data` is now empty, even though `SELECT meta_data FROM blnk.balances WHERE balance_id = ...` still shows it in Postgres.

## Fix

Add `meta_data` to the SELECT and scan it into a `[]byte`, then unmarshal into `balance.MetaData` when non-empty — the same nil-safe pattern already used by `GetSourceDestination` and `GetAllBalances` elsewhere in this file, so this brings `GetBalanceByIDLite` in line with its siblings rather than introducing a new pattern.

## Scope note

`GetBalancesByIDsLite` (the bulk version, used by `transaction_coalescing.go` and `lineage_allocation.go`) has the identical gap — its SELECT also omits `meta_data`. I left it untouched since issue #256 is specifically about the single-lookup path and I wanted to keep this PR focused; happy to open a follow-up for the bulk path if useful.

## Testing

- Updated the three existing `GetBalanceByIDLite` sqlmock tests for the new query text/columns.
- Added `TestGetBalanceByIDLite_Success` assertion that `meta_data` round-trips (was previously not asserted at all, which is how this shipped).
- Added `TestGetBalanceByIDLite_NilMetaData` for the NULL `meta_data` case.
- `go test ./database/...` passes (three env-dependent `_RealDB` tests skip locally, no Postgres running — unrelated to this change).
- `go vet ./...` and `golangci-lint run ./database/...` are clean on the changed files (one pre-existing, unrelated staticcheck note elsewhere in `balance.go` at line ~1455, outside this diff).
- `gofmt` clean.

Fixes #256