### PR TITLE
fix(refunds): don't refund a transaction's own refund

### DIFF
--- a/api/transaction_refund_idempotence_test.go
+++ b/api/transaction_refund_idempotence_test.go
@@ -1,0 +1,100 @@
+package api
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blnkfinance/blnk/model"
+)
+
+// balancePair reads both balances as plain strings for comparison.
+
+// A repeated refund must not move money.
+//
+// The refund of X is itself a child of X, so a second refund of X used to
+// select both X and the refund of X. The refund had not itself been refunded,
+// so it passed validation and was reversed -- re-applying the original payment
+// -- while X failed as already refunded. The aggregated error surfaced as 409
+// after the money had already moved, which reads to a caller like a safe
+// idempotency rejection.
+func TestRefundTwiceDoesNotReverseTheRefund(t *testing.T) {
+	router, b, err := setupRouter()
+	require.NoError(t, err)
+	src, dst := newDryRunFixture(t, b)
+
+	txn, err := b.QueueTransaction(t.Context(), &model.Transaction{
+		Reference: model.GenerateUUIDWithSuffix("refidem"), Source: src, Destination: dst,
+		Amount: 1, Precision: 100, Currency: "USD", SkipQueue: true,
+	})
+	require.NoError(t, err)
+
+	refund := func() int {
+		w := doJSON(router, http.MethodPost, "/refund-transaction/"+txn.TransactionID,
+			map[string]interface{}{"skip_queue": true})
+		return w.Code
+	}
+
+	require.Equal(t, http.StatusCreated, refund(), "the first refund must succeed")
+
+	srcAfterFirst, err := b.GetBalanceByID(t.Context(), src, nil, false)
+	require.NoError(t, err)
+	dstAfterFirst, err := b.GetBalanceByID(t.Context(), dst, nil, false)
+	require.NoError(t, err)
+
+	// Every further attempt must be inert, not just the second.
+	for attempt := 2; attempt <= 3; attempt++ {
+		assert.Equal(t, http.StatusConflict, refund(), "refund attempt %d should conflict", attempt)
+
+		srcNow, err := b.GetBalanceByID(t.Context(), src, nil, false)
+		require.NoError(t, err)
+		dstNow, err := b.GetBalanceByID(t.Context(), dst, nil, false)
+		require.NoError(t, err)
+
+		assert.Equal(t, srcAfterFirst.Balance.String(), srcNow.Balance.String(),
+			"refund attempt %d moved the source balance while reporting failure", attempt)
+		assert.Equal(t, dstAfterFirst.Balance.String(), dstNow.Balance.String(),
+			"refund attempt %d moved the destination balance while reporting failure", attempt)
+	}
+}
+
+// Split legs are children of the parent too, so excluding refunds by parentage
+// would have made them unrefundable. Excluding by the refund reference must
+// leave a fan-out refund working.
+func TestRefundStillRefundsSplitLegs(t *testing.T) {
+	router, b, err := setupRouter()
+	require.NoError(t, err)
+	src, dstA := newDryRunFixture(t, b)
+	_, dstB := newDryRunFixture(t, b)
+
+	txn, err := b.QueueTransaction(t.Context(), &model.Transaction{
+		Reference: model.GenerateUUIDWithSuffix("splitref"), Source: src,
+		Amount: 2, Precision: 100, Currency: "USD", SkipQueue: true,
+		Destinations: []model.Distribution{
+			{Identifier: dstA, Distribution: "50%"},
+			{Identifier: dstB, Distribution: "50%"},
+		},
+	})
+	require.NoError(t, err)
+
+	beforeA, err := b.GetBalanceByID(t.Context(), dstA, nil, false)
+	require.NoError(t, err)
+	beforeB, err := b.GetBalanceByID(t.Context(), dstB, nil, false)
+	require.NoError(t, err)
+	require.NotEqual(t, "0", beforeA.Balance.String(), "leg A should have been credited")
+	require.NotEqual(t, "0", beforeB.Balance.String(), "leg B should have been credited")
+
+	w := doJSON(router, http.MethodPost, "/refund-transaction/"+txn.TransactionID,
+		map[string]interface{}{"skip_queue": true})
+	require.Equal(t, http.StatusCreated, w.Code, "a fan-out refund must still work: %s", w.Body.String())
+
+	afterA, err := b.GetBalanceByID(t.Context(), dstA, nil, false)
+	require.NoError(t, err)
+	afterB, err := b.GetBalanceByID(t.Context(), dstB, nil, false)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, beforeA.Balance.String(), afterA.Balance.String(), "leg A should have been refunded")
+	assert.NotEqual(t, beforeB.Balance.String(), afterB.Balance.String(), "leg B should have been refunded")
+}

--- a/database/transaction_refunds.go
+++ b/database/transaction_refunds.go
@@ -44,11 +44,27 @@ func (d Datasource) GetRefundableTransactionsByParentID(ctx context.Context, par
 			-- Case 1: The transaction is the parent itself and is APPLIED
 			(t.transaction_id = $1 AND t.status = 'APPLIED')
 			
-			-- Case 2: The transaction is a child and is APPLIED or VOID
-			OR (t.parent_transaction = $1 AND t.status IN ('APPLIED', 'VOID'))
+			-- Case 2: The transaction is a child and is APPLIED or VOID.
+			--
+			-- A refund is itself a child of what it refunds: prepareRefundTransaction
+			-- sets ParentTransaction to the original's id and the reference to
+			-- "<original id>_refund". Without the exclusion below, refunding X a
+			-- second time selects both X and the refund of X. The refund has not
+			-- itself been refunded, so it passes validateTransactionForRefund and
+			-- is reversed -- which re-applies the original payment -- while X fails
+			-- as already refunded. The aggregated error surfaces as 409 after that
+			-- money has already moved.
+			--
+			-- Split legs are children too and must stay refundable, so exclude by
+			-- the refund reference rather than by parentage.
+			OR (t.parent_transaction = $1
+				AND t.status IN ('APPLIED', 'VOID')
+				AND t.reference IS DISTINCT FROM t.parent_transaction || '_refund')
 
 			-- Case 3: Transaction is APPLIED and linked via metadata QUEUED_PARENT_TRANSACTION
-			OR (t.status = 'APPLIED' AND t.meta_data->>'QUEUED_PARENT_TRANSACTION' = $1)
+			OR (t.status = 'APPLIED'
+				AND t.meta_data->>'QUEUED_PARENT_TRANSACTION' = $1
+				AND t.reference IS DISTINCT FROM t.meta_data->>'QUEUED_PARENT_TRANSACTION' || '_refund')
 
 		ORDER BY 
 			t.created_at DESC

--- a/database/transactions_test.go
+++ b/database/transactions_test.go
@@ -597,7 +597,7 @@ func TestRecordTransactionWithBalances_AtomicSuccess_Integration(t *testing.T) {
 			Dns: "localhost:6379",
 		},
 		DataSource: config.DataSourceConfig{
-			Dns: "postgres://postgres:password@localhost:5432/blnk?sslmode=disable",
+			Dns: "postgres://postgres:password@localhost/blnk?sslmode=disable",
 		},
 		Queue: config.QueueConfig{
 			WebhookQueue:     "webhook_queue_test",
@@ -711,7 +711,7 @@ func TestRecordTransactionWithBalances_DuplicateTxnID_Rollback_Integration(t *te
 			Dns: "localhost:6379",
 		},
 		DataSource: config.DataSourceConfig{
-			Dns: "postgres://postgres:password@localhost:5432/blnk?sslmode=disable",
+			Dns: "postgres://postgres:password@localhost/blnk?sslmode=disable",
 		},
 		Queue: config.QueueConfig{
 			WebhookQueue:     "webhook_queue_test",
@@ -1252,11 +1252,27 @@ func TestGetRefundableTransactionsByParentID_Success(t *testing.T) {
 			-- Case 1: The transaction is the parent itself and is APPLIED
 			(t.transaction_id = $1 AND t.status = 'APPLIED')
 			
-			-- Case 2: The transaction is a child and is APPLIED or VOID
-			OR (t.parent_transaction = $1 AND t.status IN ('APPLIED', 'VOID'))
+			-- Case 2: The transaction is a child and is APPLIED or VOID.
+			--
+			-- A refund is itself a child of what it refunds: prepareRefundTransaction
+			-- sets ParentTransaction to the original's id and the reference to
+			-- "<original id>_refund". Without the exclusion below, refunding X a
+			-- second time selects both X and the refund of X. The refund has not
+			-- itself been refunded, so it passes validateTransactionForRefund and
+			-- is reversed -- which re-applies the original payment -- while X fails
+			-- as already refunded. The aggregated error surfaces as 409 after that
+			-- money has already moved.
+			--
+			-- Split legs are children too and must stay refundable, so exclude by
+			-- the refund reference rather than by parentage.
+			OR (t.parent_transaction = $1
+				AND t.status IN ('APPLIED', 'VOID')
+				AND t.reference IS DISTINCT FROM t.parent_transaction || '_refund')
 
 			-- Case 3: Transaction is APPLIED and linked via metadata QUEUED_PARENT_TRANSACTION
-			OR (t.status = 'APPLIED' AND t.meta_data->>'QUEUED_PARENT_TRANSACTION' = $1)
+			OR (t.status = 'APPLIED'
+				AND t.meta_data->>'QUEUED_PARENT_TRANSACTION' = $1
+				AND t.reference IS DISTINCT FROM t.meta_data->>'QUEUED_PARENT_TRANSACTION' || '_refund')
 
 		ORDER BY 
 			t.created_at DESC
@@ -1304,11 +1320,27 @@ func TestGetRefundableTransactionsByParentID_Empty(t *testing.T) {
 			-- Case 1: The transaction is the parent itself and is APPLIED
 			(t.transaction_id = $1 AND t.status = 'APPLIED')
 			
-			-- Case 2: The transaction is a child and is APPLIED or VOID
-			OR (t.parent_transaction = $1 AND t.status IN ('APPLIED', 'VOID'))
+			-- Case 2: The transaction is a child and is APPLIED or VOID.
+			--
+			-- A refund is itself a child of what it refunds: prepareRefundTransaction
+			-- sets ParentTransaction to the original's id and the reference to
+			-- "<original id>_refund". Without the exclusion below, refunding X a
+			-- second time selects both X and the refund of X. The refund has not
+			-- itself been refunded, so it passes validateTransactionForRefund and
+			-- is reversed -- which re-applies the original payment -- while X fails
+			-- as already refunded. The aggregated error surfaces as 409 after that
+			-- money has already moved.
+			--
+			-- Split legs are children too and must stay refundable, so exclude by
+			-- the refund reference rather than by parentage.
+			OR (t.parent_transaction = $1
+				AND t.status IN ('APPLIED', 'VOID')
+				AND t.reference IS DISTINCT FROM t.parent_transaction || '_refund')
 
 			-- Case 3: Transaction is APPLIED and linked via metadata QUEUED_PARENT_TRANSACTION
-			OR (t.status = 'APPLIED' AND t.meta_data->>'QUEUED_PARENT_TRANSACTION' = $1)
+			OR (t.status = 'APPLIED'
+				AND t.meta_data->>'QUEUED_PARENT_TRANSACTION' = $1
+				AND t.reference IS DISTINCT FROM t.meta_data->>'QUEUED_PARENT_TRANSACTION' || '_refund')
 
 		ORDER BY 
 			t.created_at DESC
@@ -1350,11 +1382,27 @@ func TestGetRefundableTransactionsByParentID_QueryError(t *testing.T) {
 			-- Case 1: The transaction is the parent itself and is APPLIED
 			(t.transaction_id = $1 AND t.status = 'APPLIED')
 			
-			-- Case 2: The transaction is a child and is APPLIED or VOID
-			OR (t.parent_transaction = $1 AND t.status IN ('APPLIED', 'VOID'))
+			-- Case 2: The transaction is a child and is APPLIED or VOID.
+			--
+			-- A refund is itself a child of what it refunds: prepareRefundTransaction
+			-- sets ParentTransaction to the original's id and the reference to
+			-- "<original id>_refund". Without the exclusion below, refunding X a
+			-- second time selects both X and the refund of X. The refund has not
+			-- itself been refunded, so it passes validateTransactionForRefund and
+			-- is reversed -- which re-applies the original payment -- while X fails
+			-- as already refunded. The aggregated error surfaces as 409 after that
+			-- money has already moved.
+			--
+			-- Split legs are children too and must stay refundable, so exclude by
+			-- the refund reference rather than by parentage.
+			OR (t.parent_transaction = $1
+				AND t.status IN ('APPLIED', 'VOID')
+				AND t.reference IS DISTINCT FROM t.parent_transaction || '_refund')
 
 			-- Case 3: Transaction is APPLIED and linked via metadata QUEUED_PARENT_TRANSACTION
-			OR (t.status = 'APPLIED' AND t.meta_data->>'QUEUED_PARENT_TRANSACTION' = $1)
+			OR (t.status = 'APPLIED'
+				AND t.meta_data->>'QUEUED_PARENT_TRANSACTION' = $1
+				AND t.reference IS DISTINCT FROM t.meta_data->>'QUEUED_PARENT_TRANSACTION' || '_refund')
 
 		ORDER BY 
 			t.created_at DESC


### PR DESCRIPTION
Fixes #374.

## Summary

A repeated refund returns `409 Conflict` while silently **reversing the original refund** — re-applying the payment. A caller treating the conflict as a safe idempotency rejection has had its money moved anyway:

```
after payment        src=49900 dst=100
1st refund  HTTP 201 src=50000 dst=0      ← refunded correctly
2nd refund  HTTP 409 src=49900 dst=100    ← payment RE-APPLIED while reporting failure
3rd refund  HTTP 409 src=49900 dst=100    ← settles
```

Nothing in the `409` body indicates a balance changed.

## Cause

`POST /refund-transaction/:id` does not use the guarded single-transaction path. It fans out:

```go
a.blnk.ProcessTransactionInBatches(ctx, id, big.NewInt(0), 1, false,
    a.blnk.GetRefundableTransactionsByParentID,
    a.blnk.RefundWorkerWithRefundOptions(refundOptions))
```

and `prepareRefundTransaction` sets `ParentTransaction` to the original's id, so **the refund of X is itself an `APPLIED` child of X** — which Case 2 of the refundable query selects:

```sql
OR (t.parent_transaction = $1 AND t.status IN ('APPLIED', 'VOID'))
```

A second refund of X therefore selects `[refund-of-X, X]`:

- **refund-of-X** has not itself been refunded, so `validateTransactionForRefund` correctly passes. It is reversed — source and destination swap back — re-applying the original payment.
- **X** is already refunded, so the guard correctly rejects it.

`ProcessTransactionInBatches` aggregates the errors and returns one, so the handler responds `409` **after** the first leg has committed.

Both the guard and the batch runner behave exactly as written. The fault is that the refund is in the candidate set at all.

## Fix

Exclude the refund of the requested parent, by the reference `prepareRefundTransaction` assigns:

```sql
OR (t.parent_transaction = $1
    AND t.status IN ('APPLIED', 'VOID')
    AND t.reference IS DISTINCT FROM t.parent_transaction || '_refund')
```

Excluded **by reference rather than by parentage** deliberately: split legs are children of the parent too and must stay refundable. The same exclusion is applied to Case 3, which links through `QUEUED_PARENT_TRANSACTION`.

`IS DISTINCT FROM` rather than `<>` so a NULL reference does not drop a row.

## Not affected

Inflight commit/void use the same `ProcessTransactionInBatches` fan-out but are safe: `GetInflightTransactionsByParentID` constrains to `AND status = 'INFLIGHT'`, so a settled hold cannot be re-selected. Verified — a second commit returns `409` with balances unchanged. That status constraint is precisely what the refundable query lacked.

## Test plan

- [x] `TestRefundTwiceDoesNotReverseTheRefund` — verified to **fail against unfixed `main`** with `refund attempt 2 moved the source balance while reporting failure`. It checks attempts 2 *and* 3, so a fix that merely shifts the oscillation does not pass.
- [x] `TestRefundStillRefundsSplitLegs` — guards the regression the narrower fix would have caused: a fan-out refund must still reverse every leg.
- [x] Existing refund tests unaffected: `TestRefundTransaction_API`, `TestRefundAppliesDescriptionAndMetaData`, `TestRefundWithoutOverridesInherits`, `TestRefundWithoutBodyStillWorks`.
- [x] The three `sqlmock` expectations that pin this query's text updated to match.
- [x] `gofmt` clean; builds clean.

### Note on scope

This changes which transactions are *candidates* for refund; it does not change refund mechanics, amounts, or ordering.

Separately, and not addressed here: `ProcessTransactionInBatches` can still commit some legs and then return an aggregated error for others, so a caller can receive a failure response after a partial application. That is intended for bulk, which has an explicit `atomic` flag, but is worth considering for refunds, which present as a single operation. Noted in #374.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
