### PR TITLE
chore: clear the pre-existing golangci-lint findings

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -321,7 +321,7 @@ func gracefulShutdown(server *http.Server, quit <-chan os.Signal, timeout time.D
 // Renamed from initializeObservability to better reflect its purpose
 func initializeTelemetryAndObservability(ctx context.Context, cfg *config.Configuration) (posthog.Client, func(context.Context) error, error) {
 	var phClient posthog.Client
-	var tracingShutdown func(context.Context) error = func(context.Context) error { return nil }
+	tracingShutdown := func(context.Context) error { return nil }
 	var err error
 
 	// Initialize tracing if observability is enabled
@@ -372,7 +372,11 @@ func serverCommands(b *blnkInstance) *cobra.Command {
 				}()
 			}
 			if phClient != nil {
-				defer phClient.Close()
+				defer func() {
+					if err := phClient.Close(); err != nil {
+						logrus.Warnf("failed to close PostHog client: %v", err)
+					}
+				}()
 			}
 
 			// Initialize router (after OTel so /metrics handler is available)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -191,7 +191,7 @@ func TestLoadConfigFromFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create temporary file: %v", err)
 	}
-	defer os.Remove(tmpFile.Name()) // Clean up after the test
+	defer func() { _ = os.Remove(tmpFile.Name()) }() // Clean up after the test
 
 	// Sample configuration to write to the temp file
 	sampleConfig := Configuration{
@@ -209,11 +209,13 @@ func TestLoadConfigFromFile(t *testing.T) {
 	if err := json.NewEncoder(tmpFile).Encode(sampleConfig); err != nil {
 		t.Fatalf("Unable to write to temporary file: %v", err)
 	}
-	tmpFile.Close() // Close the file so loadConfigFromFile can open it
+	if err := tmpFile.Close(); err != nil { // Close the file so loadConfigFromFile can open it
+		t.Fatalf("Unable to close temporary file: %v", err)
+	}
 
-	// Set an environment variable to override the project name
-	os.Setenv("BLNK_PROJECT_NAME", "Env Project")
-	defer os.Unsetenv("BLNK_PROJECT_NAME") // Clean up after the test
+	// Set an environment variable to override the project name. t.Setenv
+	// restores the previous value when the test ends.
+	t.Setenv("BLNK_PROJECT_NAME", "Env Project")
 
 	// Load the configuration from the file
 	if err := loadConfigFromFile(tmpFile.Name()); err != nil {
@@ -287,7 +289,7 @@ func TestInitConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create temporary file: %v", err)
 	}
-	defer os.Remove(tmpFile.Name()) // Clean up after the test
+	defer func() { _ = os.Remove(tmpFile.Name()) }() // Clean up after the test
 
 	// Sample configuration to write to the temp file
 	sampleConfig := Configuration{
@@ -301,7 +303,9 @@ func TestInitConfig(t *testing.T) {
 	if err := json.NewEncoder(tmpFile).Encode(sampleConfig); err != nil {
 		t.Fatalf("Unable to write to temporary file: %v", err)
 	}
-	tmpFile.Close() // Close the file so InitConfig can open it
+	if err := tmpFile.Close(); err != nil { // Close the file so InitConfig can open it
+		t.Fatalf("Unable to close temporary file: %v", err)
+	}
 
 	// Attempt to initialize the configuration using the temporary file
 	if err := InitConfig(tmpFile.Name()); err != nil {

--- a/database/balance.go
+++ b/database/balance.go
@@ -970,7 +970,7 @@ func updateBalanceChunk(ctx context.Context, tx *sql.Tx, balances []*model.Balan
 			query.WriteString(",")
 		}
 		base := i*11 + 1
-		query.WriteString(fmt.Sprintf(
+		fmt.Fprintf(&query,
 			"($%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d)",
 			base,
 			base+1,
@@ -983,7 +983,7 @@ func updateBalanceChunk(ctx context.Context, tx *sql.Tx, balances []*model.Balan
 			base+8,
 			base+9,
 			base+10,
-		))
+		)
 		args = append(args,
 			balance.BalanceID,
 			balance.Balance.String(),
@@ -1452,7 +1452,8 @@ func (d Datasource) getMostRecentSnapshot(ctx context.Context, tx *sql.Tx, balan
 
 	err = snapshot.Scan(&snapshotBalance, &snapshotCredit, &snapshotDebit, &snapshotTime)
 
-	if err == nil {
+	switch err {
+	case nil:
 		// Snapshot found, use it as starting point
 		creditBalance, err = parseBigInt(snapshotCredit)
 		if err != nil {
@@ -1469,7 +1470,7 @@ func (d Datasource) getMostRecentSnapshot(ctx context.Context, tx *sql.Tx, balan
 			"debit":      snapshotDebit,
 		}).Debug("found snapshot for balance")
 		return creditBalance, debitBalance, snapshotTime, nil
-	} else if err == sql.ErrNoRows {
+	case sql.ErrNoRows:
 		// No snapshot found, calculate from genesis (all transactions)
 		logrus.WithField("balance_id", balanceID).Debug("no snapshot found, calculating from genesis")
 		return new(big.Int).SetInt64(0), new(big.Int).SetInt64(0), time.Time{}, nil

--- a/database/lineage.go
+++ b/database/lineage.go
@@ -189,7 +189,7 @@ func insertLineageOutboxesInTx(ctx context.Context, tx *sql.Tx, outboxes []*mode
 			query.WriteString(",")
 		}
 		base := len(args) + 1
-		query.WriteString(fmt.Sprintf("($%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d)", base, base+1, base+2, base+3, base+4, base+5, base+6, base+7, base+8, base+9))
+		fmt.Fprintf(&query, "($%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d)", base, base+1, base+2, base+3, base+4, base+5, base+6, base+7, base+8, base+9)
 		args = append(args,
 			outbox.TransactionID,
 			outbox.SourceBalanceID,

--- a/internal/pg-backups/pg-backup-drive.go
+++ b/internal/pg-backups/pg-backup-drive.go
@@ -182,7 +182,11 @@ func (bm *BackupManager) BackupToS3(ctx context.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to open file for S3 upload")
 	}
-	defer file.Close()
+	defer func() {
+		if cerr := file.Close(); cerr != nil {
+			log.Warnf("failed to close %s after S3 upload: %v", filePath, cerr)
+		}
+	}()
 
 	_, filename := filepath.Split(filePath) // Get the filename from the full path
 

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -1411,10 +1411,11 @@ func TestInflightTransactionFlowWithSkipQueueThenPartialCommitThenVoid(t *testin
 	hasVoid := false
 
 	for _, historyTxn := range txnHistory {
-		if historyTxn.Status == StatusApplied {
+		switch historyTxn.Status {
+		case StatusApplied:
 			hasApplied = true
 			require.Equal(t, partialAmount, historyTxn.Amount, "Applied transaction should have partial amount")
-		} else if historyTxn.Status == StatusVoid {
+		case StatusVoid:
 			hasVoid = true
 			remainingAmount := originalAmount - partialAmount
 			require.InDelta(t, remainingAmount, historyTxn.Amount, 0.01,

--- a/webhooks_test.go
+++ b/webhooks_test.go
@@ -127,7 +127,7 @@ func TestConnectionReuse(t *testing.T) {
 	// Create Blnk instance
 	blnk, err := NewBlnk(nil)
 	assert.NoError(t, err)
-	defer blnk.Close()
+	defer func() { _ = blnk.Close() }()
 
 	// Send multiple webhook requests directly (bypass queue for immediate testing)
 	numRequests := 10
@@ -191,7 +191,7 @@ func TestHTTPClientConfiguration(t *testing.T) {
 	// Create Blnk instance
 	blnk, err := NewBlnk(nil)
 	assert.NoError(t, err)
-	defer blnk.Close()
+	defer func() { _ = blnk.Close() }()
 
 	// Verify HTTP client is configured properly
 	assert.NotNil(t, blnk.httpClient, "HTTP client should be initialized")
@@ -241,7 +241,7 @@ func TestProcessWebhookWithReusedClient(t *testing.T) {
 
 	blnk, err := NewBlnk(nil)
 	assert.NoError(t, err)
-	defer blnk.Close()
+	defer func() { _ = blnk.Close() }()
 
 	// Store reference to the HTTP client
 	clientMutex.Lock()


### PR DESCRIPTION
## Summary

Sixteen `golangci-lint` findings that predate the current gate. CI runs the linter with `only-new-issues: true`, so these never failed a build and accumulated quietly — `main` reports them today.

No behaviour change.

## errcheck (11)

Unchecked `Close` / `Remove` / `Setenv` results. Closes now log or fail the test rather than discarding the error:

```go
- defer file.Close()
+ defer func() {
+ 	if cerr := file.Close(); cerr != nil {
+ 		log.Warnf("failed to close %s after S3 upload: %v", filePath, cerr)
+ 	}
+ }()
```

The two `os.Setenv` / `defer os.Unsetenv` pairs in `config_test.go` become `t.Setenv`, which restores the previous value automatically and removes the manual cleanup:

```go
- os.Setenv("BLNK_PROJECT_NAME", "Env Project")
- defer os.Unsetenv("BLNK_PROJECT_NAME")
+ t.Setenv("BLNK_PROJECT_NAME", "Env Project")
```

`tmpFile.Close()` in tests is now checked with `t.Fatalf`, since a failed close means the file the test is about to read may be incomplete.

## staticcheck (5)

Two `query.WriteString(fmt.Sprintf(...))` calls become `fmt.Fprintf(&query, ...)`, and two `if`/`else if` chains comparing one value become tagged switches:

```go
- if err == nil {
+ switch err {
+ case nil:
 	...
- } else if err == sql.ErrNoRows {
+ case sql.ErrNoRows:
```

## Not included

The seventeenth finding, `func serveTLS is unused`, is deliberately left alone here. It is not dead code — it is the visible symptom of a regression that made `"ssl": true` silently serve plaintext, and it is fixed in #370 by restoring the caller. Silencing it with `//nolint` would have hidden a real bug.

These two PRs are independent and can merge in either order; together they take `golangci-lint` on `main` to zero.

## Test plan

- [x] `golangci-lint run ./...` drops from 17 findings to 1 (the `serveTLS` one, addressed in #370)
- [x] `go test ./config/... ./database/... ./internal/pg-backups/... ./cmd/... .` all pass
- [x] `gofmt` clean

### Note

`database/identity_test.go` and `database/repository.go` are not `gofmt`-clean on `main`. They are untouched here to keep this diff to lint findings only, and are worth a separate pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
