### PR TITLE
test(refunds): harden idempotence coverage after #375

### DIFF
--- a/api/transaction_refund_idempotence_test.go
+++ b/api/transaction_refund_idempotence_test.go
@@ -1,16 +1,18 @@
 package api
 
 import (
+	"context"
+	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/blnkfinance/blnk/config"
 	"github.com/blnkfinance/blnk/model"
 )
-
-// balancePair reads both balances as plain strings for comparison.
 
 // A repeated refund must not move money.
 //
@@ -60,6 +62,49 @@ func TestRefundTwiceDoesNotReverseTheRefund(t *testing.T) {
 	}
 }
 
+// Default (queued) refund path: worker applies the reversal, then repeats are inert.
+func TestRefundQueuedThenRepeatDoesNotMoveBalances(t *testing.T) {
+	router, b, err := setupRouter()
+	require.NoError(t, err)
+
+	cnf, err := config.Fetch()
+	require.NoError(t, err)
+
+	queueName := fmt.Sprintf("%s_%d", cnf.Queue.TransactionQueue, 1)
+	cleanup := StartTestAsynqWorker(t, cnf, b, queueName)
+	defer cleanup()
+
+	src, dst := newDryRunFixture(t, b)
+
+	txn, err := b.QueueTransaction(t.Context(), &model.Transaction{
+		Reference: model.GenerateUUIDWithSuffix("refqueue"), Source: src, Destination: dst,
+		Amount: 1, Precision: 100, Currency: "USD", SkipQueue: true,
+	})
+	require.NoError(t, err)
+
+	w := doJSON(router, http.MethodPost, "/refund-transaction/"+txn.TransactionID, map[string]interface{}{})
+	require.Equal(t, http.StatusCreated, w.Code, "first queued refund must succeed: %s", w.Body.String())
+
+	appliedRef := model.RefundReference(txn.TransactionID) + "_q"
+	_, err = pollForTransactionStatus(context.Background(), b.GetDataSource(), appliedRef, "APPLIED", 200*time.Millisecond, 10*time.Second)
+	require.NoError(t, err, "worker must apply the queued refund")
+
+	srcAfterApply := balanceString(t, b, src)
+	dstAfterApply := balanceString(t, b, dst)
+
+	refund := func() int {
+		return doJSON(router, http.MethodPost, "/refund-transaction/"+txn.TransactionID, map[string]interface{}{}).Code
+	}
+
+	for attempt := 2; attempt <= 3; attempt++ {
+		assert.Equal(t, http.StatusConflict, refund(), "refund attempt %d should conflict", attempt)
+		assert.Equal(t, srcAfterApply, balanceString(t, b, src),
+			"refund attempt %d moved the source balance while reporting failure", attempt)
+		assert.Equal(t, dstAfterApply, balanceString(t, b, dst),
+			"refund attempt %d moved the destination balance while reporting failure", attempt)
+	}
+}
+
 // Split legs are children of the parent too, so excluding refunds by parentage
 // would have made them unrefundable. Excluding by the refund reference must
 // leave a fan-out refund working.
@@ -68,6 +113,10 @@ func TestRefundStillRefundsSplitLegs(t *testing.T) {
 	require.NoError(t, err)
 	src, dstA := newDryRunFixture(t, b)
 	_, dstB := newDryRunFixture(t, b)
+
+	srcPre := balanceString(t, b, src)
+	dstAPre := balanceString(t, b, dstA)
+	dstBPre := balanceString(t, b, dstB)
 
 	txn, err := b.QueueTransaction(t.Context(), &model.Transaction{
 		Reference: model.GenerateUUIDWithSuffix("splitref"), Source: src,
@@ -79,22 +128,27 @@ func TestRefundStillRefundsSplitLegs(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	beforeA, err := b.GetBalanceByID(t.Context(), dstA, nil, false)
-	require.NoError(t, err)
-	beforeB, err := b.GetBalanceByID(t.Context(), dstB, nil, false)
-	require.NoError(t, err)
-	require.NotEqual(t, "0", beforeA.Balance.String(), "leg A should have been credited")
-	require.NotEqual(t, "0", beforeB.Balance.String(), "leg B should have been credited")
+	srcPostPay := balanceString(t, b, src)
+	dstAPostPay := balanceString(t, b, dstA)
+	dstBPostPay := balanceString(t, b, dstB)
+	require.NotEqual(t, dstAPre, dstAPostPay, "leg A should have been credited")
+	require.NotEqual(t, dstBPre, dstBPostPay, "leg B should have been credited")
+	require.NotEqual(t, srcPre, srcPostPay, "source should have been debited")
 
 	w := doJSON(router, http.MethodPost, "/refund-transaction/"+txn.TransactionID,
 		map[string]interface{}{"skip_queue": true})
 	require.Equal(t, http.StatusCreated, w.Code, "a fan-out refund must still work: %s", w.Body.String())
 
-	afterA, err := b.GetBalanceByID(t.Context(), dstA, nil, false)
-	require.NoError(t, err)
-	afterB, err := b.GetBalanceByID(t.Context(), dstB, nil, false)
-	require.NoError(t, err)
+	assert.Equal(t, srcPre, balanceString(t, b, src), "source should be restored after refund")
+	assert.Equal(t, dstAPre, balanceString(t, b, dstA), "leg A should be restored after refund")
+	assert.Equal(t, dstBPre, balanceString(t, b, dstB), "leg B should be restored after refund")
+}
 
-	assert.NotEqual(t, beforeA.Balance.String(), afterA.Balance.String(), "leg A should have been refunded")
-	assert.NotEqual(t, beforeB.Balance.String(), afterB.Balance.String(), "leg B should have been refunded")
+func balanceString(t *testing.T, b interface {
+	GetBalanceByID(ctx context.Context, id string, include []string, withQueued bool) (*model.Balance, error)
+}, balanceID string) string {
+	t.Helper()
+	bal, err := b.GetBalanceByID(t.Context(), balanceID, nil, false)
+	require.NoError(t, err)
+	return bal.Balance.String()
 }

--- a/database/transaction_refunds.go
+++ b/database/transaction_refunds.go
@@ -29,11 +29,8 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-func (d Datasource) GetRefundableTransactionsByParentID(ctx context.Context, parentTransactionID string, batchSize int, offset int64) ([]*model.Transaction, error) {
-	ctx, span := otel.Tracer("transaction.database").Start(ctx, "GetRefundableTransactionsByParentID")
-	defer span.End()
-
-	rows, err := d.Conn.QueryContext(ctx, `
+func refundableTransactionsByParentIDSQL() string {
+	return fmt.Sprintf(`
 		SELECT 
 			t.transaction_id, t.parent_transaction, t.source, t.reference, t.amount, t.precise_amount, 
 			t.precision, t.currency, t.destination, t.description, t.status, t.created_at, 
@@ -44,32 +41,28 @@ func (d Datasource) GetRefundableTransactionsByParentID(ctx context.Context, par
 			-- Case 1: The transaction is the parent itself and is APPLIED
 			(t.transaction_id = $1 AND t.status = 'APPLIED')
 			
-			-- Case 2: The transaction is a child and is APPLIED or VOID.
-			--
-			-- A refund is itself a child of what it refunds: prepareRefundTransaction
-			-- sets ParentTransaction to the original's id and the reference to
-			-- "<original id>_refund". Without the exclusion below, refunding X a
-			-- second time selects both X and the refund of X. The refund has not
-			-- itself been refunded, so it passes validateTransactionForRefund and
-			-- is reversed -- which re-applies the original payment -- while X fails
-			-- as already refunded. The aggregated error surfaces as 409 after that
-			-- money has already moved.
-			--
-			-- Split legs are children too and must stay refundable, so exclude by
-			-- the refund reference rather than by parentage.
+			-- Case 2: APPLIED/VOID children, excluding auto-refunds (model.RefundReferenceSuffix).
+			-- Split legs stay refundable; refund rows are excluded by reference, not parentage.
 			OR (t.parent_transaction = $1
 				AND t.status IN ('APPLIED', 'VOID')
-				AND t.reference IS DISTINCT FROM t.parent_transaction || '_refund')
+				AND t.reference IS DISTINCT FROM t.parent_transaction || '%[1]s')
 
-			-- Case 3: Transaction is APPLIED and linked via metadata QUEUED_PARENT_TRANSACTION
+			-- Case 3: APPLIED rows linked via QUEUED_PARENT_TRANSACTION, same refund exclusion
 			OR (t.status = 'APPLIED'
 				AND t.meta_data->>'QUEUED_PARENT_TRANSACTION' = $1
-				AND t.reference IS DISTINCT FROM t.meta_data->>'QUEUED_PARENT_TRANSACTION' || '_refund')
+				AND t.reference IS DISTINCT FROM t.meta_data->>'QUEUED_PARENT_TRANSACTION' || '%[1]s')
 
 		ORDER BY 
 			t.created_at DESC
 		LIMIT $2 OFFSET $3
-	`, parentTransactionID, batchSize, offset)
+	`, model.RefundReferenceSuffix)
+}
+
+func (d Datasource) GetRefundableTransactionsByParentID(ctx context.Context, parentTransactionID string, batchSize int, offset int64) ([]*model.Transaction, error) {
+	ctx, span := otel.Tracer("transaction.database").Start(ctx, "GetRefundableTransactionsByParentID")
+	defer span.End()
+
+	rows, err := d.Conn.QueryContext(ctx, refundableTransactionsByParentIDSQL(), parentTransactionID, batchSize, offset)
 	if err != nil {
 		span.RecordError(err)
 		return nil, apierror.NewAPIError(apierror.ErrInternalServer, "Failed to retrieve refundable transactions", err)

--- a/database/transactions_test.go
+++ b/database/transactions_test.go
@@ -591,7 +591,7 @@ func TestRecordTransactionWithBalances_AtomicSuccess_Integration(t *testing.T) {
 			Dns: "localhost:6379",
 		},
 		DataSource: config.DataSourceConfig{
-			Dns: "postgres://postgres:password@localhost/blnk?sslmode=disable",
+			Dns: "postgres://postgres:password@localhost:5432/blnk?sslmode=disable",
 		},
 		Queue: config.QueueConfig{
 			WebhookQueue:     "webhook_queue_test",
@@ -699,7 +699,7 @@ func TestRecordTransactionWithBalances_DuplicateTxnID_Rollback_Integration(t *te
 			Dns: "localhost:6379",
 		},
 		DataSource: config.DataSourceConfig{
-			Dns: "postgres://postgres:password@localhost/blnk?sslmode=disable",
+			Dns: "postgres://postgres:password@localhost:5432/blnk?sslmode=disable",
 		},
 		Queue: config.QueueConfig{
 			WebhookQueue:     "webhook_queue_test",
@@ -1229,43 +1229,7 @@ func TestGetRefundableTransactionsByParentID_Success(t *testing.T) {
 	metaData := map[string]interface{}{"key": "value"}
 	metaDataJSON, _ := json.Marshal(metaData)
 
-	query := `
-		SELECT 
-			t.transaction_id, t.parent_transaction, t.source, t.reference, t.amount, t.precise_amount, 
-			t.precision, t.currency, t.destination, t.description, t.status, t.created_at, 
-			t.meta_data, t.scheduled_for, t.hash
-		FROM 
-			blnk.transactions t
-		WHERE 
-			-- Case 1: The transaction is the parent itself and is APPLIED
-			(t.transaction_id = $1 AND t.status = 'APPLIED')
-			
-			-- Case 2: The transaction is a child and is APPLIED or VOID.
-			--
-			-- A refund is itself a child of what it refunds: prepareRefundTransaction
-			-- sets ParentTransaction to the original's id and the reference to
-			-- "<original id>_refund". Without the exclusion below, refunding X a
-			-- second time selects both X and the refund of X. The refund has not
-			-- itself been refunded, so it passes validateTransactionForRefund and
-			-- is reversed -- which re-applies the original payment -- while X fails
-			-- as already refunded. The aggregated error surfaces as 409 after that
-			-- money has already moved.
-			--
-			-- Split legs are children too and must stay refundable, so exclude by
-			-- the refund reference rather than by parentage.
-			OR (t.parent_transaction = $1
-				AND t.status IN ('APPLIED', 'VOID')
-				AND t.reference IS DISTINCT FROM t.parent_transaction || '_refund')
-
-			-- Case 3: Transaction is APPLIED and linked via metadata QUEUED_PARENT_TRANSACTION
-			OR (t.status = 'APPLIED'
-				AND t.meta_data->>'QUEUED_PARENT_TRANSACTION' = $1
-				AND t.reference IS DISTINCT FROM t.meta_data->>'QUEUED_PARENT_TRANSACTION' || '_refund')
-
-		ORDER BY 
-			t.created_at DESC
-		LIMIT $2 OFFSET $3
-	`
+	query := refundableTransactionsByParentIDSQL()
 
 	mock.ExpectQuery(regexp.QuoteMeta(query)).
 		WithArgs("parent_txn_123", 100, int64(0)).
@@ -1297,43 +1261,7 @@ func TestGetRefundableTransactionsByParentID_Empty(t *testing.T) {
 	ds := Datasource{Conn: db}
 	ctx := context.Background()
 
-	query := `
-		SELECT 
-			t.transaction_id, t.parent_transaction, t.source, t.reference, t.amount, t.precise_amount, 
-			t.precision, t.currency, t.destination, t.description, t.status, t.created_at, 
-			t.meta_data, t.scheduled_for, t.hash
-		FROM 
-			blnk.transactions t
-		WHERE 
-			-- Case 1: The transaction is the parent itself and is APPLIED
-			(t.transaction_id = $1 AND t.status = 'APPLIED')
-			
-			-- Case 2: The transaction is a child and is APPLIED or VOID.
-			--
-			-- A refund is itself a child of what it refunds: prepareRefundTransaction
-			-- sets ParentTransaction to the original's id and the reference to
-			-- "<original id>_refund". Without the exclusion below, refunding X a
-			-- second time selects both X and the refund of X. The refund has not
-			-- itself been refunded, so it passes validateTransactionForRefund and
-			-- is reversed -- which re-applies the original payment -- while X fails
-			-- as already refunded. The aggregated error surfaces as 409 after that
-			-- money has already moved.
-			--
-			-- Split legs are children too and must stay refundable, so exclude by
-			-- the refund reference rather than by parentage.
-			OR (t.parent_transaction = $1
-				AND t.status IN ('APPLIED', 'VOID')
-				AND t.reference IS DISTINCT FROM t.parent_transaction || '_refund')
-
-			-- Case 3: Transaction is APPLIED and linked via metadata QUEUED_PARENT_TRANSACTION
-			OR (t.status = 'APPLIED'
-				AND t.meta_data->>'QUEUED_PARENT_TRANSACTION' = $1
-				AND t.reference IS DISTINCT FROM t.meta_data->>'QUEUED_PARENT_TRANSACTION' || '_refund')
-
-		ORDER BY 
-			t.created_at DESC
-		LIMIT $2 OFFSET $3
-	`
+	query := refundableTransactionsByParentIDSQL()
 
 	mock.ExpectQuery(regexp.QuoteMeta(query)).
 		WithArgs("nonexistent_parent", 100, int64(0)).
@@ -1359,43 +1287,7 @@ func TestGetRefundableTransactionsByParentID_QueryError(t *testing.T) {
 	ds := Datasource{Conn: db}
 	ctx := context.Background()
 
-	query := `
-		SELECT 
-			t.transaction_id, t.parent_transaction, t.source, t.reference, t.amount, t.precise_amount, 
-			t.precision, t.currency, t.destination, t.description, t.status, t.created_at, 
-			t.meta_data, t.scheduled_for, t.hash
-		FROM 
-			blnk.transactions t
-		WHERE 
-			-- Case 1: The transaction is the parent itself and is APPLIED
-			(t.transaction_id = $1 AND t.status = 'APPLIED')
-			
-			-- Case 2: The transaction is a child and is APPLIED or VOID.
-			--
-			-- A refund is itself a child of what it refunds: prepareRefundTransaction
-			-- sets ParentTransaction to the original's id and the reference to
-			-- "<original id>_refund". Without the exclusion below, refunding X a
-			-- second time selects both X and the refund of X. The refund has not
-			-- itself been refunded, so it passes validateTransactionForRefund and
-			-- is reversed -- which re-applies the original payment -- while X fails
-			-- as already refunded. The aggregated error surfaces as 409 after that
-			-- money has already moved.
-			--
-			-- Split legs are children too and must stay refundable, so exclude by
-			-- the refund reference rather than by parentage.
-			OR (t.parent_transaction = $1
-				AND t.status IN ('APPLIED', 'VOID')
-				AND t.reference IS DISTINCT FROM t.parent_transaction || '_refund')
-
-			-- Case 3: Transaction is APPLIED and linked via metadata QUEUED_PARENT_TRANSACTION
-			OR (t.status = 'APPLIED'
-				AND t.meta_data->>'QUEUED_PARENT_TRANSACTION' = $1
-				AND t.reference IS DISTINCT FROM t.meta_data->>'QUEUED_PARENT_TRANSACTION' || '_refund')
-
-		ORDER BY 
-			t.created_at DESC
-		LIMIT $2 OFFSET $3
-	`
+	query := refundableTransactionsByParentIDSQL()
 
 	mock.ExpectQuery(regexp.QuoteMeta(query)).
 		WithArgs("parent_txn_123", 100, int64(0)).

--- a/model/transaction_refund.go
+++ b/model/transaction_refund.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2024 Blnk Finance Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package model
+
+// RefundReferenceSuffix is appended to the original transaction id to form
+// the refund transaction's reference (see docs.blnkfinance.com/reference/refund-transaction).
+const RefundReferenceSuffix = "_refund"
+
+// RefundReference returns the canonical reference for a refund of originalTransactionID.
+func RefundReference(originalTransactionID string) string {
+	return originalTransactionID + RefundReferenceSuffix
+}

--- a/model/transaction_refund_test.go
+++ b/model/transaction_refund_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2024 Blnk Finance Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRefundReference(t *testing.T) {
+	const original = "txn_abc123"
+	assert.Equal(t, "txn_abc123_refund", RefundReference(original))
+	assert.Equal(t, original+RefundReferenceSuffix, RefundReference(original))
+}

--- a/transaction_core_coverage_test.go
+++ b/transaction_core_coverage_test.go
@@ -199,7 +199,7 @@ func TestRefundTransaction_DeterministicReference(t *testing.T) {
 
 	refund, err := b.RefundTransaction(context.Background(), txn.TransactionID, true)
 	require.NoError(t, err)
-	assert.Equal(t, txn.TransactionID+"_refund", refund.Reference,
+	assert.Equal(t, model.RefundReference(txn.TransactionID), refund.Reference,
 		"refund reference must be deterministic for idempotency")
 }
 

--- a/transaction_refunds.go
+++ b/transaction_refunds.go
@@ -199,7 +199,7 @@ type RefundOptions struct {
 func prepareRefundTransaction(originalTxn *model.Transaction, opts RefundOptions) *model.Transaction {
 	newTransaction := *originalTxn // Create a copy
 	newTransaction.TransactionID = model.GenerateUUIDWithSuffix("txn")
-	newTransaction.Reference = fmt.Sprintf("%s_refund", originalTxn.TransactionID)
+	newTransaction.Reference = model.RefundReference(originalTxn.TransactionID)
 	newTransaction.ParentTransaction = originalTxn.TransactionID
 	newTransaction.Source = originalTxn.Destination // Swap source and destination
 	newTransaction.Destination = originalTxn.Source


### PR DESCRIPTION
Centralize the refund reference convention in model.RefundReference so prepareRefundTransaction and the refundable query exclusion stay in sync. Add a queued-refund worker test that asserts repeat requests are balance-inert, and tighten split-leg refund assertions to verify full balance restoration. Revert unrelated integration-test DSN port edits and dedupe sqlmock query text.