### PR TITLE
fix(database): retry the connection instead of latching on the first failure

### DIFF
--- a/database/db.go
+++ b/database/db.go
@@ -28,9 +28,17 @@ import (
 )
 
 // Declare a package-level variable to hold the singleton instance.
+//
+// instanceMu guards instance. A plain mutex is used rather than sync.Once
+// because a Once latches on its first run whether that run succeeded or not:
+// if the very first connection attempt in the process failed, the body would
+// never run again, instance would stay nil forever, and every later caller
+// would be handed that nil back. Connecting is exactly the kind of work that
+// deserves a second attempt, so failures leave instance unset and the next
+// call tries again.
 var (
-	instance *Datasource
-	once     sync.Once
+	instance   *Datasource
+	instanceMu sync.Mutex
 )
 
 type Datasource struct {
@@ -61,26 +69,31 @@ func NewDataSource(configuration *config.Configuration) (IDataSource, error) {
 }
 
 // GetDBConnection ensures a single database connection instance.
+//
+// It never returns a nil *Datasource alongside a nil error: either the
+// singleton is returned, or the connection error that prevented building it.
 func GetDBConnection(configuration *config.Configuration) (*Datasource, error) {
-	var err error
-	once.Do(func() {
-		con, errConn := ConnectDB(configuration.DataSource)
-		if errConn != nil {
-			err = errConn
-			return
-		}
+	instanceMu.Lock()
+	defer instanceMu.Unlock()
 
-		cacheInstance, errCache := cache.NewCache()
-		if errCache != nil {
-			logrus.Errorf("Error creating cache: %v", errCache)
-			// Continue without cache instead of failing completely.
-		}
+	if instance != nil {
+		return instance, nil
+	}
 
-		instance = &Datasource{Conn: con, Cache: cacheInstance}
-	})
+	con, err := ConnectDB(configuration.DataSource)
 	if err != nil {
+		// Leave instance nil so a later call can retry rather than being
+		// permanently poisoned by one unreachable-database moment.
 		return nil, err
 	}
+
+	cacheInstance, errCache := cache.NewCache()
+	if errCache != nil {
+		logrus.Errorf("Error creating cache: %v", errCache)
+		// Continue without cache instead of failing completely.
+	}
+
+	instance = &Datasource{Conn: con, Cache: cacheInstance}
 	return instance, nil
 }
 

--- a/database/db.go
+++ b/database/db.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"database/sql"
 	"sync"
+	"sync/atomic"
 
 	"github.com/blnkfinance/blnk/config"
 	"github.com/blnkfinance/blnk/internal/cache"
@@ -29,15 +30,20 @@ import (
 
 // Declare a package-level variable to hold the singleton instance.
 //
-// instanceMu guards instance. A plain mutex is used rather than sync.Once
-// because a Once latches on its first run whether that run succeeded or not:
-// if the very first connection attempt in the process failed, the body would
-// never run again, instance would stay nil forever, and every later caller
-// would be handed that nil back. Connecting is exactly the kind of work that
-// deserves a second attempt, so failures leave instance unset and the next
-// call tries again.
+// sync.Once is not usable here: a Once latches on its first run whether that
+// run succeeded or not, so one failed connection attempt would leave instance
+// nil forever and hand that nil to every later caller. Connecting deserves a
+// second attempt, so a failure must leave the singleton unset and retryable.
+//
+// The retry has to be added without giving up the concurrency a completed
+// Once provides. GetDBConnection sits on request paths -- the health endpoint
+// and two transaction handlers call it per request -- so serializing every
+// caller on a mutex just to read a pointer that never changes again would be
+// a regression. instance is therefore read through an atomic pointer on the
+// fast path, and instanceMu is taken only to build the singleton, with a
+// second check under the lock so concurrent first callers connect once.
 var (
-	instance   *Datasource
+	instance   atomic.Pointer[Datasource]
 	instanceMu sync.Mutex
 )
 
@@ -73,17 +79,23 @@ func NewDataSource(configuration *config.Configuration) (IDataSource, error) {
 // It never returns a nil *Datasource alongside a nil error: either the
 // singleton is returned, or the connection error that prevented building it.
 func GetDBConnection(configuration *config.Configuration) (*Datasource, error) {
+	// Fast path: once built, the singleton is read without locking.
+	if ds := instance.Load(); ds != nil {
+		return ds, nil
+	}
+
 	instanceMu.Lock()
 	defer instanceMu.Unlock()
 
-	if instance != nil {
-		return instance, nil
+	// Another caller may have built it while we waited for the lock.
+	if ds := instance.Load(); ds != nil {
+		return ds, nil
 	}
 
 	con, err := ConnectDB(configuration.DataSource)
 	if err != nil {
-		// Leave instance nil so a later call can retry rather than being
-		// permanently poisoned by one unreachable-database moment.
+		// Leave the singleton unset so a later call can retry rather than
+		// being permanently poisoned by one unreachable-database moment.
 		return nil, err
 	}
 
@@ -93,8 +105,9 @@ func GetDBConnection(configuration *config.Configuration) (*Datasource, error) {
 		// Continue without cache instead of failing completely.
 	}
 
-	instance = &Datasource{Conn: con, Cache: cacheInstance}
-	return instance, nil
+	ds := &Datasource{Conn: con, Cache: cacheInstance}
+	instance.Store(ds)
+	return ds, nil
 }
 
 // ConnectDB establishes a database connection with pooling.

--- a/database/db_test.go
+++ b/database/db_test.go
@@ -1,7 +1,9 @@
 package database
 
 import (
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/blnkfinance/blnk/config"
 	"github.com/stretchr/testify/assert"
@@ -14,7 +16,7 @@ import (
 func resetDBSingleton() {
 	instanceMu.Lock()
 	defer instanceMu.Unlock()
-	instance = nil
+	instance.Store(nil)
 }
 
 func TestGetDBConnection_Singleton(t *testing.T) {
@@ -106,6 +108,78 @@ func TestNewDataSource_NoPanicAfterFailedAttempt(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, ds)
 	})
+}
+
+// Concurrent callers must all receive the same singleton, and exactly one
+// connection must be built. GetDBConnection is called per request by the
+// health endpoint and by two transaction handlers, so it has to stay safe
+// under parallel use.
+func TestGetDBConnection_ConcurrentCallersShareOneInstance(t *testing.T) {
+	resetDBSingleton()
+	t.Cleanup(resetDBSingleton)
+
+	cfg := &config.Configuration{
+		DataSource: config.DataSourceConfig{
+			Dns: "postgres://postgres:password@localhost/blnk?sslmode=disable",
+		},
+	}
+
+	const goroutines = 64
+	var wg sync.WaitGroup
+	results := make([]*Datasource, goroutines)
+	errs := make([]error, goroutines)
+
+	start := make(chan struct{})
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start // release them together to maximise overlap
+			results[i], errs[i] = GetDBConnection(cfg)
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i := 0; i < goroutines; i++ {
+		require.NoError(t, errs[i])
+		require.NotNil(t, results[i])
+		assert.Same(t, results[0], results[i], "every caller must get the same singleton")
+	}
+}
+
+// The fast path must not take the construction lock. If a future change moves
+// the lock back to the top of GetDBConnection, this deadlocks and fails on the
+// timeout rather than passing silently.
+func TestGetDBConnection_FastPathDoesNotBlockOnTheBuildLock(t *testing.T) {
+	resetDBSingleton()
+	t.Cleanup(resetDBSingleton)
+
+	cfg := &config.Configuration{
+		DataSource: config.DataSourceConfig{
+			Dns: "postgres://postgres:password@localhost/blnk?sslmode=disable",
+		},
+	}
+	// Build the singleton first so subsequent calls take the fast path.
+	ds, err := GetDBConnection(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, ds)
+
+	instanceMu.Lock() // hold the construction lock
+	defer instanceMu.Unlock()
+
+	done := make(chan *Datasource, 1)
+	go func() {
+		got, _ := GetDBConnection(cfg)
+		done <- got
+	}()
+
+	select {
+	case got := <-done:
+		assert.Same(t, ds, got)
+	case <-time.After(5 * time.Second):
+		t.Fatal("GetDBConnection blocked on the construction lock: the cached read is not lock-free")
+	}
 }
 
 func TestConnectDB_Success(t *testing.T) {

--- a/database/db_test.go
+++ b/database/db_test.go
@@ -1,17 +1,25 @@
 package database
 
 import (
-	"sync"
 	"testing"
 
 	"github.com/blnkfinance/blnk/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestGetDBConnection_Singleton(t *testing.T) {
-	// Reset the instance and once for testing purposes
+// resetDBSingleton clears the cached connection so a test can control what the
+// next GetDBConnection call sees. Tests that leave the singleton unset must not
+// strand later tests, so this only drops the pointer.
+func resetDBSingleton() {
+	instanceMu.Lock()
+	defer instanceMu.Unlock()
 	instance = nil
-	once = sync.Once{}
+}
+
+func TestGetDBConnection_Singleton(t *testing.T) {
+	// Reset the singleton so this test controls the first connection attempt.
+	resetDBSingleton()
 
 	// Create a mock configuration with a valid DNS string
 	mockConfig := &config.Configuration{
@@ -34,9 +42,8 @@ func TestGetDBConnection_Singleton(t *testing.T) {
 }
 
 func TestGetDBConnection_Failure(t *testing.T) {
-	// Reset the instance and once for testing purposes
-	instance = nil
-	once = sync.Once{}
+	// Reset the singleton so this test controls the first connection attempt.
+	resetDBSingleton()
 
 	// Create a mock configuration with invalid DNS
 	mockConfig := &config.Configuration{
@@ -48,6 +55,57 @@ func TestGetDBConnection_Failure(t *testing.T) {
 	// Expect error when connecting to DB with invalid DNS
 	_, err := GetDBConnection(mockConfig)
 	assert.Error(t, err)
+}
+
+// A failed first attempt must not poison the process. Before the singleton
+// retried, sync.Once latched on that failure: instance stayed nil, and because
+// the error was a fresh local on every call, later callers were handed
+// (nil, nil) — a nil datasource with nothing to check. NewDataSource then
+// dereferenced it, so an unreachable database at startup turned every
+// subsequent connection into a nil-pointer panic instead of a retry.
+func TestGetDBConnection_RetriesAfterFailedAttempt(t *testing.T) {
+	resetDBSingleton()
+	t.Cleanup(resetDBSingleton)
+
+	failing := &config.Configuration{
+		DataSource: config.DataSourceConfig{Dns: "invalid-dns"},
+	}
+	ds, err := GetDBConnection(failing)
+	assert.Error(t, err)
+	assert.Nil(t, ds, "a failed attempt must not yield a datasource")
+
+	working := &config.Configuration{
+		DataSource: config.DataSourceConfig{
+			Dns: "postgres://postgres:password@localhost/blnk?sslmode=disable",
+		},
+	}
+	ds2, err2 := GetDBConnection(working)
+	assert.NoError(t, err2)
+	require.NotNil(t, ds2, "a later attempt must reconnect, not return the nil left behind by the failure")
+}
+
+// The panic this guards against was previously masked: two integration tests
+// recovered from it and reported themselves as skipped, so it never surfaced.
+func TestNewDataSource_NoPanicAfterFailedAttempt(t *testing.T) {
+	resetDBSingleton()
+	t.Cleanup(resetDBSingleton)
+
+	failing := &config.Configuration{
+		DataSource: config.DataSourceConfig{Dns: "invalid-dns"},
+	}
+	_, err := GetDBConnection(failing)
+	require.Error(t, err)
+
+	working := &config.Configuration{
+		DataSource: config.DataSourceConfig{
+			Dns: "postgres://postgres:password@localhost/blnk?sslmode=disable",
+		},
+	}
+	require.NotPanics(t, func() {
+		ds, err := NewDataSource(working)
+		assert.NoError(t, err)
+		assert.NotNil(t, ds)
+	})
 }
 
 func TestConnectDB_Success(t *testing.T) {

--- a/database/transactions_test.go
+++ b/database/transactions_test.go
@@ -585,12 +585,6 @@ func TestRecordTransactionWithBalances_AtomicSuccess_Integration(t *testing.T) {
 		t.Skip("Skipping integration test in short mode")
 	}
 
-	defer func() {
-		if r := recover(); r != nil {
-			t.Skipf("Skipping test: recovered from panic (likely database connection issue): %v", r)
-		}
-	}()
-
 	ctx := context.Background()
 	cnf := &config.Configuration{
 		Redis: config.RedisConfig{
@@ -698,12 +692,6 @@ func TestRecordTransactionWithBalances_DuplicateTxnID_Rollback_Integration(t *te
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
-
-	defer func() {
-		if r := recover(); r != nil {
-			t.Skipf("Skipping test: recovered from panic (likely database connection issue): %v", r)
-		}
-	}()
 
 	ctx := context.Background()
 	cnf := &config.Configuration{


### PR DESCRIPTION
## Summary

`GetDBConnection` builds its singleton inside a `sync.Once`. A `Once` latches on its first run **whether that run succeeded or not** — the standard library is explicit that there is no retry:

> "Do calls the function f if and only if Do is being called for the first time for this instance of Once." … "If f panics, Do considers it to have returned; future calls of Do return without calling f." — [pkg.go.dev/sync](https://pkg.go.dev/sync#Once.Do)

So one failed connect is permanent:

```go
var (instance *Datasource; once sync.Once)

func GetDBConnection(cfg *config.Configuration) (*Datasource, error) {
	var err error            // fresh local — nil on every later call
	once.Do(func() {
		con, errConn := ConnectDB(cfg.DataSource)
		if errConn != nil { err = errConn; return }   // instance left nil
		instance = &Datasource{Conn: con, Cache: cacheInstance}
	})
	if err != nil { return nil, err }
	return instance, nil     // nil, with a nil error
}
```

If the first attempt in the process fails, `instance` stays nil and the `Once` never runs again. Every later caller finds `err == nil` — it is a fresh local, and the body that set it will never execute again — and is handed **`(nil, nil)`**: a nil datasource with nothing to check.

`NewDataSource` then dereferences it:

```go
con, err := GetDBConnection(configuration)
if err != nil { return nil, err }            // err is nil, so we continue
con.Conn.ExecContext(ctx, "SET search_path TO blnk")   // con is nil → panic
```

So a database that is briefly unreachable at startup — an ordinary container-ordering race — does not produce a retry or an error. It produces a nil-pointer panic on **every subsequent connection attempt for the life of the process**, and the failure is permanent even after the database comes up.

## Why this was invisible

Two integration tests hit this panic, recover from it, and report themselves as skipped:

```go
defer func() {
	if r := recover(); r != nil {
		t.Skipf("Skipping test: recovered from panic (likely database connection issue): %v", r)
	}
}()
```

The trigger is in-suite and deterministic: `TestGetDBConnection_Failure` resets the singleton and connects to `invalid-dns`, consuming the `Once` with a failure. Everything after it in the package gets `(nil, nil)`.

The consequence is that `TestRecordTransactionWithBalances_AtomicSuccess_Integration` and `TestRecordTransactionWithBalances_DuplicateTxnID_Rollback_Integration` — the two tests covering transaction atomicity and rollback — have not been running. The package still reports `ok`, so nothing indicated the loss of coverage. The label on the skip ("likely database connection issue") points at the environment, which is why it reads as benign.

## Fix

Guard the singleton with a mutex rather than a `Once`. Connecting is exactly the kind of work that deserves a second attempt, so a failed attempt leaves `instance` unset and the next call tries again:

```go
instanceMu.Lock()
defer instanceMu.Unlock()

if instance != nil { return instance, nil }

con, err := ConnectDB(configuration.DataSource)
if err != nil { return nil, err }   // instance stays nil; next call retries
...
instance = &Datasource{Conn: con, Cache: cacheInstance}
return instance, nil
```

The singleton contract is unchanged — one shared `*Datasource`, built once — but the function can no longer return a nil datasource alongside a nil error, and a transient outage is no longer permanent.

The two `recover`-to-`Skipf` blocks are removed so those tests execute.

## Test plan

- [x] Two new regression tests, both verified to **fail against the unfixed code**: `TestGetDBConnection_RetriesAfterFailedAttempt` fails with `Expected value not to be nil` (the `(nil, nil)` return), and `TestNewDataSource_NoPanicAfterFailedAttempt` fails on the latched error
- [x] The two previously-masked integration tests now run and pass rather than skipping
- [x] Suite-wide skips drop from 4 to 2; the remaining two are honest environment gates (`BLNK_TEST_PG_DUMP` unset, and a Slack timeout test)
- [x] Full `go test ./...`: 24/24 packages, 0 failures
- [x] `go test -race -p 1` on `./database/` and `./cmd/`: clean, no data races
- [x] `golangci-lint` introduces no new findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
