### PR TITLE
fix(transactions): reject splitting sources and destinations at once

### DIFF
--- a/api/model/model.go
+++ b/api/model/model.go
@@ -63,6 +63,30 @@ func destinationOrDestinationsValidation(t *RecordTransaction) validation.RuleFu
 	}
 }
 
+// splitOnOneSideValidation rejects a transaction that splits both sides at
+// once.
+//
+// SplitTransactionPrecise distributes over one side only — it takes Sources
+// when they are present and Destinations otherwise — and clears both on the
+// legs it produces. A transaction carrying both therefore has its
+// Destinations silently dropped, and every leg is left with an empty
+// Destination, which surfaces downstream as a lookup for a balance with a
+// blank id:
+//
+//	Balance with ID '' not found
+//
+// That names neither the field at fault nor the reason, for a request the
+// ledger cannot express in the first place. Reject it where the shape is
+// still visible.
+func splitOnOneSideValidation(t *RecordTransaction) validation.RuleFunc {
+	return func(value interface{}) error {
+		if len(t.Sources) > 0 && len(t.Destinations) > 0 {
+			return errors.New("a transaction can split either sources or destinations, not both")
+		}
+		return nil
+	}
+}
+
 func (l *CreateLedger) ValidateCreateLedger() error {
 	return validation.ValidateStruct(l,
 		validation.Field(&l.Name, validation.Required),
@@ -183,7 +207,7 @@ func (t *RecordTransaction) ValidateRecordTransaction() error {
 		validation.Field(&t.Currency, validation.Required),
 		validation.Field(&t.Reference, validation.Required),
 		validation.Field(&t.Description, validation.Required),
-		validation.Field(&t.Source, validation.By(sourceOrSourcesValidation(t))),
+		validation.Field(&t.Source, validation.By(sourceOrSourcesValidation(t)), validation.By(splitOnOneSideValidation(t))),
 		validation.Field(&t.Destination, validation.By(destinationOrDestinationsValidation(t))),
 		validation.Field(&t.ScheduledFor, validation.When(t.ScheduledFor != "", validation.By(func(value interface{}) error {
 			dateStr, ok := value.(string)

--- a/api/model/model_test.go
+++ b/api/model/model_test.go
@@ -698,3 +698,90 @@ func TestToBalanceMonitor(t *testing.T) {
 	assert.Equal(t, createMonitor.Condition.Value, monitor.Condition.Value)
 	assert.Equal(t, createMonitor.Condition.Precision, monitor.Condition.Precision)
 }
+
+// TestSplitOnOneSideValidation pins that a transaction cannot split both
+// sides at once. SplitTransactionPrecise distributes over Sources when they
+// are present and Destinations otherwise, clearing both on the legs it
+// produces, so a transaction carrying both had its Destinations silently
+// dropped and every leg left with an empty Destination — reported downstream
+// as "Balance with ID ” not found", which names neither the field at fault
+// nor the reason.
+func TestSplitOnOneSideValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		transaction RecordTransaction
+		wantErr     bool
+	}{
+		{
+			name: "Invalid - both sources and destinations split",
+			transaction: RecordTransaction{
+				Amount:      100,
+				Currency:    "USD",
+				Reference:   "ref_both",
+				Description: "d",
+				Sources: []model.Distribution{
+					{Identifier: "bln_a", Distribution: "60"},
+					{Identifier: "bln_b", Distribution: "40"},
+				},
+				Destinations: []model.Distribution{
+					{Identifier: "bln_c", Distribution: "60"},
+					{Identifier: "bln_d", Distribution: "40"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Valid - sources split only (fan-in)",
+			transaction: RecordTransaction{
+				Amount:      100,
+				Currency:    "USD",
+				Reference:   "ref_fanin",
+				Description: "d",
+				Sources: []model.Distribution{
+					{Identifier: "bln_a", Distribution: "60"},
+					{Identifier: "bln_b", Distribution: "40"},
+				},
+				Destination: "bln_c",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Valid - destinations split only (fan-out)",
+			transaction: RecordTransaction{
+				Amount:      100,
+				Currency:    "USD",
+				Reference:   "ref_fanout",
+				Description: "d",
+				Source:      "bln_a",
+				Destinations: []model.Distribution{
+					{Identifier: "bln_c", Distribution: "60"},
+					{Identifier: "bln_d", Distribution: "40"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Valid - neither side split",
+			transaction: RecordTransaction{
+				Amount:      100,
+				Currency:    "USD",
+				Reference:   "ref_plain",
+				Description: "d",
+				Source:      "bln_a",
+				Destination: "bln_b",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.transaction.ValidateRecordTransaction()
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

A transaction carrying **both** `sources[]` and `destinations[]` is accepted, then fails downstream with a message about neither:

```bash
POST /transactions
{
  "amount": 100, "precision": 100, "currency": "USD",
  "sources":      [{"identifier":"bln_a","distribution":"60"}, {"identifier":"bln_b","distribution":"40"}],
  "destinations": [{"identifier":"bln_c","distribution":"60"}, {"identifier":"bln_d","distribution":"40"}]
}

→ 404 TXN_NOT_FOUND   "Balance with ID '' not found"
```

## This combination is already documented as invalid

Both documentation pages state the restriction explicitly, and the second states it twice:

> **[Multiple sources](https://docs.blnkfinance.com/transactions/multiple-sources):** "When sending from multiple sources, you can only send to one destination."

> **[Multiple destinations](https://docs.blnkfinance.com/transactions/multiple-destinations):** "When sending to multiple destinations, you can only send from one source."

So this PR does not introduce a new rule — it enforces one the docs already commit to, and which the API has been accepting anyway.

## Why the failure looks unrelated to the cause

`SplitTransactionPrecise` distributes over **one side only** — `Sources` when present, `Destinations` otherwise — and clears both on the legs it produces:

```go
var ds []Distribution
if len(transaction.Sources) > 0 {
    ds = transaction.Sources
} else if len(transaction.Destinations) > 0 {
    ds = transaction.Destinations
}
```

A transaction carrying both therefore has its `Destinations` **silently dropped**, and every leg is left with an empty `Destination`. The blank id in that error is not something the caller sent — it is what the split left behind.

## The status is wrong too, not just the message

`404` reads as *"not there yet"*. A client with retry-on-not-found logic will retry a request that can never succeed, because the real fault is a malformed shape. This should be a `400` the caller never retries.

## Fix

Reject the combination while the shape is still visible, naming the actual conflict rather than a field that only *appears* missing as a consequence of it:

```
400 TXN_VALIDATION_ERROR
source: a transaction can split either sources or destinations, not both
```

The check sits alongside the existing `sourceOrSourcesValidation` / `destinationOrDestinationsValidation` rules, which already reject the singular-plus-plural combinations on each side individually. This closes the remaining one: plural on **both** sides.

## Test plan

- [x] New `TestSplitOnOneSideValidation` covering both-sides-split (rejected) and the three legitimate shapes — fan-in, fan-out, plain — accepted
- [x] Verified live: both-sides now returns the same `400` and identical message on the real and preview paths; fan-in, fan-out and plain transactions are unaffected
- [x] Full `go test -short ./...` passes (Postgres, Redis, TypeSense running)
- [x] `golangci-lint` clean

### Notes

Related: #183 ("Atomic bulk transactions fail when payload contains multiple sources or multiple destinations") covered a different failure for payloads of this shape. This PR addresses the validation gap that lets the shape through in the first place.

This also removes a preview/reality divergence for callers of the `dry_run` work in #349: that endpoint reported `400 TXN_VALIDATION_ERROR "destination is required"` for this input while the real post reported `404 TXN_NOT_FOUND` — the preview was right about the category and wrong about the reason, since the caller did supply destinations. Validation runs ahead of both branches, so the two now agree by construction, on a message that describes the actual mistake. The fix stands on its own regardless of #349.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
