### PR TITLE
fix(lock): release locks on a context detached from cancellation

### DIFF
--- a/internal/lock/lock.go
+++ b/internal/lock/lock.go
@@ -100,11 +100,15 @@ func (l *Locker) Lock(ctx context.Context, timeout time.Duration) error {
 
 // Unlock releases the lock if the calling instance is the lock holder (based on the value).
 // The operation is atomic, ensuring only the holder of the lock can release it.
+// ctx's cancellation is ignored: an abandoned request must still free the lock.
 // Parameters:
 // - ctx: The context for managing the unlock request lifecycle.
 // Returns an error if the unlock operation fails, either because the lock expired or
 // the caller is not the lock holder.
 func (l *Locker) Unlock(ctx context.Context) error {
+	ctx, cancel := releaseContext(ctx)
+	defer cancel()
+
 	// Lua script ensures atomicity: checks the value and deletes the key if the value matches.
 	script := "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end"
 	result, err := l.client.Eval(ctx, script, []string{l.key}, l.value).Result()
@@ -303,7 +307,14 @@ func (m *MultiLocker) Keys() []string {
 const (
 	lockBackoffBase = 5 * time.Millisecond
 	lockBackoffMax  = 100 * time.Millisecond
+
+	lockReleaseTimeout = 5 * time.Second
 )
+
+// releaseContext keeps ctx's values but drops its cancellation, bounded by lockReleaseTimeout.
+func releaseContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(ctx), lockReleaseTimeout)
+}
 
 // sleepWithJitter sleeps for an exponentially growing, jittered backoff period:
 // the cap starts at lockBackoffBase and doubles per attempt up to lockBackoffMax,

--- a/internal/lock/lock_test.go
+++ b/internal/lock/lock_test.go
@@ -21,8 +21,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/alicebob/miniredis/v2"
 	"github.com/go-redis/redismock/v9"
+	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLocker_Lock_Success(t *testing.T) {
@@ -71,6 +74,29 @@ func TestLocker_Unlock_Failure(t *testing.T) {
 	err := locker.Unlock(context.Background())
 	assert.EqualError(t, err, "unlock failed, either lock expired or you're not the lock holder for key test-key")
 	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// newRedisTestClient starts an in-process redis, for tests that assert real key state.
+func newRedisTestClient(t *testing.T) (*redis.Client, *miniredis.Miniredis) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	return client, mr
+}
+
+func TestLocker_Unlock_ReleasesWhenContextCancelled(t *testing.T) {
+	db, mr := newRedisTestClient(t)
+	locker := NewLocker(db, "test-key", "test-value")
+
+	require.NoError(t, locker.Lock(context.Background(), time.Minute))
+	require.True(t, mr.Exists("test-key"))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	assert.NoError(t, locker.Unlock(ctx))
+	assert.False(t, mr.Exists("test-key"), "lock key survived a release on a cancelled context")
 }
 
 func TestLocker_ExtendLock_Success(t *testing.T) {
@@ -244,6 +270,22 @@ func TestMultiLocker_Unlock_ReturnsLastError(t *testing.T) {
 	// Should return the error from first failed unlock
 	assert.Error(t, err)
 	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestMultiLocker_Unlock_ReleasesWhenContextCancelled(t *testing.T) {
+	db, mr := newRedisTestClient(t)
+	multiLocker := NewMultiLocker(db, []string{"key-b", "key-a"}, "test-value")
+
+	require.NoError(t, multiLocker.Lock(context.Background(), time.Minute))
+	require.True(t, mr.Exists("key-a"))
+	require.True(t, mr.Exists("key-b"))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	assert.NoError(t, multiLocker.Unlock(ctx))
+	assert.False(t, mr.Exists("key-a"), "lock key survived a release on a cancelled context")
+	assert.False(t, mr.Exists("key-b"), "lock key survived a release on a cancelled context")
 }
 
 func TestMultiLocker_WaitLock_Success(t *testing.T) {


### PR DESCRIPTION
Locker.Unlock ran its redis Eval on the caller's context, so a cancelled or timed-out request left the key to expire on its own TTL and every later transaction on that balance failed with "failed to acquire lock". Nothing surfaced it: rollback discards the error, releaseLock and releaseSingleLock only log it.

Fixes #354