### PR TITLE
test(chain): wait on this test's own transaction, not the whole table

### DIFF
--- a/chain_worker_test.go
+++ b/chain_worker_test.go
@@ -18,6 +18,7 @@ package blnk
 
 import (
 	"context"
+	"database/sql"
 	"strings"
 	"sync"
 	"testing"
@@ -103,10 +104,31 @@ func TestChainProcessor_ChainsAcrossTicks(t *testing.T) {
 	defer p.Stop()
 	assert.True(t, p.IsRunning())
 
+	// Wait on this test's own transaction rather than on
+	// CountUnchainedTransactions, which counts every unchained row in the
+	// database. That global count only reaches zero when no other test has
+	// left unchained rows behind, so the assertion depended on which tests
+	// ran first: it passed in a full-suite run (TestChain_SealsTransactions
+	// happens to drain the backlog via chainAll first) and failed when this
+	// test ran alone against a database that already had rows in it.
+	//
+	// The wait is also why that dependence was time-zone sensitive.
+	// transactions.created_at is a naive TIMESTAMP written from local
+	// time.Now(), so a database carrying rows recorded under different TZ
+	// settings holds created_at values in different frames, and the
+	// created_at < cutoff bound shared by the counter and the chainer then
+	// admits a different set of rows depending on the TZ of the run.
+	//
+	// What this test actually verifies is the line below it: that the
+	// processor picks the transaction up on a poll tick. Scope the wait to
+	// that, and the test stops depending on unrelated rows entirely.
+	conn := ds.(*database.Datasource).Conn
 	require.Eventually(t, func() bool {
-		n, err := ds.CountUnchainedTransactions(ctx, time.Now())
-		return err == nil && n == 0
-	}, 15*time.Second, 200*time.Millisecond, "processor should drain the backlog")
+		var seq sql.NullInt64
+		err := conn.QueryRowContext(ctx,
+			`SELECT chain_seq FROM blnk.transactions WHERE transaction_id = $1`, id).Scan(&seq)
+		return err == nil && seq.Valid
+	}, 15*time.Second, 200*time.Millisecond, "processor should chain the transaction across poll ticks")
 
 	assertSealed(t, ds, id)
 }


### PR DESCRIPTION
## Summary

`TestChainProcessor_ChainsAcrossTicks` records one transaction, starts the processor, then waits for **`CountUnchainedTransactions` to reach zero** before asserting that its own transaction was sealed.

```go
require.Eventually(t, func() bool {
    n, err := ds.CountUnchainedTransactions(ctx, time.Now())   // every row in the DB
    return err == nil && n == 0
}, 15*time.Second, 200*time.Millisecond, "processor should drain the backlog")

assertSealed(t, ds, id)                                        // ...but only this one matters
```

That counter covers **every unchained row in the database**, so the wait only succeeds when no other test has left unchained rows behind. The test passes or fails based on what ran before it — green in a full-suite run (where `TestChain_SealsTransactions` drains the backlog via `chainAll` first), red when run alone against a database that already has rows in it.

## Why it looked time-zone sensitive

`transactions.created_at` is a naive `TIMESTAMP` written from local `time.Now()`. A database holding rows recorded under different `TZ` settings holds `created_at` values in **different frames**, so the `created_at < cutoff` bound that the counter and the chainer share admits a different set of rows depending on the TZ of the run.

Neither condition alone reproduced it:

| database | TZ | result |
|---|---|---|
| populated | `UTC` | passes |
| clean | `Asia/Kolkata` | passes |
| populated | `Asia/Kolkata` | **fails** |

Only the combination fails — which is exactly why it reads as flaky.

## Fix

The line immediately after the wait, `assertSealed(t, ds, id)`, is what this test is actually for: **the processor picks the transaction up on a poll tick.** Scope the wait to that same transaction and the test stops depending on unrelated rows, in any time zone.

No production change — test only.

## Test plan

- [x] Against the exact database state and time zone that reproduced it: **red 3/3 on `main`, green 3/3 with this change**
- [x] Green at **UTC**, **Asia/Kolkata (+5:30)**, **America/New_York (−5)**, **Pacific/Kiritimati (+14)**
- [x] Full `go test -short ./...` passes

Found while auditing test failures during work on #349.

### Related

The naive-`TIMESTAMP` / `TIMESTAMPTZ` split that made this look time-zone dependent is a real production bug in its own right — `GetBalanceAtTime` silently returns wrong historical balances on non-UTC servers. That is fixed separately in #363; this PR is only the test-hygiene half.

Running CI in one non-UTC time zone would surface both classes of problem for free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)