### PR TITLE
feat(balances): allow creating General Ledger balances with an explicit indicator

### DIFF
--- a/api/balance_api_test.go
+++ b/api/balance_api_test.go
@@ -117,6 +117,102 @@ func TestCreateBalance(t *testing.T) {
 	}
 }
 
+func TestCreateBalance_WithIndicator(t *testing.T) {
+	router, b, err := setupRouter()
+	if err != nil {
+		t.Fatalf("Failed to setup router: %v", err)
+	}
+
+	// "general_ledger_id" is a pre-seeded ledger
+	// it is not created here since ledger IDs are always server-generated.
+	otherLedger, err := b.CreateLedger(model.Ledger{Name: gofakeit.Name()})
+	if err != nil {
+		t.Fatalf("Failed to create ledger: %v", err)
+	}
+
+	currency := gofakeit.Currency().Short
+	validIndicator := "@" + gofakeit.UUID()
+
+	tests := []struct {
+		name         string
+		payload      model2.CreateBalance
+		expectedCode int
+	}{
+		{
+			name: "Valid GL indicator",
+			payload: model2.CreateBalance{
+				LedgerId:  "general_ledger_id",
+				Currency:  currency,
+				Indicator: validIndicator,
+			},
+			expectedCode: http.StatusCreated,
+		},
+		{
+			name: "Missing @ prefix",
+			payload: model2.CreateBalance{
+				LedgerId:  "general_ledger_id",
+				Currency:  gofakeit.Currency().Short,
+				Indicator: "no-at-prefix",
+			},
+			expectedCode: http.StatusBadRequest,
+		},
+		{
+			name: "Indicator with spaces",
+			payload: model2.CreateBalance{
+				LedgerId:  "general_ledger_id",
+				Currency:  gofakeit.Currency().Short,
+				Indicator: "@cash flow",
+			},
+			expectedCode: http.StatusBadRequest,
+		},
+		{
+			name: "Non-GL ledger with indicator",
+			payload: model2.CreateBalance{
+				LedgerId:  otherLedger.LedgerID,
+				Currency:  gofakeit.Currency().Short,
+				Indicator: "@cash",
+			},
+			expectedCode: http.StatusBadRequest,
+		},
+		{
+			name: "Duplicate indicator and currency",
+			payload: model2.CreateBalance{
+				LedgerId:  "general_ledger_id",
+				Currency:  currency,
+				Indicator: validIndicator,
+			},
+			expectedCode: http.StatusConflict,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payloadBytes, _ := request.ToJsonReq(&tt.payload)
+			var response model.Balance
+			resp, err := SetUpTestRequest(TestRequest{
+				Payload:  payloadBytes,
+				Response: &response,
+				Method:   "POST",
+				Route:    "/balances",
+				Auth:     "",
+				Router:   router,
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedCode, resp.Code)
+			if resp.Code == http.StatusCreated {
+				assert.NotEmpty(t, response.BalanceID, "a 201 response must not carry an empty balance")
+			}
+
+			if tt.expectedCode == http.StatusCreated {
+				require.NotEmpty(t, response.BalanceID)
+				balanceFromDB, err := b.GetBalanceByID(context.Background(), response.BalanceID, nil, false)
+				require.NoError(t, err)
+				assert.Equal(t, tt.payload.Indicator, balanceFromDB.Indicator)
+			}
+		})
+	}
+}
+
 func TestGetBalance(t *testing.T) {
 	router, b, _ := setupRouter()
 	newLedger, err := b.CreateLedger(model.Ledger{Name: gofakeit.Name()})

--- a/api/model/balance.go
+++ b/api/model/balance.go
@@ -23,6 +23,7 @@ type CreateBalance struct {
 	MetaData           map[string]interface{} `json:"meta_data"`
 	TrackFundLineage   bool                   `json:"track_fund_lineage"`
 	AllocationStrategy string                 `json:"allocation_strategy"`
+	Indicator          string                 `json:"indicator,omitempty"`
 }
 
 type CreateBalanceMonitor struct {

--- a/api/model/model.go
+++ b/api/model/model.go
@@ -18,6 +18,7 @@ package model
 import (
 	"errors"
 	"math"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -82,17 +83,42 @@ func validateDateFormat(format, value string) error {
 	return nil
 }
 
+// generalLedgerID is the well-known ledger ID for General Ledger (@) balances.
+// Only balances under this ledger may be pre-provisioned with an explicit indicator.
+const generalLedgerID = "general_ledger_id"
+
+// indicatorPattern validates optional balance indicators: must start with "@"
+// and contain no whitespace
+var indicatorPattern = regexp.MustCompile(`^@\S+$`)
+
 func (b *CreateBalance) ValidateCreateBalance() error {
 	// Normalize allocation strategy: trim and uppercase
 	if b.AllocationStrategy != "" {
 		b.AllocationStrategy = strings.TrimSpace(strings.ToUpper(b.AllocationStrategy))
 	}
 
+	// Trim surrounding whitespace only; internal whitespace remains invalid.
+	if b.Indicator != "" {
+		b.Indicator = strings.TrimSpace(b.Indicator)
+	}
+
+	isGeneralLedger := b.LedgerId == generalLedgerID
+
 	return validation.ValidateStruct(b,
 		validation.Field(&b.LedgerId, validation.Required),
 		validation.Field(&b.Currency, validation.Required),
 		validation.Field(&b.IdentityId, validation.When(b.TrackFundLineage, validation.Required.Error("identity_id is required when track_fund_lineage is enabled"))),
 		validation.Field(&b.AllocationStrategy, validation.When(b.AllocationStrategy != "", validation.In("FIFO", "LIFO", "PROPORTIONAL").Error("allocation_strategy must be one of: FIFO, LIFO, PROPORTIONAL"))),
+		validation.Field(&b.Indicator,
+			validation.When(b.Indicator != "" && !isGeneralLedger,
+				validation.By(func(value interface{}) error {
+					return errors.New("indicator is only allowed for General Ledger balances (ledger_id = general_ledger_id)")
+				}),
+			),
+			validation.When(b.Indicator != "" && isGeneralLedger,
+				validation.Match(indicatorPattern).Error("indicator must start with '@' and contain no whitespace (e.g. '@cash')"),
+			),
+		),
 	)
 }
 
@@ -215,7 +241,7 @@ func (b *CreateBalance) ToBalance() model.Balance {
 	if allocationStrategy == "" {
 		allocationStrategy = "FIFO"
 	}
-	return model.Balance{LedgerID: b.LedgerId, IdentityID: b.IdentityId, Currency: b.Currency, MetaData: b.MetaData, TrackFundLineage: b.TrackFundLineage, AllocationStrategy: allocationStrategy}
+	return model.Balance{LedgerID: b.LedgerId, IdentityID: b.IdentityId, Currency: b.Currency, MetaData: b.MetaData, TrackFundLineage: b.TrackFundLineage, AllocationStrategy: allocationStrategy, Indicator: b.Indicator}
 }
 
 func (b *CreateBalanceMonitor) ToBalanceMonitor() model.BalanceMonitor {

--- a/api/model/model_test.go
+++ b/api/model/model_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/blnkfinance/blnk/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSourceOrSourcesValidation(t *testing.T) {
@@ -492,6 +493,91 @@ func TestValidateCreateBalanceMonitor(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateCreateBalance_Indicator(t *testing.T) {
+	tests := []struct {
+		name    string
+		balance CreateBalance
+		wantErr bool
+	}{
+		{
+			name: "Valid GL indicator",
+			balance: CreateBalance{
+				LedgerId:  "general_ledger_id",
+				Currency:  "USD",
+				Indicator: "@cash",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Indicator omitted",
+			balance: CreateBalance{
+				LedgerId: "general_ledger_id",
+				Currency: "USD",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Missing @ prefix",
+			balance: CreateBalance{
+				LedgerId:  "general_ledger_id",
+				Currency:  "USD",
+				Indicator: "cash",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Indicator with internal spaces",
+			balance: CreateBalance{
+				LedgerId:  "general_ledger_id",
+				Currency:  "USD",
+				Indicator: "@cash flow",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Indicator with leading/trailing spaces only",
+			balance: CreateBalance{
+				LedgerId:  "general_ledger_id",
+				Currency:  "USD",
+				Indicator: "  @cash  ",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Non-GL ledger with indicator set",
+			balance: CreateBalance{
+				LedgerId:  "some_other_ledger",
+				Currency:  "USD",
+				Indicator: "@cash",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.balance.ValidateCreateBalance()
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestCreateBalance_ToBalance_Indicator(t *testing.T) {
+	cb := CreateBalance{
+		LedgerId:  "general_ledger_id",
+		Currency:  "USD",
+		Indicator: "@cash",
+	}
+	require.NoError(t, cb.ValidateCreateBalance())
+
+	balance := cb.ToBalance()
+	assert.Equal(t, "@cash", balance.Indicator)
 }
 
 func TestValidateMonitorCondition(t *testing.T) {

--- a/balance.go
+++ b/balance.go
@@ -18,8 +18,8 @@ package blnk
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/blnkfinance/blnk/config"
@@ -33,6 +33,24 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
+
+// isAlreadyExists reports whether err means the balance already exists
+// (apierror.ErrConflict), e.g. a duplicate (indicator, currency) pair from
+// CreateBalance. Used by get-or-create so a concurrent create race can fall
+// through to a re-fetch instead of failing. Checking the error code (rather
+// than an empty balance ID or a substring of the message) keeps this resilient
+// to message changes.
+func isAlreadyExists(err error) bool {
+	var apiErr apierror.APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.Code == apierror.ErrConflict
+	}
+	var apiErrPtr *apierror.APIError
+	if errors.As(err, &apiErrPtr) && apiErrPtr != nil {
+		return apiErrPtr.Code == apierror.ErrConflict
+	}
+	return false
+}
 
 // balanceTracer is an OpenTelemetry tracer for tracking balance-related transactions.
 var (
@@ -154,7 +172,7 @@ func (l *Blnk) getOrCreateBalanceByIndicator(ctx context.Context, indicator, cur
 			Currency:  currency,
 		}
 		_, err := l.CreateBalance(ctx, *balance)
-		if err != nil && !strings.Contains(err.Error(), "Balance already exist") {
+		if err != nil && !isAlreadyExists(err) {
 			span.RecordError(err)
 			return nil, err
 		}
@@ -232,21 +250,10 @@ func (l *Blnk) CreateBalance(ctx context.Context, balance model.Balance) (model.
 	ctx, span := balanceTracer.Start(ctx, "CreateBalance")
 	defer span.End()
 
-	requestedIndicator := balance.Indicator
-
 	balance, err := l.datasource.CreateBalance(balance)
 	if err != nil {
 		span.RecordError(err)
 		return model.Balance{}, err
-	}
-
-	// The datasource signals a duplicate (indicator, currency) pair by returning
-	// an empty balance with a nil error (see database/balance.go unique_indicator_currency
-	// handling). Without this check the API would respond 201 with an empty body.
-	if requestedIndicator != "" && balance.BalanceID == "" {
-		conflictErr := apierror.NewAPIError(apierror.ErrConflict, fmt.Sprintf("Balance already exists for indicator '%s' and this currency", requestedIndicator), nil)
-		span.RecordError(conflictErr)
-		return model.Balance{}, conflictErr
 	}
 
 	l.postBalanceActions(ctx, &balance)

--- a/balance.go
+++ b/balance.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/blnkfinance/blnk/config"
+	"github.com/blnkfinance/blnk/internal/apierror"
 	"github.com/blnkfinance/blnk/internal/filter"
 	"github.com/blnkfinance/blnk/internal/metrics"
 	"github.com/blnkfinance/blnk/internal/notification"
@@ -231,11 +232,23 @@ func (l *Blnk) CreateBalance(ctx context.Context, balance model.Balance) (model.
 	ctx, span := balanceTracer.Start(ctx, "CreateBalance")
 	defer span.End()
 
+	requestedIndicator := balance.Indicator
+
 	balance, err := l.datasource.CreateBalance(balance)
 	if err != nil {
 		span.RecordError(err)
 		return model.Balance{}, err
 	}
+
+	// The datasource signals a duplicate (indicator, currency) pair by returning
+	// an empty balance with a nil error (see database/balance.go unique_indicator_currency
+	// handling). Without this check the API would respond 201 with an empty body.
+	if requestedIndicator != "" && balance.BalanceID == "" {
+		conflictErr := apierror.NewAPIError(apierror.ErrConflict, fmt.Sprintf("Balance already exists for indicator '%s' and this currency", requestedIndicator), nil)
+		span.RecordError(conflictErr)
+		return model.Balance{}, conflictErr
+	}
+
 	l.postBalanceActions(ctx, &balance)
 	metrics.BalanceCreatedTotal.Add(ctx, 1)
 	span.AddEvent("Balance created", trace.WithAttributes(attribute.String("balance.id", balance.BalanceID)))

--- a/balance_test.go
+++ b/balance_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"database/sql/driver"
 	"encoding/json"
+	"errors"
 	"math/big"
 	"regexp"
 	"testing"
@@ -27,6 +28,7 @@ import (
 
 	"github.com/brianvoe/gofakeit/v6"
 
+	"github.com/blnkfinance/blnk/internal/apierror"
 	"github.com/blnkfinance/blnk/model"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -555,4 +557,47 @@ func TestGetBalanceByIndicator(t *testing.T) {
 	assert.Equal(t, 0, big.NewInt(0).Cmp(retrievedBalance.Balance), "Balance should be 0")
 	assert.Equal(t, 0, big.NewInt(0).Cmp(retrievedBalance.CreditBalance), "Credit balance should be 0")
 	assert.Equal(t, 0, big.NewInt(0).Cmp(retrievedBalance.DebitBalance), "Debit balance should be 0")
+}
+
+func TestIsAlreadyExists(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "APIError value with ErrConflict code",
+			err:  apierror.NewAPIError(apierror.ErrConflict, "Balance already exists for indicator '@cash' and this currency", nil),
+			want: true,
+		},
+		{
+			name: "APIError pointer with ErrConflict code",
+			err: func() error {
+				e := apierror.NewAPIError(apierror.ErrConflict, "conflict", nil)
+				return &e
+			}(),
+			want: true,
+		},
+		{
+			name: "APIError with a different code",
+			err:  apierror.NewAPIError(apierror.ErrBadRequest, "Invalid ledger ID", nil),
+			want: false,
+		},
+		{
+			name: "generic non-APIError",
+			err:  errors.New("some unrelated failure"),
+			want: false,
+		},
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isAlreadyExists(tt.err))
+		})
+	}
 }

--- a/database/balance.go
+++ b/database/balance.go
@@ -260,7 +260,7 @@ func (d Datasource) CreateBalance(balance model.Balance) (model.Balance, error) 
 			switch pqErr.Code.Name() {
 			case "unique_violation":
 				if strings.Contains(pqErr.Message, "unique_indicator_currency") {
-					return model.Balance{}, nil
+					return model.Balance{}, apierror.NewAPIError(apierror.ErrConflict, fmt.Sprintf("Balance already exists for indicator '%s' and '%s'", balance.Indicator, balance.Currency), err)
 				}
 				return model.Balance{}, apierror.NewAPIError(apierror.ErrConflict, fmt.Sprintf("Balance already exists: %s", balance.BalanceID), err)
 			case "foreign_key_violation":

--- a/database/balance_test.go
+++ b/database/balance_test.go
@@ -117,6 +117,38 @@ func TestCreateBalance_UniqueViolation(t *testing.T) {
 	assert.Equal(t, apierror.ErrConflict, apiErr.Code)
 }
 
+func TestCreateBalance_DuplicateIndicatorCurrency(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	ds := Datasource{Conn: db}
+
+	balance := model.Balance{
+		Balance:       big.NewInt(0),
+		CreditBalance: big.NewInt(0),
+		DebitBalance:  big.NewInt(0),
+		Currency:      "USD",
+		LedgerID:      "general_ledger_id",
+		Indicator:     "@cash",
+	}
+
+	metaDataJSON, err := json.Marshal(balance.MetaData)
+	assert.NoError(t, err)
+
+	mock.ExpectExec("INSERT INTO blnk.balances").
+		WithArgs(sqlmock.AnyArg(), balance.Balance.String(), balance.CreditBalance.String(), balance.DebitBalance.String(), balance.Currency, balance.LedgerID, sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), metaDataJSON, false, "FIFO").
+		WillReturnError(&pq.Error{Code: "23505", Message: `duplicate key value violates unique constraint "unique_indicator_currency"`})
+
+	_, err = ds.CreateBalance(balance)
+	assert.Error(t, err, "a duplicate (indicator, currency) pair must surface as a real error, not a silent empty balance")
+
+	apiErr, ok := err.(apierror.APIError)
+	assert.True(t, ok)
+	assert.Equal(t, apierror.ErrConflict, apiErr.Code)
+	assert.Contains(t, apiErr.Message, "@cash")
+}
+
 func TestGetBalanceByID_Success(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)


### PR DESCRIPTION
General Ledger balances can now be created with an explicit indicator on POST /balances, so @ accounts (e.g. @cash) can be provisioned up front instead of only appearing on first use.

indicator is optional, GL-only (ledger_id = general_ledger_id), must look like @name, and duplicates for the same (indicator, currency) return 409 instead of an empty 201.

Test plan

 Create a GL balance with indicator: "@cash" — succeeds

 Reject bad indicators (no @, whitespace, non-GL ledger)

 Creating the same indicator + currency again returns 409

 Existing create-balance paths (no indicator) still works