### PR TITLE
fix(refunds): complete parent fan-out when split legs are already refunded

### DIFF
--- a/api/errors_test.go
+++ b/api/errors_test.go
@@ -169,6 +169,17 @@ func TestRespondErrorMessagePatterns(t *testing.T) {
 	}
 }
 
+func TestClassifyMessageMixedRefundBatchError(t *testing.T) {
+	joined := "transaction txn_1 has already been refunded\nfailed to queue refund transaction"
+	code, ok := classifyMessage(joined)
+	require.True(t, ok, "unfiltered joined batch errors must still classify as conflict")
+	assert.Equal(t, apierror.ErrGenConflict, code)
+
+	fatalOnly := "failed to queue refund transaction"
+	_, ok = classifyMessage(fatalOnly)
+	assert.False(t, ok, "fatal-only batch errors must not inherit conflict from skippable legs")
+}
+
 func TestRespondErrorFallbackSanitizes(t *testing.T) {
 	c, w := newTestContext()
 	respondError(c, errors.New("pq: connection refused on 10.0.0.5"))

--- a/api/transaction_refund_idempotence_test.go
+++ b/api/transaction_refund_idempotence_test.go
@@ -144,6 +144,123 @@ func TestRefundStillRefundsSplitLegs(t *testing.T) {
 	assert.Equal(t, dstBPre, balanceString(t, b, dstB), "leg B should be restored after refund")
 }
 
+// After one split leg is refunded directly, a parent fan-out refund should
+// finish the remaining legs and return success — not 409 with silent partial apply.
+func TestRefundParentCompletesAfterOneSplitLegRefunded(t *testing.T) {
+	router, b, err := setupRouter()
+	require.NoError(t, err)
+	src, dstA := newDryRunFixture(t, b)
+	_, dstB := newDryRunFixture(t, b)
+
+	srcPre := balanceString(t, b, src)
+	dstAPre := balanceString(t, b, dstA)
+	dstBPre := balanceString(t, b, dstB)
+
+	ref := model.GenerateUUIDWithSuffix("splitpart")
+	txn, err := b.QueueTransaction(t.Context(), &model.Transaction{
+		Reference: ref, Source: src,
+		Amount: 2, Precision: 100, Currency: "USD", SkipQueue: true,
+		Destinations: []model.Distribution{
+			{Identifier: dstA, Distribution: "50%"},
+			{Identifier: dstB, Distribution: "50%"},
+		},
+	})
+	require.NoError(t, err)
+
+	leg1Ref := ref + "-1"
+	leg1, err := b.GetTransactionByRef(t.Context(), leg1Ref)
+	require.NoError(t, err)
+
+	w := doJSON(router, http.MethodPost, "/refund-transaction/"+leg1.TransactionID,
+		map[string]interface{}{"skip_queue": true})
+	require.Equal(t, http.StatusCreated, w.Code, "single-leg refund must succeed: %s", w.Body.String())
+
+	assert.Equal(t, "49900", balanceString(t, b, src))
+	assert.Equal(t, "0", balanceString(t, b, dstA))
+	assert.Equal(t, "100", balanceString(t, b, dstB))
+
+	w = doJSON(router, http.MethodPost, "/refund-transaction/"+txn.TransactionID,
+		map[string]interface{}{"skip_queue": true})
+	require.Equal(t, http.StatusCreated, w.Code,
+		"parent refund must finish remaining legs: %s", w.Body.String())
+
+	assert.Equal(t, srcPre, balanceString(t, b, src))
+	assert.Equal(t, dstAPre, balanceString(t, b, dstA))
+	assert.Equal(t, dstBPre, balanceString(t, b, dstB))
+
+	w = doJSON(router, http.MethodPost, "/refund-transaction/"+txn.TransactionID,
+		map[string]interface{}{"skip_queue": true})
+	assert.Equal(t, http.StatusConflict, w.Code, "fully refunded parent must conflict")
+	assert.Equal(t, srcPre, balanceString(t, b, src))
+	assert.Equal(t, dstAPre, balanceString(t, b, dstA))
+	assert.Equal(t, dstBPre, balanceString(t, b, dstB))
+}
+
+// Queued path for the split partial-refund scenario: worker applies each
+// reversal before the next refund is issued.
+func TestRefundParentCompletesAfterOneSplitLegRefundedQueued(t *testing.T) {
+	router, b, err := setupRouter()
+	require.NoError(t, err)
+
+	cnf, err := config.Fetch()
+	require.NoError(t, err)
+
+	queueName := fmt.Sprintf("%s_%d", cnf.Queue.TransactionQueue, 1)
+	cleanup := StartTestAsynqWorker(t, cnf, b, queueName)
+	defer cleanup()
+
+	ds := b.GetDataSource()
+	src, dstA := newDryRunFixture(t, b)
+	_, dstB := newDryRunFixture(t, b)
+
+	srcPre := balanceString(t, b, src)
+	dstAPre := balanceString(t, b, dstA)
+	dstBPre := balanceString(t, b, dstB)
+
+	ref := model.GenerateUUIDWithSuffix("splitpartq")
+	txn, err := b.QueueTransaction(t.Context(), &model.Transaction{
+		Reference: ref, Source: src,
+		Amount: 2, Precision: 100, Currency: "USD", SkipQueue: true,
+		Destinations: []model.Distribution{
+			{Identifier: dstA, Distribution: "50%"},
+			{Identifier: dstB, Distribution: "50%"},
+		},
+	})
+	require.NoError(t, err)
+
+	leg1, err := b.GetTransactionByRef(t.Context(), ref+"-1")
+	require.NoError(t, err)
+	leg2, err := b.GetTransactionByRef(t.Context(), ref+"-2")
+	require.NoError(t, err)
+
+	w := doJSON(router, http.MethodPost, "/refund-transaction/"+leg1.TransactionID, map[string]interface{}{})
+	require.Equal(t, http.StatusCreated, w.Code, "queued single-leg refund must succeed: %s", w.Body.String())
+
+	_, err = pollForTransactionStatus(context.Background(), ds, model.RefundReference(leg1.TransactionID)+"_q", "APPLIED", 200*time.Millisecond, 10*time.Second)
+	require.NoError(t, err, "worker must apply the queued leg-1 refund")
+
+	assert.Equal(t, "49900", balanceString(t, b, src))
+	assert.Equal(t, "0", balanceString(t, b, dstA))
+	assert.Equal(t, "100", balanceString(t, b, dstB))
+
+	w = doJSON(router, http.MethodPost, "/refund-transaction/"+txn.TransactionID, map[string]interface{}{})
+	require.Equal(t, http.StatusCreated, w.Code,
+		"queued parent refund must finish remaining legs: %s", w.Body.String())
+
+	_, err = pollForTransactionStatus(context.Background(), ds, model.RefundReference(leg2.TransactionID)+"_q", "APPLIED", 200*time.Millisecond, 10*time.Second)
+	require.NoError(t, err, "worker must apply the queued leg-2 refund")
+
+	assert.Equal(t, srcPre, balanceString(t, b, src))
+	assert.Equal(t, dstAPre, balanceString(t, b, dstA))
+	assert.Equal(t, dstBPre, balanceString(t, b, dstB))
+
+	w = doJSON(router, http.MethodPost, "/refund-transaction/"+txn.TransactionID, map[string]interface{}{})
+	assert.Equal(t, http.StatusConflict, w.Code, "fully refunded parent must conflict")
+	assert.Equal(t, srcPre, balanceString(t, b, src))
+	assert.Equal(t, dstAPre, balanceString(t, b, dstA))
+	assert.Equal(t, dstBPre, balanceString(t, b, dstB))
+}
+
 func balanceString(t *testing.T, b interface {
 	GetBalanceByID(ctx context.Context, id string, include []string, withQueued bool) (*model.Balance, error)
 }, balanceID string) string {

--- a/api/transactions.go
+++ b/api/transactions.go
@@ -270,7 +270,7 @@ func (a Api) RefundTransaction(c *gin.Context) {
 		MetaData:    req.MetaData,
 	}
 
-	transaction, err := a.blnk.ProcessTransactionInBatches(c.Request.Context(), id, big.NewInt(0), 1, false, a.blnk.GetRefundableTransactionsByParentID, a.blnk.RefundWorkerWithRefundOptions(refundOptions))
+	transaction, err := a.blnk.ProcessRefundsInBatches(c.Request.Context(), id, refundOptions)
 	if err != nil {
 		respondError(c, err, withUpgrade(apierror.ErrGenNotFound, apierror.ErrTxnNotFound), withDefault(apierror.ErrGenBadRequest))
 		return

--- a/transaction_batch_processing.go
+++ b/transaction_batch_processing.go
@@ -18,7 +18,7 @@ package blnk
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"math/big"
 	"sync"
 
@@ -119,7 +119,7 @@ func (l *Blnk) ProcessTransactionInBatches(ctx context.Context, parentTransactio
 			if len(allErrors) == 1 {
 				return allTxns, allErrors[0]
 			}
-			return allTxns, fmt.Errorf("error occurred during processing: %v", allErrors)
+			return allTxns, errors.Join(allErrors...)
 		}
 
 		span.AddEvent("Processed all transactions in batches")

--- a/transaction_bulk.go
+++ b/transaction_bulk.go
@@ -84,15 +84,7 @@ func (l *Blnk) voidInflightBatchTransactions(ctx context.Context, batchID string
 
 // refundNonInflightBatchTransactions refunds all non-inflight transactions in a batch
 func (l *Blnk) refundNonInflightBatchTransactions(ctx context.Context, batchID string) (string, error) {
-	_, err := l.ProcessTransactionInBatches(
-		ctx,
-		batchID,
-		big.NewInt(0),
-		1, // Assuming 1 worker is sufficient for rollback, adjust if needed
-		false,
-		l.GetRefundableTransactionsByParentID,
-		l.RefundWorker,
-	)
+	_, err := l.ProcessRefundsInBatches(ctx, batchID, RefundOptions{})
 	return "refunded", err
 }
 

--- a/transaction_dryrun.go
+++ b/transaction_dryrun.go
@@ -18,6 +18,7 @@ package blnk
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"strings"
@@ -112,6 +113,7 @@ func (l *Blnk) PreviewRefund(ctx context.Context, transactionID string) (*model.
 
 	preview := &model.TransactionPreview{DryRun: true, WouldApply: true}
 
+	skippedAlreadyRefunded := 0
 	for _, original := range refundable {
 		// The same eligibility check each leg passes through on the real
 		// path. GetRefundableTransactionsByParentID filters on status alone,
@@ -119,8 +121,12 @@ func (l *Blnk) PreviewRefund(ctx context.Context, transactionID string) (*model.
 		// back from the query — its reversal is itself an APPLIED row under
 		// the same parent — and would be projected as refundable again, both
 		// claiming the refund would apply and counting the reversal into the
-		// total.
+		// total. Already-refunded legs are skipped, matching ProcessRefundsInBatches.
 		if err := l.validateTransactionForRefund(ctx, original); err != nil {
+			if isTransactionAlreadyRefundedError(err) {
+				skippedAlreadyRefunded++
+				continue
+			}
 			preview.WouldApply = false
 			legErrors = append(legErrors, err)
 			continue
@@ -168,7 +174,10 @@ func (l *Blnk) PreviewRefund(ctx context.Context, transactionID string) (*model.
 	}
 
 	if len(legErrors) > 0 {
-		preview.Rejection = previewRejection(fmt.Errorf("error occurred during processing: %v", legErrors))
+		preview.Rejection = previewRejection(errors.Join(legErrors...))
+	} else if total.Sign() == 0 && skippedAlreadyRefunded > 0 {
+		preview.WouldApply = false
+		preview.Rejection = previewRejection(&errTransactionAlreadyRefunded{transactionID: transactionID})
 	}
 
 	preview.PreciseAmount = preciseString(total)

--- a/transaction_refunds.go
+++ b/transaction_refunds.go
@@ -312,21 +312,29 @@ func isTransactionAlreadyRefundedError(err error) bool {
 	return errors.As(err, &target)
 }
 
-func allRefundBatchErrorsAreAlreadyRefunded(err error) bool {
+func unwrapRefundBatchErrors(err error) ([]error, bool) {
 	if err == nil {
-		return false
-	}
-	if isTransactionAlreadyRefundedError(err) {
-		return true
+		return nil, false
 	}
 	type unwrapMultiple interface {
 		Unwrap() []error
 	}
 	u, ok := err.(unwrapMultiple)
 	if !ok {
-		return false
+		return []error{err}, false
 	}
 	errs := u.Unwrap()
+	if len(errs) == 0 {
+		return nil, true
+	}
+	return errs, true
+}
+
+func allRefundBatchErrorsAreAlreadyRefunded(err error) bool {
+	errs, joined := unwrapRefundBatchErrors(err)
+	if !joined {
+		return isTransactionAlreadyRefundedError(err)
+	}
 	if len(errs) == 0 {
 		return false
 	}
@@ -338,6 +346,32 @@ func allRefundBatchErrorsAreAlreadyRefunded(err error) bool {
 	return true
 }
 
+// nonSkippableRefundBatchErrors drops already-refunded legs from a batch error
+// so API classifiers do not treat a mixed failure as a safe idempotent conflict
+// when a fatal leg error is also present.
+func nonSkippableRefundBatchErrors(err error) error {
+	errs, joined := unwrapRefundBatchErrors(err)
+	if !joined {
+		if isTransactionAlreadyRefundedError(err) {
+			return nil
+		}
+		return err
+	}
+	var fatal []error
+	for _, e := range errs {
+		if !isTransactionAlreadyRefundedError(e) {
+			fatal = append(fatal, e)
+		}
+	}
+	if len(fatal) == 0 {
+		return nil
+	}
+	if len(fatal) == 1 {
+		return fatal[0]
+	}
+	return errors.Join(fatal...)
+}
+
 func reconcileRefundBatchResults(applied []*model.Transaction, err error) ([]*model.Transaction, error) {
 	if err == nil {
 		return applied, nil
@@ -346,6 +380,10 @@ func reconcileRefundBatchResults(applied []*model.Transaction, err error) ([]*mo
 	if len(applied) > 0 && allRefundBatchErrorsAreAlreadyRefunded(err) {
 		return applied, nil
 	}
+	if fatal := nonSkippableRefundBatchErrors(err); fatal != nil {
+		return applied, fatal
+	}
+	// Only skippable errors remain and nothing new was applied.
 	return applied, err
 }
 

--- a/transaction_refunds.go
+++ b/transaction_refunds.go
@@ -164,7 +164,7 @@ func (l *Blnk) validateTransactionForRefund(ctx context.Context, originalTxn *mo
 		return fmt.Errorf("failed to check if transaction %s was already refunded: %w", originalTxn.TransactionID, err)
 	}
 	if isRefunded {
-		err := fmt.Errorf("transaction %s has already been refunded", originalTxn.TransactionID)
+		err := &errTransactionAlreadyRefunded{transactionID: originalTxn.TransactionID}
 		span.RecordError(err)
 		return err
 	}
@@ -295,4 +295,80 @@ func (l *Blnk) RefundTransactionWithOptions(ctx context.Context, transactionID s
 
 	span.AddEvent("Refund transaction queued", trace.WithAttributes(attribute.String("refund.transaction.id", queuedRefundTxn.TransactionID)))
 	return queuedRefundTxn, nil
+}
+
+// errTransactionAlreadyRefunded marks a leg that was already reversed. Fan-out
+// refunds treat this as skippable so a parent refund can finish remaining legs.
+type errTransactionAlreadyRefunded struct {
+	transactionID string
+}
+
+func (e *errTransactionAlreadyRefunded) Error() string {
+	return fmt.Sprintf("transaction %s has already been refunded", e.transactionID)
+}
+
+func isTransactionAlreadyRefundedError(err error) bool {
+	var target *errTransactionAlreadyRefunded
+	return errors.As(err, &target)
+}
+
+func allRefundBatchErrorsAreAlreadyRefunded(err error) bool {
+	if err == nil {
+		return false
+	}
+	if isTransactionAlreadyRefundedError(err) {
+		return true
+	}
+	type unwrapMultiple interface {
+		Unwrap() []error
+	}
+	u, ok := err.(unwrapMultiple)
+	if !ok {
+		return false
+	}
+	errs := u.Unwrap()
+	if len(errs) == 0 {
+		return false
+	}
+	for _, e := range errs {
+		if !isTransactionAlreadyRefundedError(e) {
+			return false
+		}
+	}
+	return true
+}
+
+func reconcileRefundBatchResults(applied []*model.Transaction, err error) ([]*model.Transaction, error) {
+	if err == nil {
+		return applied, nil
+	}
+	// Some legs refunded, others were already done — success for the caller.
+	if len(applied) > 0 && allRefundBatchErrorsAreAlreadyRefunded(err) {
+		return applied, nil
+	}
+	return applied, err
+}
+
+// ProcessRefundsInBatches fans out a refund across every refundable leg under
+// parentTransactionID. Legs that were already reversed are skipped; the call
+// succeeds when at least one leg is refunded and fails with conflict only when
+// nothing was left to refund.
+func (l *Blnk) ProcessRefundsInBatches(ctx context.Context, parentTransactionID string, opts RefundOptions) ([]*model.Transaction, error) {
+	ctx, span := tracer.Start(ctx, "ProcessRefundsInBatches")
+	defer span.End()
+
+	applied, err := l.ProcessTransactionInBatches(
+		ctx,
+		parentTransactionID,
+		big.NewInt(0),
+		1,
+		false,
+		l.GetRefundableTransactionsByParentID,
+		l.RefundWorkerWithRefundOptions(opts),
+	)
+	result, reconcileErr := reconcileRefundBatchResults(applied, err)
+	if reconcileErr != nil {
+		span.RecordError(reconcileErr)
+	}
+	return result, reconcileErr
 }

--- a/transaction_refunds_batch_test.go
+++ b/transaction_refunds_batch_test.go
@@ -1,0 +1,57 @@
+package blnk
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/blnkfinance/blnk/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReconcileRefundBatchResults(t *testing.T) {
+	applied := []*model.Transaction{{TransactionID: "txn_refund_b"}}
+
+	t.Run("no error", func(t *testing.T) {
+		got, err := reconcileRefundBatchResults(applied, nil)
+		require.NoError(t, err)
+		assert.Equal(t, applied, got)
+	})
+
+	t.Run("applied with skippable already-refunded error", func(t *testing.T) {
+		batchErr := &errTransactionAlreadyRefunded{transactionID: "txn_leg_a"}
+		got, err := reconcileRefundBatchResults(applied, batchErr)
+		require.NoError(t, err)
+		assert.Equal(t, applied, got)
+	})
+
+	t.Run("applied with joined already-refunded errors", func(t *testing.T) {
+		batchErr := errors.Join(
+			&errTransactionAlreadyRefunded{transactionID: "txn_leg_a"},
+			&errTransactionAlreadyRefunded{transactionID: "txn_leg_c"},
+		)
+		got, err := reconcileRefundBatchResults(applied, batchErr)
+		require.NoError(t, err)
+		assert.Equal(t, applied, got)
+	})
+
+	t.Run("nothing applied all already refunded", func(t *testing.T) {
+		batchErr := errors.Join(
+			&errTransactionAlreadyRefunded{transactionID: "txn_leg_a"},
+			&errTransactionAlreadyRefunded{transactionID: "txn_leg_b"},
+		)
+		got, err := reconcileRefundBatchResults(nil, batchErr)
+		require.Error(t, err)
+		assert.Nil(t, got)
+		assert.True(t, allRefundBatchErrorsAreAlreadyRefunded(err))
+	})
+
+	t.Run("applied with fatal error", func(t *testing.T) {
+		fatal := fmt.Errorf("failed to queue refund transaction")
+		got, err := reconcileRefundBatchResults(applied, fatal)
+		require.Error(t, err)
+		assert.Equal(t, applied, got)
+		assert.Equal(t, fatal, err)
+	})
+}

--- a/transaction_refunds_batch_test.go
+++ b/transaction_refunds_batch_test.go
@@ -3,6 +3,7 @@ package blnk
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/blnkfinance/blnk/model"
@@ -53,5 +54,41 @@ func TestReconcileRefundBatchResults(t *testing.T) {
 		require.Error(t, err)
 		assert.Equal(t, applied, got)
 		assert.Equal(t, fatal, err)
+	})
+
+	t.Run("applied with mixed already-refunded and fatal errors", func(t *testing.T) {
+		batchErr := errors.Join(
+			&errTransactionAlreadyRefunded{transactionID: "txn_leg_a"},
+			fmt.Errorf("failed to queue refund transaction"),
+		)
+		got, err := reconcileRefundBatchResults(applied, batchErr)
+		require.Error(t, err)
+		assert.Equal(t, applied, got)
+		assert.False(t, isTransactionAlreadyRefundedError(err))
+		assert.NotContains(t, err.Error(), "has already been refunded")
+		assert.Contains(t, err.Error(), "failed to queue refund transaction")
+	})
+
+	t.Run("mixed errors without apply keeps skippable-only conflict", func(t *testing.T) {
+		batchErr := errors.Join(
+			&errTransactionAlreadyRefunded{transactionID: "txn_leg_a"},
+			fmt.Errorf("failed to queue refund transaction"),
+		)
+		got, err := reconcileRefundBatchResults(nil, batchErr)
+		require.Error(t, err)
+		assert.Nil(t, got)
+		assert.Contains(t, err.Error(), "failed to queue refund transaction")
+		assert.NotContains(t, err.Error(), "has already been refunded")
+	})
+}
+
+func TestNonSkippableRefundBatchErrors(t *testing.T) {
+	t.Run("joined mixed strips skippable phrase", func(t *testing.T) {
+		err := nonSkippableRefundBatchErrors(errors.Join(
+			&errTransactionAlreadyRefunded{transactionID: "txn_leg_a"},
+			fmt.Errorf("failed to queue refund transaction"),
+		))
+		require.Error(t, err)
+		assert.False(t, strings.Contains(err.Error(), "has already been refunded"))
 	})
 }


### PR DESCRIPTION


Skip already-reversed legs during refund batch processing so refunding a parent after one child leg returns 201 instead of 409 with silent partial apply. Add ProcessRefundsInBatches reconciliation, use errors.Join so per-leg typed errors unwrap, and align dry-run preview with the live path.