### PR TITLE
fix(transactions): reject source == destination before processing starts

### DIFF
--- a/api/model/model.go
+++ b/api/model/model.go
@@ -63,6 +63,45 @@ func destinationOrDestinationsValidation(t *RecordTransaction) validation.RuleFu
 	}
 }
 
+// sameBalanceValidation rejects a source and destination that resolve to the
+// same balance, whether directly or through a split.
+//
+// updateBalance guards each row with optimistic locking: UPDATE ... WHERE
+// balance_id = $1 AND version = $N. Source and destination are fetched as
+// two independent balance reads, both carrying the row's version from
+// before either update runs. When they name the same row, the first UPDATE
+// advances the version and the second's WHERE version=<now stale> clause
+// matches nothing — a deterministic conflict every single time this is
+// attempted, not a rare race. Rejecting it here, before any balance is
+// fetched, avoids both the confusing downstream "optimistic locking
+// failure" (which reads as a transient race, not a guaranteed one) and,
+// on the default queued path, several retry cycles spent on a transaction
+// that can never succeed.
+func sameBalanceValidation(t *RecordTransaction) validation.RuleFunc {
+	return func(value interface{}) error {
+		const msg = "source and destination cannot be the same balance"
+
+		if t.Source != "" && t.Destination != "" && t.Source == t.Destination {
+			return errors.New(msg)
+		}
+		if t.Source != "" {
+			for _, d := range t.Destinations {
+				if d.Identifier == t.Source {
+					return errors.New(msg)
+				}
+			}
+		}
+		if t.Destination != "" {
+			for _, s := range t.Sources {
+				if s.Identifier == t.Destination {
+					return errors.New(msg)
+				}
+			}
+		}
+		return nil
+	}
+}
+
 func (l *CreateLedger) ValidateCreateLedger() error {
 	return validation.ValidateStruct(l,
 		validation.Field(&l.Name, validation.Required),
@@ -184,7 +223,7 @@ func (t *RecordTransaction) ValidateRecordTransaction() error {
 		validation.Field(&t.Reference, validation.Required),
 		validation.Field(&t.Description, validation.Required),
 		validation.Field(&t.Source, validation.By(sourceOrSourcesValidation(t))),
-		validation.Field(&t.Destination, validation.By(destinationOrDestinationsValidation(t))),
+		validation.Field(&t.Destination, validation.By(destinationOrDestinationsValidation(t)), validation.By(sameBalanceValidation(t))),
 		validation.Field(&t.ScheduledFor, validation.When(t.ScheduledFor != "", validation.By(func(value interface{}) error {
 			dateStr, ok := value.(string)
 			if !ok {

--- a/api/model/model_test.go
+++ b/api/model/model_test.go
@@ -318,6 +318,64 @@ func TestValidateRecordTransaction(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "Invalid Transaction - Source equals Destination",
+			transaction: RecordTransaction{
+				Amount:      100,
+				Currency:    "USD",
+				Reference:   "ref1",
+				Description: "Test transaction",
+				Source:      "bln_same",
+				Destination: "bln_same",
+				SkipQueue:   true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "Invalid Transaction - Source appears among Destinations (fan-out)",
+			transaction: RecordTransaction{
+				Amount:      100,
+				Currency:    "USD",
+				Reference:   "ref1",
+				Description: "Test transaction",
+				Source:      "bln_a",
+				Destinations: []model.Distribution{
+					{Identifier: "bln_a", Distribution: "50%"},
+					{Identifier: "bln_b", Distribution: "50%"},
+				},
+				SkipQueue: true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "Invalid Transaction - Destination appears among Sources (fan-in)",
+			transaction: RecordTransaction{
+				Amount:      100,
+				Currency:    "USD",
+				Reference:   "ref1",
+				Description: "Test transaction",
+				Destination: "bln_b",
+				Sources: []model.Distribution{
+					{Identifier: "bln_a", Distribution: "50%"},
+					{Identifier: "bln_b", Distribution: "50%"},
+				},
+				SkipQueue: true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "Valid Transaction - Source and Destination distinct",
+			transaction: RecordTransaction{
+				Amount:      100,
+				Currency:    "USD",
+				Reference:   "ref1",
+				Description: "Test transaction",
+				Source:      "bln_a",
+				Destination: "bln_b",
+				SkipQueue:   true,
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

A transaction with `source == destination` (or a source appearing as one of the destinations in a split, or vice versa) fails 100% of the time — but only after being partially processed, with a misleading error:

```json
HTTP 409
{"error": "Optimistic locking failure: balance with ID '<id>' may have been updated or deleted by another transaction"}
```

This isn't a concurrency race. `updateBalance` guards every row with optimistic locking (`UPDATE ... WHERE balance_id = $1 AND version = $N`). Source and destination are fetched as two independent balance reads, both carrying the row's version from before either update runs. When they name the same row, the first `UPDATE` advances the version and the second's `WHERE version=<now stale>` clause matches zero rows — a guaranteed conflict every single time, not a rare one, despite what the message implies.

**On the default (queued) path this is worse than a confusing message.** I ran a real worker against a queued self-transfer and watched it get retried — same transaction ID, same error, across two consecutive retry cycles ~25s apart. It's capped at `MaxRetryAttempts` (default 5), not infinite, but every one of those attempts is a guaranteed loss the system could know about immediately. The caller sees `201 QUEUED` right away and has no way to know the transaction is doomed without polling through several retry cycles.

## Fix

Add validation in `RecordTransaction.ValidateRecordTransaction`, next to the existing source/destination presence checks, so this is rejected with a clear, on-topic message before any balance is ever fetched:
- Plain transaction: `source == destination`
- Fan-out: `source` appears among `destinations`
- Fan-in: `destination` appears among `sources`

This runs through the same validation path every transaction-creation entry point already calls (including each item of a bulk request), so no separate wiring was needed per-endpoint.

## Test plan

- [x] Added 4 new cases to `TestValidateRecordTransaction` (self-transfer, fan-out, fan-in, plus a sanity "distinct balances still valid" case) — all pass
- [x] Full existing `api/model` suite passes unchanged
- [x] Verified live against 6 scenarios: plain self-transfer on both `skip_queue: true` and the default queued path (now rejected upfront instead of reaching `201 QUEUED`), fan-out, fan-in, and two sanity checks that ordinary transactions/splits still work
- [x] Verified a bulk-transaction item with a self-transfer gets the same protection
- [x] Full `api`, `api/model`, and root-package test suites pass (`go test -short ./api/... .`)
- [x] Ran the entire repo's test suite (`go test -short ./...`) — the only failures (`cmd`, `database`, `internal/request`, `internal/search`) are pre-existing TypeSense/network-sandbox/balance-snapshot flakiness, unrelated to transaction validation, and fail identically without this change

Found while adversarially testing the dry-run preview PR (#349) against the real API — this bug is unrelated to that PR and lives entirely in existing core transaction-processing code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)