### PR TITLE
fix(transactions): reject negative amount and precision at validation

### DIFF
--- a/api/model/model.go
+++ b/api/model/model.go
@@ -45,6 +45,63 @@ func validatePrecisionIsInteger(value interface{}) error {
 	return nil
 }
 
+// validatePrecisionNotNegative rejects a negative precision.
+//
+// Precision is a scaling factor — "the number you used to convert the
+// smallest unit to an integer" — so it is only meaningful as a positive
+// value. Zero is left valid because it means "not supplied" and is
+// defaulted to 1 downstream (see model.ApplyPrecision).
+//
+// A negative precision is not merely meaningless, it is load-bearing for
+// the bypass described on validateAmountNotNegative below: it flips the
+// sign of the computed precise amount.
+func validatePrecisionNotNegative(value interface{}) error {
+	precision, ok := value.(float64)
+	if !ok {
+		return errors.New("invalid precision type")
+	}
+
+	if precision < 0 {
+		return errors.New("precision cannot be negative")
+	}
+
+	return nil
+}
+
+// validateAmountNotNegative rejects negative amounts on both the float
+// `amount` field and the big.Int `precise_amount` field.
+//
+// The ledger's intent is that amounts are positive — model.Transaction's own
+// validate() reports "transaction amount must be positive" — but that check
+// runs deep in the apply path and, for `amount`, is unreachable: by the time
+// it runs, PreciseAmount has been computed and its non-nil branch returns
+// early. That left the effective guard against a negative `amount` to be an
+// unrelated split-distribution check firing by accident on a negative total.
+//
+// That accidental guard is bypassable, because precision multiplies:
+//
+//	amount(-25) x precision(-100) = precise_amount(+2500)
+//
+// The product is positive, so every downstream positivity check passes, and
+// the transaction applies — while `amount: -25` and `precision: -100` are
+// persisted as sent. The stored record then reports the opposite sign of the
+// movement it describes, and is invisible to an `amount > 0` filter.
+//
+// Zero is left to the existing downstream handling rather than rejected
+// here, so that the current zero-amount semantics (and issue #334's request
+// to make them opt-in) are not changed by this fix.
+func validateAmountNotNegative(t *RecordTransaction) validation.RuleFunc {
+	return func(value interface{}) error {
+		if t.Amount < 0 {
+			return errors.New("amount cannot be negative")
+		}
+		if t.PreciseAmount != nil && t.PreciseAmount.Sign() < 0 {
+			return errors.New("precise_amount cannot be negative")
+		}
+		return nil
+	}
+}
+
 func sourceOrSourcesValidation(t *RecordTransaction) validation.RuleFunc {
 	return func(value interface{}) error {
 		if (t.Source == "" && len(t.Sources) == 0) || (t.Source != "" && len(t.Sources) > 0) {
@@ -142,7 +199,7 @@ func (c *MonitorCondition) ValidateMonitorCondition() error {
 	return validation.ValidateStruct(c,
 		validation.Field(&c.Field, validation.Required, validation.In("debit_balance", "credit_balance", "balance", "inflight_debit_balance", "inflight_credit_balance", "inflight_balance")),
 		validation.Field(&c.Operator, validation.Required),
-		validation.Field(&c.Precision, validation.Required),
+		validation.Field(&c.Precision, validation.Required, validation.By(validatePrecisionNotNegative)),
 		validation.Field(&c.Value, validation.Required),
 	)
 }
@@ -178,8 +235,8 @@ func (t *RecordTransaction) ValidateRecordTransaction() error {
 			}
 
 			return nil
-		})),
-		validation.Field(&t.Precision, validation.By(validatePrecisionIsInteger)),
+		}), validation.By(validateAmountNotNegative(t))),
+		validation.Field(&t.Precision, validation.By(validatePrecisionIsInteger), validation.By(validatePrecisionNotNegative)),
 		validation.Field(&t.Currency, validation.Required),
 		validation.Field(&t.Reference, validation.Required),
 		validation.Field(&t.Description, validation.Required),

--- a/api/model/model_test.go
+++ b/api/model/model_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"math/big"
 	"testing"
 	"time"
 
@@ -317,6 +318,93 @@ func TestValidateRecordTransaction(t *testing.T) {
 				InflightCommitDate: "invalid-date",
 			},
 			wantErr: true,
+		},
+		{
+			// The bypass: negative x negative yields a positive precise
+			// amount, so every downstream positivity check passes while the
+			// persisted record still reports a negative amount.
+			name: "Invalid Transaction - Negative amount with negative precision (bypass)",
+			transaction: RecordTransaction{
+				Amount:      -25,
+				Precision:   -100,
+				Currency:    "USD",
+				Reference:   "ref_neg_bypass",
+				Description: "Test transaction",
+				Source:      "source1",
+				Destination: "dest1",
+				SkipQueue:   true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "Invalid Transaction - Negative amount alone",
+			transaction: RecordTransaction{
+				Amount:      -25,
+				Precision:   100,
+				Currency:    "USD",
+				Reference:   "ref_neg_amount",
+				Description: "Test transaction",
+				Source:      "source1",
+				Destination: "dest1",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Invalid Transaction - Negative precision alone",
+			transaction: RecordTransaction{
+				Amount:      25,
+				Precision:   -100,
+				Currency:    "USD",
+				Reference:   "ref_neg_precision",
+				Description: "Test transaction",
+				Source:      "source1",
+				Destination: "dest1",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Invalid Transaction - Negative precise_amount",
+			transaction: RecordTransaction{
+				PreciseAmount: big.NewInt(-1000),
+				Precision:     100,
+				Currency:      "USD",
+				Reference:     "ref_neg_precise",
+				Description:   "Test transaction",
+				Source:        "source1",
+				Destination:   "dest1",
+			},
+			wantErr: true,
+		},
+		{
+			// Zero precision means "not supplied" and is defaulted to 1
+			// downstream, so it must stay valid.
+			name: "Valid Transaction - Zero precision is still allowed",
+			transaction: RecordTransaction{
+				Amount:      100,
+				Precision:   0,
+				Currency:    "USD",
+				Reference:   "ref_zero_precision",
+				Description: "Test transaction",
+				Source:      "source1",
+				Destination: "dest1",
+			},
+			wantErr: false,
+		},
+		{
+			// Zero amount alongside precise_amount is the existing sentinel
+			// for "use precise_amount"; this fix must not disturb it.
+			name: "Valid Transaction - Zero amount with positive precise_amount",
+			transaction: RecordTransaction{
+				Amount:        0,
+				PreciseAmount: big.NewInt(1000),
+				Precision:     100,
+				Currency:      "USD",
+				Reference:     "ref_zero_amount",
+				Description:   "Test transaction",
+				Source:        "source1",
+				Destination:   "dest1",
+			},
+			wantErr: false,
 		},
 	}
 

--- a/model/model.go
+++ b/model/model.go
@@ -439,7 +439,17 @@ func convertDecimalToPrecise(transaction *Transaction) *big.Int {
 }
 
 // validate checks if the transaction has a positive amount.
+//
+// Amount is checked first, and unconditionally. PreciseAmount is derived from
+// Amount x Precision and is set on every path that reaches here, so the
+// PreciseAmount branch below always returns early — which left the Amount
+// check unreachable in practice. A negative Amount paired with a negative
+// Precision yields a positive PreciseAmount, so checking only the product
+// silently accepted a transaction whose own recorded amount was negative.
 func (transaction *Transaction) validate() error {
+	if transaction.Amount < 0 {
+		return errors.New("transaction amount must be positive")
+	}
 	if transaction.PreciseAmount != nil {
 		if transaction.PreciseAmount.Sign() <= 0 {
 			return errors.New("transaction precise amount must be positive")


### PR DESCRIPTION
## Summary

A transaction with a negative `amount` is **accepted and applied** when `precision` is also negative, because precision multiplies:

```
amount(-25) × precision(-100) = precise_amount(+2500)
```

The product is positive, so every downstream positivity check passes and the transaction applies normally — but `amount: -25` and `precision: -100` are **persisted as sent**.

```bash
curl -X POST /transactions -d '{
  "amount": -25, "precision": -100,
  "currency": "USD", "source": "bln_A", "destination": "bln_B",
  "reference": "...", "description": "...",
  "allow_overdraft": true, "skip_queue": true
}'
# -> HTTP 201, status: APPLIED, balances move
```

## Impact

**Balances stay correct.** Double-entry holds, insufficient-funds is still enforced, and no money is created or destroyed — I verified this on every surface, including through refund, void, and bulk-commit round-trips. This is not a fund-theft bug and I don't want to overstate it.

**The damage is to the record**, and to anything downstream that reads `amount`. In a ledger of four such transactions:

```
SUM of reported `amount`       = -105
SUM of actual `precise_amount` = 10500   (= +105.00)
```

A reporting or reconciliation job summing `amount` sees the sign inverted. And these records are invisible to positive-amount queries:

```
POST /transactions/filter  {"field":"amount","operator":"gt","value":0}  -> 0 rows
POST /transactions/filter  {"field":"amount","operator":"lt","value":0}  -> 9 rows
```

A routine "all transactions where amount > 0" report silently returns **none** of them, despite each having moved real money. `precise_amount / precision` also recomputes to `-25`, so the record is internally consistent in its wrongness.

## Why nothing caught it

`model.Transaction.validate()` already intends to enforce this:

```go
func (transaction *Transaction) validate() error {
	if transaction.PreciseAmount != nil {
		if transaction.PreciseAmount.Sign() <= 0 {
			return errors.New("transaction precise amount must be positive")
		}
		return nil          // <-- early return
	}
	if transaction.Amount <= 0 {          // <-- unreachable in practice
		return errors.New("transaction amount must be positive")
	}
	return nil
}
```

`PreciseAmount` is set on every path that reaches this, so the non-nil branch always returns early after checking only the (positive) product — the `Amount` check never runs. That left the effective guard against a negative `amount` to be an *unrelated split-distribution check* firing by accident on a negative total (`validateDistributions`, where `fixedTotalDec (0) > totalAmountDec (negative)` is true), which the sign flip bypasses.

Positive amounts are clearly the intended policy — the codebase says so in its own error text, `validateRequestedAmount` enforces it on the inflight-commit path, and #334 requests zero-amount as an *opt-in* precisely because it's currently rejected.

## Fix

Three parts:

1. Reject negative `amount` / `precise_amount` and negative `precision` in `RecordTransaction.ValidateRecordTransaction` — before anything is queued or persisted, covering every creation surface through one validator (bulk items included).
2. Check `Amount` unconditionally in `model.Transaction.validate()`, ahead of the `PreciseAmount` early-return, so the existing deep guard works as defense in depth.
3. Reject negative precision on `MonitorCondition`, which accepted it too.

**Zero is deliberately left alone** in both places: `precision: 0` means "not supplied" and is defaulted to 1 downstream (`model.ApplyPrecision`), and zero-amount handling has existing semantics (#137, #334) this change should not alter.

## Test plan

- [x] 7 new cases in `TestValidateRecordTransaction` covering the bypass, each negative field alone, and the two must-not-break zero cases
- [x] **All 12 surfaces that previously accepted the bypass now return 400**: plain (both queue modes), inflight, scheduled, `precise_amount` + negative precision, bulk, atomic bulk, unbounded scale (`-1 × -1e9`), negative amount with normal precision, negative `precise_amount`, split fan-in, and balance monitors
- [x] **8 legitimate-traffic regression cases still pass**: normal transaction, `precision: 0`, `precise_amount`-only, inflight, split fan-out, bulk, balance monitor, scheduled
- [x] Zero negative-amount records reach the ledger after the full matrix
- [x] `go test -short ./api/... ./model/... .` passes
- [x] Full `go test -short ./...` — `cmd`, `database`, `internal/request`, `internal/search` fail identically without this change (TypeSense/network-sandbox/balance-snapshot flakiness, unrelated to validation)

Found while adversarially testing the dry-run preview PR (#349) against the real API; unrelated to that PR and lives in existing core validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)