### PR TITLE
test(auth): cover wildcard scopes on /:id/metadata

### DIFF
--- a/api/middleware/auth_test.go
+++ b/api/middleware/auth_test.go
@@ -76,6 +76,15 @@ func TestAuthMiddleware_Authenticate(t *testing.T) {
 	metadataWriterKey, err := blnkService.CreateAPIKey(context.Background(), "metadata-writer", "test-owner", []string{"metadata:write"}, time.Now().Add(24*time.Hour))
 	assert.NoError(t, err)
 
+	wildcardAllKey, err := blnkService.CreateAPIKey(context.Background(), "wildcard-all", "test-owner", []string{"*:*"}, time.Now().Add(24*time.Hour))
+	assert.NoError(t, err)
+
+	wildcardWriteKey, err := blnkService.CreateAPIKey(context.Background(), "wildcard-write", "test-owner", []string{"*:write"}, time.Now().Add(24*time.Hour))
+	assert.NoError(t, err)
+
+	metadataWildcardActionKey, err := blnkService.CreateAPIKey(context.Background(), "metadata-wildcard-action", "test-owner", []string{"metadata:*"}, time.Now().Add(24*time.Hour))
+	assert.NoError(t, err)
+
 	tests := []struct {
 		name          string
 		path          string
@@ -583,6 +592,62 @@ func TestAuthMiddleware_Authenticate(t *testing.T) {
 			expectedCode:  http.StatusForbidden,
 			expectedError: "Insufficient permissions for metadata:write",
 		},
+		{
+			name:   "*:* wildcard scoped key allows POST /:id/metadata",
+			path:   "/:id/metadata",
+			method: "POST",
+			apiKey: wildcardAllKey.Key,
+			setupConfig: func() *config.Configuration {
+				return &config.Configuration{
+					Server: config.ServerConfig{
+						Secure: true,
+					},
+				}
+			},
+			expectedCode: http.StatusOK,
+		},
+		{
+			name:   "*:write wildcard scoped key allows POST /:id/metadata",
+			path:   "/:id/metadata",
+			method: "POST",
+			apiKey: wildcardWriteKey.Key,
+			setupConfig: func() *config.Configuration {
+				return &config.Configuration{
+					Server: config.ServerConfig{
+						Secure: true,
+					},
+				}
+			},
+			expectedCode: http.StatusOK,
+		},
+		{
+			name:   "metadata:* wildcard scoped key allows POST /:id/metadata",
+			path:   "/:id/metadata",
+			method: "POST",
+			apiKey: metadataWildcardActionKey.Key,
+			setupConfig: func() *config.Configuration {
+				return &config.Configuration{
+					Server: config.ServerConfig{
+						Secure: true,
+					},
+				}
+			},
+			expectedCode: http.StatusOK,
+		},
+		{
+			name:   "*:* wildcard scoped key allows POST /ldg_123/metadata",
+			path:   "/ldg_123/metadata",
+			method: "POST",
+			apiKey: wildcardAllKey.Key,
+			setupConfig: func() *config.Configuration {
+				return &config.Configuration{
+					Server: config.ServerConfig{
+						Secure: true,
+					},
+				}
+			},
+			expectedCode: http.StatusOK,
+		},
 	}
 
 	for _, tt := range tests {
@@ -694,6 +759,11 @@ func TestGetResourceFromPath(t *testing.T) {
 		{
 			name:     "/:id/metadata path",
 			path:     "/:id/metadata",
+			expected: ResourceMetadata,
+		},
+		{
+			name:     "/ldg_123/metadata entity path",
+			path:     "/ldg_123/metadata",
 			expected: ResourceMetadata,
 		},
 		{


### PR DESCRIPTION
Adds auth tests for wildcard scopes (*:*, *:write, metadata:*) on POST /:id/metadata.