### PR TITLE
fix(transactions): attribute split legs deterministically

### DIFF
--- a/model/transaction.go
+++ b/model/transaction.go
@@ -425,9 +425,33 @@ func (transaction *Transaction) SplitTransactionPrecise(ctx context.Context) ([]
 		return nil, err
 	}
 
+	// Walk the distributions in the order the caller supplied them rather than
+	// ranging over the map CalculateDistributionsPrecise returns.
+	//
+	// Go randomises map iteration, and both the write-back below and the
+	// reference suffix are positional, so map order decided which Distribution
+	// entry received which leg's TransactionID. With two sources that was wrong
+	// roughly a quarter of the time: the response told the caller that the
+	// first source's leg was some transaction id that actually belonged to the
+	// second. The "-1"/"-2" reference suffixes moved between identifiers the
+	// same way, so the same split produced a different identifier-to-reference
+	// mapping on each run.
+	//
+	// Iterating ds fixes both: leg n always belongs to ds[n], and every entry
+	// is matched to its own amount by identifier instead of by position.
 	var transactions []*Transaction
 	counter := 1
-	for direction, preciseAmount := range distributions {
+	emitted := make(map[string]bool, len(ds))
+	for _, d := range ds {
+		// The distribution map is keyed by identifier, so repeating one
+		// identifier yields a single merged amount. Emit it once; the extra
+		// entries share that leg rather than duplicating the money.
+		preciseAmount, ok := distributions[d.Identifier]
+		if !ok || emitted[d.Identifier] {
+			continue
+		}
+		emitted[d.Identifier] = true
+
 		newTransaction := *transaction                               // Create a copy of the original transaction
 		newTransaction.TransactionID = GenerateUUIDWithSuffix("txn") // Set the transaction ID
 		newTransaction.PreciseAmount = preciseAmount                 // Set the precise amount based on the distribution
@@ -440,12 +464,22 @@ func (transaction *Transaction) SplitTransactionPrecise(ctx context.Context) ([]
 		newTransaction.Destinations = nil                            // Clear the Destinations slice
 		newTransaction.ParentTransaction = transaction.TransactionID // Set the parent transaction ID
 
+		// Attribute the leg to every entry naming this identifier, so a
+		// repeated identifier does not leave one of its entries blank.
 		if len(transaction.Sources) > 0 {
-			newTransaction.Source = direction // Set the source
-			transaction.Sources[counter-1].TransactionID = newTransaction.TransactionID
+			newTransaction.Source = d.Identifier // Set the source
+			for i := range transaction.Sources {
+				if transaction.Sources[i].Identifier == d.Identifier {
+					transaction.Sources[i].TransactionID = newTransaction.TransactionID
+				}
+			}
 		} else if len(transaction.Destinations) > 0 {
-			newTransaction.Destination = direction // Set the destination
-			transaction.Destinations[counter-1].TransactionID = newTransaction.TransactionID
+			newTransaction.Destination = d.Identifier // Set the destination
+			for i := range transaction.Destinations {
+				if transaction.Destinations[i].Identifier == d.Identifier {
+					transaction.Destinations[i].TransactionID = newTransaction.TransactionID
+				}
+			}
 		}
 
 		newTransaction.Reference = fmt.Sprintf("%s-%d", transaction.Reference, counter)

--- a/model/transaction_split_attribution_test.go
+++ b/model/transaction_split_attribution_test.go
@@ -1,0 +1,144 @@
+package model
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func splitFanIn(t *testing.T, sources []Distribution) (*Transaction, []*Transaction) {
+	t.Helper()
+	txn := &Transaction{
+		TransactionID: "txn_parent",
+		Reference:     "ref",
+		Precision:     100,
+		PreciseAmount: big.NewInt(10000),
+		Amount:        100,
+		Currency:      "USD",
+		Destination:   "bln_dst",
+		Sources:       sources,
+	}
+	legs, err := txn.SplitTransactionPrecise(context.Background())
+	require.NoError(t, err)
+	return txn, legs
+}
+
+// Each Distribution entry must carry the id of the leg built for its own
+// identifier. The write-back and the reference suffix were both positional
+// while the loop ranged over a map, and Go randomises map iteration, so the
+// first source regularly received the second source's transaction id. Repeat
+// the split so a wrong ordering cannot pass by luck.
+func TestSplitTransactionPrecise_AttributesLegsToTheirOwnEntry(t *testing.T) {
+	const runs = 200
+	for i := 0; i < runs; i++ {
+		txn, legs := splitFanIn(t, []Distribution{
+			{Identifier: "bln_A", Distribution: "60%"},
+			{Identifier: "bln_B", Distribution: "40%"},
+		})
+		require.Len(t, legs, 2)
+
+		bySource := make(map[string]*Transaction, len(legs))
+		for _, leg := range legs {
+			bySource[leg.Source] = leg
+		}
+
+		for _, d := range txn.Sources {
+			leg := bySource[d.Identifier]
+			require.NotNil(t, leg, "no leg produced for %s", d.Identifier)
+			require.Equal(t, leg.TransactionID, d.TransactionID,
+				"entry %s carries the id of a different leg", d.Identifier)
+		}
+	}
+}
+
+// Leg references must be stable: the same split has to map the same identifier
+// to the same "-n" suffix on every run, or reconciling by reference attributes
+// an amount to the wrong balance.
+func TestSplitTransactionPrecise_ReferencesAreStable(t *testing.T) {
+	const runs = 200
+	for i := 0; i < runs; i++ {
+		_, legs := splitFanIn(t, []Distribution{
+			{Identifier: "bln_A", Distribution: "60%"},
+			{Identifier: "bln_B", Distribution: "40%"},
+		})
+		require.Len(t, legs, 2)
+
+		byRef := make(map[string]string, len(legs))
+		for _, leg := range legs {
+			byRef[leg.Reference] = leg.Source
+		}
+		assert.Equal(t, "bln_A", byRef["ref-1"], "first source must keep the first reference suffix")
+		assert.Equal(t, "bln_B", byRef["ref-2"], "second source must keep the second reference suffix")
+	}
+}
+
+// Legs must be produced in the order the caller supplied them.
+func TestSplitTransactionPrecise_PreservesInputOrder(t *testing.T) {
+	for i := 0; i < 50; i++ {
+		_, legs := splitFanIn(t, []Distribution{
+			{Identifier: "bln_A", Distribution: "50%"},
+			{Identifier: "bln_B", Distribution: "30%"},
+			{Identifier: "bln_C", Distribution: "20%"},
+		})
+		require.Len(t, legs, 3)
+		assert.Equal(t, []string{"bln_A", "bln_B", "bln_C"},
+			[]string{legs[0].Source, legs[1].Source, legs[2].Source})
+	}
+}
+
+// A repeated identifier collapses to one leg carrying the merged amount, so
+// iterating the caller's slice must not emit it twice and move the money
+// twice. Every entry naming that identifier is attributed to the single leg
+// rather than one of them being left blank.
+func TestSplitTransactionPrecise_RepeatedIdentifierEmitsOneLeg(t *testing.T) {
+	txn, legs := splitFanIn(t, []Distribution{
+		{Identifier: "bln_A", Distribution: "60"},
+		{Identifier: "bln_A", Distribution: "40"},
+	})
+
+	require.Len(t, legs, 1, "a repeated identifier must not produce two legs")
+	assert.Equal(t, "bln_A", legs[0].Source)
+	assert.Equal(t, 0, legs[0].PreciseAmount.Cmp(big.NewInt(10000)),
+		"the single leg must carry the merged amount, not a doubled one")
+
+	for i, d := range txn.Sources {
+		assert.Equal(t, legs[0].TransactionID, d.TransactionID,
+			"sources[%d] should be attributed to the merged leg", i)
+	}
+}
+
+// Fan-out must behave identically to fan-in.
+func TestSplitTransactionPrecise_DestinationsAttributedToTheirOwnEntry(t *testing.T) {
+	const runs = 100
+	for i := 0; i < runs; i++ {
+		txn := &Transaction{
+			TransactionID: "txn_parent",
+			Reference:     "ref",
+			Precision:     100,
+			PreciseAmount: big.NewInt(10000),
+			Amount:        100,
+			Currency:      "USD",
+			Source:        "bln_src",
+			Destinations: []Distribution{
+				{Identifier: "bln_X", Distribution: "70%"},
+				{Identifier: "bln_Y", Distribution: "30%"},
+			},
+		}
+		legs, err := txn.SplitTransactionPrecise(context.Background())
+		require.NoError(t, err)
+		require.Len(t, legs, 2)
+
+		byDest := make(map[string]*Transaction, len(legs))
+		for _, leg := range legs {
+			byDest[leg.Destination] = leg
+		}
+		for _, d := range txn.Destinations {
+			leg := byDest[d.Identifier]
+			require.NotNil(t, leg)
+			require.Equal(t, leg.TransactionID, d.TransactionID)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`SplitTransactionPrecise` ranges over the map returned by `CalculateDistributionsPrecise` while writing back **positionally**:

```go
for direction, preciseAmount := range distributions {   // map[string]*big.Int
    ...
    transaction.Sources[counter-1].TransactionID = newTransaction.TransactionID
    newTransaction.Reference = fmt.Sprintf("%s-%d", transaction.Reference, counter)
    counter++
```

This is guaranteed-unspecified behaviour, not an implementation quirk:

> "When iterating over a map with a range loop, the iteration order is not specified and is not guaranteed to be the same from one iteration to the next." — [Go Maps in Action](https://go.dev/blog/maps)

`counter` therefore walks the entries in an arbitrary order while indexing `Sources` by position, so which `Distribution` entry receives which leg is decided by chance.

## Measured impact

Splitting a two-source fan-in 200 times on `main`:

```
attribution mismatches: 96 out of 400 entries   (~24%)
reference seen: bln_A=ref-1  (152 times)
reference seen: bln_A=ref-2  ( 48 times)
reference seen: bln_B=ref-2  (152 times)
reference seen: bln_B=ref-1  ( 48 times)
```

Two silent consequences:

**Legs are attributed to the wrong balance.** Roughly a quarter of the time a `Distribution` entry carries the `TransactionID` of a *different* leg. The API response tells the caller that `sources[0]`'s leg is transaction *X* when *X* is actually `sources[1]`'s transaction. Nothing errors; the amounts are right, the attribution is not.

**Leg references are unstable.** The `-1` / `-2` suffixes move between identifiers from run to run, so `ref-1` means "the 60% leg" on one run and "the 40% leg" on the next. Anything reconciling by reference — the natural key for this — matches an amount to the wrong balance depending on which run produced it.

Both affect fan-in and fan-out, which are documented core features.

## Fix

Iterate `ds`, the caller's own slice, and look each amount up by identifier:

```go
for _, d := range ds {
    preciseAmount, ok := distributions[d.Identifier]
    ...
}
```

Leg *n* now belongs to `ds[n]`, and references are stable across runs.

### Repeated identifiers

The distribution map is keyed by identifier, so listing one identifier twice yields a **single merged amount**. Iterating the caller's slice naively would emit that merged amount once per entry and move the money twice, so a repeated identifier is emitted once. Every entry naming it is attributed to that single leg — which also fills in the blank `TransactionID` such an entry was previously left with:

```json
"sources": [
  {"identifier": "bln_A", "distribution": "60", "transaction_id": "txn_e392…"},
  {"identifier": "bln_A", "distribution": "40", "transaction_id": ""}
]
```

Money movement is unchanged in every case; this PR only corrects which entry each leg is reported against, and in what order.

## Test plan

- [x] Five new tests, all verified to **fail against unfixed `main`** — `AttributesLegsToTheirOwnEntry` fails with `entry bln_A carries the id of a different leg`, `ReferencesAreStable` with `first source must keep the first reference suffix`
- [x] Each attribution test repeats the split 100–200 times, so a wrong ordering cannot pass by luck
- [x] `RepeatedIdentifierEmitsOneLeg` pins that the merged amount is not doubled
- [x] Fan-out covered symmetrically
- [x] Full `go test ./...`: 24/24 packages, 0 failures
- [x] `golangci-lint ./model/...`: 0 issues; `gofmt` clean

### Note

Found while auditing the `dry_run` preview in #349. The preview reports one leg for a repeated identifier, which looked like a preview defect — it turned out to be a faithful mirror of what the splitter really does. The defect was upstream, in the splitter itself. This PR is independent of #349 and stands on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
