### PR TITLE
fix: nullable parent_transaction scan and dry-run balance meta_data mock

### DIFF
--- a/database/transaction_queries.go
+++ b/database/transaction_queries.go
@@ -294,6 +294,7 @@ func (d Datasource) GetAllTransactions(ctx context.Context, limit, offset int) (
 		var metaDataJSON []byte
 		var preciseAmountStr string
 		var effectiveDate sql.NullTime
+		var parentTransaction sql.NullString
 
 		// Scan each row into the Transaction struct
 		err = rows.Scan(
@@ -311,7 +312,7 @@ func (d Datasource) GetAllTransactions(ctx context.Context, limit, offset int) (
 			&transaction.CreatedAt,
 			&effectiveDate,
 			&metaDataJSON,
-			&transaction.ParentTransaction,
+			&parentTransaction,
 		)
 		if err != nil {
 			span.RecordError(err)
@@ -322,6 +323,9 @@ func (d Datasource) GetAllTransactions(ctx context.Context, limit, offset int) (
 		// where GetEffectiveDate falls back to created_at).
 		if effectiveDate.Valid {
 			transaction.EffectiveDate = &effectiveDate.Time
+		}
+		if parentTransaction.Valid {
+			transaction.ParentTransaction = parentTransaction.String
 		}
 
 		// Parse the precise amount (NUMERIC) into a big.Int, mirroring the other

--- a/database/transaction_queries.go
+++ b/database/transaction_queries.go
@@ -47,7 +47,8 @@ func (d Datasource) GetTransaction(ctx context.Context, id string) (*model.Trans
 	txn := &model.Transaction{}
 	var metaDataJSON []byte
 	var preciseAmountStr string
-	err := row.Scan(&txn.TransactionID, &txn.Source, &txn.Reference, &txn.Amount, &preciseAmountStr, &txn.Precision, &txn.Currency, &txn.Destination, &txn.Description, &txn.Status, &txn.CreatedAt, &metaDataJSON, &txn.ParentTransaction, &txn.Hash)
+	var parentTransaction sql.NullString
+	err := row.Scan(&txn.TransactionID, &txn.Source, &txn.Reference, &txn.Amount, &preciseAmountStr, &txn.Precision, &txn.Currency, &txn.Destination, &txn.Description, &txn.Status, &txn.CreatedAt, &metaDataJSON, &parentTransaction, &txn.Hash)
 	// Handle errors, including no rows found
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -57,6 +58,7 @@ func (d Datasource) GetTransaction(ctx context.Context, id string) (*model.Trans
 		span.RecordError(err)
 		return nil, apierror.NewAPIError(apierror.ErrInternalServer, "Failed to retrieve transaction", err)
 	}
+	txn.ParentTransaction = nullableString(parentTransaction)
 
 	// Unmarshal the metadata JSON into the transaction's MetaData field
 	err = json.Unmarshal(metaDataJSON, &txn.MetaData)
@@ -225,7 +227,8 @@ func (d Datasource) GetTransactionByRef(ctx context.Context, reference string) (
 	txn := model.Transaction{}
 	var metaDataJSON []byte
 	var preciseAmountStr string
-	err := row.Scan(&txn.TransactionID, &txn.Source, &txn.Reference, &txn.Amount, &preciseAmountStr, &txn.Currency, &txn.Destination, &txn.Description, &txn.Status, &txn.CreatedAt, &metaDataJSON, &txn.ParentTransaction)
+	var parentTransaction sql.NullString
+	err := row.Scan(&txn.TransactionID, &txn.Source, &txn.Reference, &txn.Amount, &preciseAmountStr, &txn.Currency, &txn.Destination, &txn.Description, &txn.Status, &txn.CreatedAt, &metaDataJSON, &parentTransaction)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			span.RecordError(err)
@@ -234,6 +237,7 @@ func (d Datasource) GetTransactionByRef(ctx context.Context, reference string) (
 		span.RecordError(err)
 		return model.Transaction{}, apierror.NewAPIError(apierror.ErrInternalServer, "Failed to retrieve transaction", err)
 	}
+	txn.ParentTransaction = nullableString(parentTransaction)
 
 	// Unmarshal the metadata JSON into the transaction's MetaData field
 	err = json.Unmarshal(metaDataJSON, &txn.MetaData)
@@ -324,9 +328,7 @@ func (d Datasource) GetAllTransactions(ctx context.Context, limit, offset int) (
 		if effectiveDate.Valid {
 			transaction.EffectiveDate = &effectiveDate.Time
 		}
-		if parentTransaction.Valid {
-			transaction.ParentTransaction = parentTransaction.String
-		}
+		transaction.ParentTransaction = nullableString(parentTransaction)
 
 		// Parse the precise amount (NUMERIC) into a big.Int, mirroring the other
 		// transaction row scans in this package.
@@ -360,6 +362,15 @@ func (d Datasource) GetAllTransactions(ctx context.Context, limit, offset int) (
 
 	// Return the slice of transactions
 	return transactions, nil
+}
+
+// nullableString maps a nullable TEXT column to a Go string. Root transactions
+// store parent_transaction as NULL; scanning that into a string 500s the read.
+func nullableString(v sql.NullString) string {
+	if v.Valid {
+		return v.String
+	}
+	return ""
 }
 
 // GetTotalCommittedTransactions calculates the total committed transaction amounts for a given parent transaction.

--- a/database/transactions_test.go
+++ b/database/transactions_test.go
@@ -944,7 +944,7 @@ func TestGetAllTransactions_Success(t *testing.T) {
 			"destination", "description", "status", "hash", "created_at", "effective_date", "meta_data", "parent_transaction",
 		}).
 			AddRow("txn_1", "bln_src1", "ref_1", 1000.0, "1000", 100.0, "USD", "bln_dest1", "Txn 1", "APPLIED", "hash1", time.Now(), effectiveDate, metaDataJSON, "txn_parent_1").
-			AddRow("txn_2", "bln_src2", "ref_2", 2000.0, "2000", 100.0, "EUR", "bln_dest2", "Txn 2", "PENDING", "hash2", time.Now(), nil, metaDataJSON, ""))
+			AddRow("txn_2", "bln_src2", "ref_2", 2000.0, "2000", 100.0, "EUR", "bln_dest2", "Txn 2", "PENDING", "hash2", time.Now(), nil, metaDataJSON, nil))
 
 	transactions, err := ds.GetAllTransactions(ctx, 10, 0)
 	assert.NoError(t, err)
@@ -954,6 +954,7 @@ func TestGetAllTransactions_Success(t *testing.T) {
 	// Regression guard for the reindex field-loss bug (blnk#326): the query
 	// previously omitted these, so reindexed docs lost them in Typesense.
 	assert.Equal(t, "txn_parent_1", transactions[0].ParentTransaction)
+	assert.Equal(t, "", transactions[1].ParentTransaction)
 	assert.Equal(t, "1000", transactions[0].PreciseAmount.String())
 	assert.Equal(t, 100.0, transactions[0].Precision)
 	assert.Equal(t, "2000", transactions[1].PreciseAmount.String())

--- a/database/transactions_test.go
+++ b/database/transactions_test.go
@@ -185,6 +185,40 @@ func TestGetTransaction_Success(t *testing.T) {
 	assert.Equal(t, "hash123", txn.Hash)
 }
 
+// TestGetTransaction_NullParentDoesNotFailScan catches GET /transactions/:id
+// 500ing on a root transaction. parent_transaction is nullable; a missing
+// parent must scan as "" rather than failing the request.
+func TestGetTransaction_NullParentDoesNotFailScan(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	ds := Datasource{Conn: db}
+	ctx := context.Background()
+
+	metaDataJSON, err := json.Marshal(map[string]interface{}{"key": "value"})
+	assert.NoError(t, err)
+
+	mock.ExpectQuery("SELECT transaction_id, source, reference, amount, precise_amount, precision, currency, destination, description, status, created_at, meta_data, parent_transaction, hash FROM blnk.transactions WHERE transaction_id = ?").
+		WithArgs("txn_root").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"transaction_id", "source", "reference", "amount", "precise_amount", "precision", "currency",
+			"destination", "description", "status", "created_at", "meta_data", "parent_transaction", "hash",
+		}).AddRow(
+			"txn_root", "src1", "ref_root", 1000, "1000", 2, "USD",
+			"dest1", "root transaction", "APPLIED", time.Now(), metaDataJSON, nil, "hash_root",
+		))
+
+	txn, err := ds.GetTransaction(ctx, "txn_root")
+	assert.NoError(t, err)
+	if assert.NotNil(t, txn) {
+		assert.Equal(t, "txn_root", txn.TransactionID)
+		assert.Equal(t, "", txn.ParentTransaction)
+	}
+
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestGetTransaction_NotFound(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
@@ -857,6 +891,44 @@ func TestGetTransactionByRef_Success(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// TestGetTransactionByRef_NullParentDoesNotFailScan catches GET
+// /transactions/reference/:ref 500ing on a root transaction whose
+// parent_transaction is NULL.
+func TestGetTransactionByRef_NullParentDoesNotFailScan(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	ds := Datasource{Conn: db}
+	ctx := context.Background()
+
+	metaDataJSON, err := json.Marshal(map[string]interface{}{"key": "value"})
+	assert.NoError(t, err)
+
+	query := `
+		SELECT transaction_id, source, reference, amount, precise_amount, currency, destination, description, status, created_at, meta_data, parent_transaction
+		FROM blnk.transactions
+		WHERE reference = $1
+	`
+
+	mock.ExpectQuery(regexp.QuoteMeta(query)).
+		WithArgs("ref_root").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"transaction_id", "source", "reference", "amount", "precise_amount", "currency",
+			"destination", "description", "status", "created_at", "meta_data", "parent_transaction",
+		}).AddRow(
+			"txn_root", "bln_source", "ref_root", 1000.0, "100000", "USD",
+			"bln_dest", "root transaction", "APPLIED", time.Now(), metaDataJSON, nil,
+		))
+
+	txn, err := ds.GetTransactionByRef(ctx, "ref_root")
+	assert.NoError(t, err)
+	assert.Equal(t, "txn_root", txn.TransactionID)
+	assert.Equal(t, "", txn.ParentTransaction)
+
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestGetTransactionByRef_NotFound(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
@@ -944,7 +1016,7 @@ func TestGetAllTransactions_Success(t *testing.T) {
 			"destination", "description", "status", "hash", "created_at", "effective_date", "meta_data", "parent_transaction",
 		}).
 			AddRow("txn_1", "bln_src1", "ref_1", 1000.0, "1000", 100.0, "USD", "bln_dest1", "Txn 1", "APPLIED", "hash1", time.Now(), effectiveDate, metaDataJSON, "txn_parent_1").
-			AddRow("txn_2", "bln_src2", "ref_2", 2000.0, "2000", 100.0, "EUR", "bln_dest2", "Txn 2", "PENDING", "hash2", time.Now(), nil, metaDataJSON, nil))
+			AddRow("txn_2", "bln_src2", "ref_2", 2000.0, "2000", 100.0, "EUR", "bln_dest2", "Txn 2", "PENDING", "hash2", time.Now(), nil, metaDataJSON, ""))
 
 	transactions, err := ds.GetAllTransactions(ctx, 10, 0)
 	assert.NoError(t, err)
@@ -954,7 +1026,6 @@ func TestGetAllTransactions_Success(t *testing.T) {
 	// Regression guard for the reindex field-loss bug (blnk#326): the query
 	// previously omitted these, so reindexed docs lost them in Typesense.
 	assert.Equal(t, "txn_parent_1", transactions[0].ParentTransaction)
-	assert.Equal(t, "", transactions[1].ParentTransaction)
 	assert.Equal(t, "1000", transactions[0].PreciseAmount.String())
 	assert.Equal(t, 100.0, transactions[0].Precision)
 	assert.Equal(t, "2000", transactions[1].PreciseAmount.String())
@@ -965,6 +1036,48 @@ func TestGetAllTransactions_Success(t *testing.T) {
 
 	err = mock.ExpectationsWereMet()
 	assert.NoError(t, err)
+}
+
+// TestGetAllTransactions_NullParentDoesNotFailScan is the regression for
+// GET /transactions returning 500 when any listed row has parent_transaction
+// IS NULL. Root transactions often have no parent; the unfiltered list must
+// treat that as "" instead of failing the whole page.
+func TestGetAllTransactions_NullParentDoesNotFailScan(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	ds := Datasource{Conn: db}
+	ctx := context.Background()
+
+	metaDataJSON, err := json.Marshal(map[string]interface{}{"key": "value"})
+	assert.NoError(t, err)
+
+	query := `
+		SELECT transaction_id, source, reference, amount, precise_amount, precision, currency, destination, description, status, hash, created_at, effective_date, meta_data, parent_transaction
+		FROM blnk.transactions
+		ORDER BY created_at DESC
+		LIMIT $1 OFFSET $2
+	`
+
+	mock.ExpectQuery(regexp.QuoteMeta(query)).
+		WithArgs(20, 0).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"transaction_id", "source", "reference", "amount", "precise_amount", "precision", "currency",
+			"destination", "description", "status", "hash", "created_at", "effective_date", "meta_data", "parent_transaction",
+		}).AddRow(
+			"txn_root", "bln_src", "ref_root", 1000.0, "1000", 100.0, "USD",
+			"bln_dst", "root txn", "APPLIED", "hash_root", time.Now(), nil, metaDataJSON, nil,
+		))
+
+	transactions, err := ds.GetAllTransactions(ctx, 20, 0)
+	assert.NoError(t, err)
+	if assert.Len(t, transactions, 1) {
+		assert.Equal(t, "txn_root", transactions[0].TransactionID)
+		assert.Equal(t, "", transactions[0].ParentTransaction)
+	}
+
+	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestGetAllTransactions_Empty(t *testing.T) {

--- a/transaction_dryrun_test.go
+++ b/transaction_dryrun_test.go
@@ -67,13 +67,13 @@ func expectBalanceLite(dbMock sqlmock.Sqlmock, balanceID, currency string, balan
 	rows := sqlmock.NewRows([]string{
 		"balance_id", "indicator", "currency", "ledger_id", "balance", "credit_balance", "debit_balance",
 		"inflight_balance", "inflight_credit_balance", "inflight_debit_balance", "created_at", "version",
-		"track_fund_lineage", "allocation_strategy", "identity_id",
+		"track_fund_lineage", "allocation_strategy", "identity_id", "meta_data",
 	}).AddRow(
 		balanceID, nil, currency, "general_ledger_id", int64ToString(balance), int64ToString(credit), int64ToString(debit),
-		"0", "0", int64ToString(inflightDebit), time.Now(), 3, false, "FIFO", "",
+		"0", "0", int64ToString(inflightDebit), time.Now(), 3, false, "FIFO", "", nil,
 	)
 
-	dbMock.ExpectQuery(regexp.QuoteMeta(`SELECT balance_id, indicator, currency, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version`)).
+	dbMock.ExpectQuery(regexp.QuoteMeta(`SELECT balance_id, indicator, currency, ledger_id, balance, credit_balance, debit_balance, inflight_balance, inflight_credit_balance, inflight_debit_balance, created_at, version, track_fund_lineage, COALESCE(allocation_strategy, 'FIFO') as allocation_strategy, COALESCE(identity_id, '') as identity_id, meta_data`)).
 		WithArgs(balanceID).
 		WillReturnRows(rows)
 }


### PR DESCRIPTION
1. Fix NULL parent_transaction values that caused row scans to fail 

2. Align dry-run balance mocks with GetBalanceByIDLite's meta_data column.