### PR TITLE
fix(server): honour server.ssl again instead of always serving plaintext

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -42,11 +42,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-/*
-serveTLS starts an HTTPS server with TLS enabled using CertMagic for automatic certificate management.
-It accepts a gin.Engine instance as the router and a ServerConfig struct for server configurations.
-If no domain is specified, the server will default to running on localhost.
-*/
 // resolveCertStoragePath returns the configured certificate storage path,
 // falling back to the default location when unset.
 func resolveCertStoragePath(conf config.ServerConfig) string {
@@ -65,7 +60,11 @@ func resolveTLSDomains(conf config.ServerConfig) []string {
 	return []string{conf.Domain}
 }
 
-func serveTLS(r *gin.Engine, conf config.ServerConfig) error {
+// newTLSServer builds the HTTPS server with CertMagic-managed certificates.
+//
+// It returns the server rather than serving it, so the HTTPS listener runs
+// through the same start-and-graceful-shutdown path as the plaintext one.
+func newTLSServer(r *gin.Engine, conf config.ServerConfig) (*http.Server, error) {
 	// Configure CertMagic's ACME (Automatic Certificate Management Environment) for automatic TLS
 	certmagic.DefaultACME.Agreed = true      // Agree to ACME TOS
 	certmagic.DefaultACME.Email = conf.Email // Set email for certificate recovery/notifications
@@ -75,29 +74,20 @@ func serveTLS(r *gin.Engine, conf config.ServerConfig) error {
 
 	// Define domain(s) for the certificate
 	if conf.Domain == "" {
-		logrus.Error("No domain specified, defaulting to localhost")
+		logrus.Warn("server.ssl is enabled but no domain is configured; defaulting to localhost")
 	}
 	domains := resolveTLSDomains(conf)
 
 	// Manage TLS certificates for the specified domains
 	if err := cfg.ManageSync(context.Background(), domains); err != nil {
-		return err
+		return nil, fmt.Errorf("failed to obtain a TLS certificate for %v: %w", domains, err)
 	}
 
-	// Create and configure the HTTPS server
-	server := &http.Server{
+	return &http.Server{
 		Addr:      ":" + conf.Port, // Server address and port
 		Handler:   r,               // Handler for HTTP requests (gin router)
 		TLSConfig: cfg.TLSConfig(), // TLS configuration from CertMagic
-	}
-
-	logrus.Errorf("Starting HTTPS server on %s\n", conf.Port)
-	// Start the HTTPS server with automatic certificate management
-	if err := server.ListenAndServeTLS("", ""); err != nil && err != http.ErrServerClosed {
-		logrus.Fatalf("Failed to start HTTPS server: %v", err)
-	}
-
-	return nil
+	}, nil
 }
 
 /*
@@ -274,13 +264,29 @@ func initializePostHog() (posthog.Client, string) {
 	return client, heartbeatID
 }
 
-func startServer(router *gin.Engine, port string) error {
-	server := newHTTPServer(router, port)
+func startServer(router *gin.Engine, conf config.ServerConfig) error {
+	var (
+		server *http.Server
+		serve  func() error
+		scheme string
+	)
+
+	if conf.SSL {
+		tlsServer, err := newTLSServer(router, conf)
+		if err != nil {
+			return err
+		}
+		server, scheme = tlsServer, "https"
+		serve = func() error { return server.ListenAndServeTLS("", "") }
+	} else {
+		server, scheme = newHTTPServer(router, conf.Port), "http"
+		serve = server.ListenAndServe
+	}
 
 	// Start server in goroutine
 	go func() {
-		logrus.Infof("Server started on port %s", port)
-		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		logrus.Infof("Server started on %s port %s", scheme, conf.Port)
+		if err := serve(); err != nil && err != http.ErrServerClosed {
 			logrus.Fatalf("Server error: %v", err)
 		}
 	}()
@@ -412,7 +418,7 @@ func serverCommands(b *blnkInstance) *cobra.Command {
 			}
 
 			// Start server
-			if err := startServer(router, cfg.Server.Port); err != nil {
+			if err := startServer(router, cfg.Server); err != nil {
 				logrus.Fatal(err)
 			}
 		},

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -78,9 +78,21 @@ func newTLSServer(r *gin.Engine, conf config.ServerConfig) (*http.Server, error)
 	}
 	domains := resolveTLSDomains(conf)
 
-	// Manage TLS certificates for the specified domains
+	// Manage TLS certificates for the specified domains.
+	//
+	// Issuance is an ACME challenge, not a local operation: CertMagic solves
+	// HTTP-01 on port 80 and TLS-ALPN-01 on port 443, independently of
+	// server.port, and the CA must reach both from the internet to validate
+	// the domain. The shipped docker-compose publishes only 5001, so a failure
+	// here is usually a missing port mapping rather than anything wrong with
+	// the certificate. Say so, because the raw ACME error does not.
 	if err := cfg.ManageSync(context.Background(), domains); err != nil {
-		return nil, fmt.Errorf("failed to obtain a TLS certificate for %v: %w", domains, err)
+		return nil, fmt.Errorf(
+			"failed to obtain a TLS certificate for %v: %w; "+
+				"ACME validation needs ports %d (HTTP-01) and %d (TLS-ALPN-01) reachable from the internet, "+
+				"separately from server.port=%s -- publish them (add \"80:80\" and \"443:443\" to the server "+
+				"service) or terminate TLS at a proxy and leave server.ssl false",
+			domains, err, certmagic.HTTPPort, certmagic.HTTPSPort, conf.Port)
 	}
 
 	return &http.Server{

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -34,9 +34,40 @@ import (
 )
 
 // Genuinely untestable in-process and deliberately not faked here: main(),
-// executeCLI's os.Exit path, ACME certificate issuance in serveTLS, and
+// executeCLI's os.Exit path, ACME certificate issuance in newTLSServer, and
 // delivery of real SIGTERM signals (gracefulShutdown is tested by sending on
 // its quit channel instead).
+
+// startServer must consult conf.SSL. The regression this guards against was
+// silent: the SSL branch was dropped during a graceful-shutdown refactor, so
+// an operator following the "Enable HTTPs" guide got a plaintext listener and
+// no indication anything was wrong.
+//
+// Certificate issuance needs ACME, so this drives the failure path instead:
+// an unwritable certificate directory makes CertMagic fail before any network
+// call. Reaching that error at all proves the TLS path was entered. Were the
+// SSL flag ignored again, startServer would bind a plaintext listener and
+// block in gracefulShutdown rather than returning.
+func TestStartServerHonoursSSLFlag(t *testing.T) {
+	conf := config.ServerConfig{
+		SSL:             true,
+		Port:            "0",
+		Domain:          "ledger.invalid",
+		Email:           "ops@example.com",
+		CertStoragePath: filepath.Join(t.TempDir(), "unwritable", "certs"),
+	}
+	require.NoError(t, os.MkdirAll(filepath.Dir(conf.CertStoragePath), 0o500))
+
+	done := make(chan error, 1)
+	go func() { done <- startServer(gin.New(), conf) }()
+
+	select {
+	case err := <-done:
+		require.Error(t, err, "SSL enabled must not fall through to a plaintext listener")
+	case <-time.After(30 * time.Second):
+		t.Fatal("startServer did not return: the SSL flag was ignored and a plaintext listener started")
+	}
+}
 
 func TestRetryWithBackoff(t *testing.T) {
 	t.Run("succeeds after transient failures", func(t *testing.T) {


### PR DESCRIPTION
## Summary

`"ssl": true` has no effect. The server always serves plaintext HTTP.

`ServerConfig.SSL` is not read anywhere in non-test code:

```console
$ grep -rn 'SSL' --include=*.go . | grep -v _test.go | grep -v sslmode
config/config.go:111:	SSL    bool   `json:"ssl"     envconfig:"BLNK_SERVER_SSL"`
config/config.go:115:	Domain string `json:"domain"  envconfig:"BLNK_SERVER_SSL_DOMAIN"`
config/config.go:116:	Email  string `json:"ssl_email" envconfig:"BLNK_SERVER_SSL_EMAIL"`
```

Three declarations, no readers. The only listener is `startServer` → `ListenAndServe`, unconditionally, and `serveTLS` has no callers.

## How it happened

`37fac6c` ("security improvements", 2026-01-24) rewrote `startServer` for graceful shutdown and dropped the TLS branch in the process:

```diff
-func startServer(router *gin.Engine, cfg config.ServerConfig) error {
-	if cfg.SSL {
-		return serveTLS(router, cfg)
+func startServer(router *gin.Engine, port string) error {
```

`startServer` stopped receiving `ServerConfig` at all, so `cfg.SSL` became unreachable and `serveTLS` was orphaned. The call site changed from `startServer(router, cfg.Server)` to `startServer(router, cfg.Server.Port)`.

This reads as collateral damage from the refactor rather than a decision to drop TLS. **The same commit was actively investing in TLS** — it replaced `serveTLS`'s placeholder certificate path with a real one and added the `CertStoragePath` config field specifically to support it:

```diff
-	cfg.Storage = &certmagic.FileStorage{Path: "path/to/certmagic/storage"}
+	certPath := conf.CertStoragePath
+	if certPath == "" {
+		certPath = "/var/lib/blnk/certs"
+	}
+	cfg.Storage = &certmagic.FileStorage{Path: certPath}
```

Nothing else references `SSL`, so nothing failed to compile and nothing failed a test.

## The documentation still promises this works

[Enable HTTPs for Blnk Server](https://docs.blnkfinance.com/advanced/enable-https) is a full guide built on the flag:

> "Blnk supports HTTPs out of the box and simplifies how you secure your financial application."

> "Modify your `blnk.json` configuration file to enable HTTPs. Update the SSL flag to `"ssl": true` and provide your domain and email for SSL certificate notifications."

> "Your Blnk server will be initiated (including the automated process of obtaining an SSL certificate for your domain)."

An operator following it gets a plaintext listener on the same port, and no error, warning, or log line indicating the flag was ignored. Their verification step — `curl https://yourdomain.com:5001 -I` — fails with a TLS handshake error that looks like a DNS or certificate problem, since nothing points at the flag being unread. For a ledger, that is a bad way to discover TLS was never on.

## Fix

Restore the branch, and give the TLS path the graceful shutdown the refactor introduced for plaintext:

```go
if conf.SSL {
	tlsServer, err := newTLSServer(router, conf)
	if err != nil {
		return err
	}
	server, scheme = tlsServer, "https"
	serve = func() error { return server.ListenAndServeTLS("", "") }
} else {
	server, scheme = newHTTPServer(router, conf.Port), "http"
	serve = server.ListenAndServe
}
```

`serveTLS` becomes `newTLSServer`, returning the server instead of serving it, so both listeners share one start-and-shutdown path. Three incidental improvements fall out:

- the TLS listener previously had **no graceful shutdown at all** — it called `ListenAndServeTLS` directly and never reached `gracefulShutdown`
- a certificate failure returns a wrapped error naming the domains, instead of `logrus.Fatalf` from inside a goroutine
- an SSL-enabled server that cannot obtain a certificate now **fails to start** rather than silently falling back to plaintext
- the startup log states the scheme, so `http` vs `https` is visible immediately

The missing-domain case is downgraded from `logrus.Error` to `logrus.Warn`, since defaulting to localhost is the documented behaviour rather than an error.

## Test plan

- [x] `TestStartServerHonoursSSLFlag` — verified to **fail against the unfixed code** with `startServer did not return: the SSL flag was ignored and a plaintext listener started`
- [x] The test drives the certificate-failure path via an unwritable cert directory, so it needs **no network and no ACME**: it fails fast and deterministically (0.00s), and never touches Let's Encrypt from CI
- [x] `go test ./cmd/` passes
- [x] Resolves the `func serveTLS is unused` lint finding, which was the visible symptom of this regression
- [x] `gofmt` clean

### Note

Certificate issuance itself still cannot be exercised in-process; the existing comment in `cmd/server_test.go` listing what is deliberately not faked has been updated to name `newTLSServer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
