### PR TITLE
fix(lineage): skip shadow work on inflight commit/void without fund lineage

### DIFF
--- a/lineage_shadow.go
+++ b/lineage_shadow.go
@@ -117,22 +117,22 @@ func (l *Blnk) voidShadowTransactions(ctx context.Context, parentTransactionID s
 // follow source TrackFundLineage; credit shadows require a provider and destination
 // TrackFundLineage. Shadow children never have nested shadows.
 //
-// When a balance lookup fails, the second return value is non-nil and the bool is true
-// so callers process shadows conservatively rather than skipping and stranding inflight
-// companions after the parent is already committed or voided.
-func (l *Blnk) inflightTransactionNeedsShadowWork(ctx context.Context, txn *model.Transaction) (bool, error) {
-	ctx, span := tracer.Start(ctx, "InflightTransactionNeedsShadowWork")
+// A balance lookup failure is treated as unknown eligibility: the error is recorded on
+// the span and the function returns true so callers process shadows conservatively
+// instead of skipping and stranding inflight companions.
+func (l *Blnk) inflightTransactionNeedsShadowWork(ctx context.Context, txn *model.Transaction) bool {
+	_, span := tracer.Start(ctx, "InflightTransactionNeedsShadowWork")
 	defer span.End()
 
 	if txn == nil {
-		return false, nil
+		return false
 	}
 	if txn.MetaData != nil {
 		if _, isShadow := txn.MetaData["_lineage_type"]; isShadow {
-			return false, nil
+			return false
 		}
 		if _, hasAlloc := txn.MetaData[LineageFundAllocation]; hasAlloc {
-			return true, nil
+			return true
 		}
 	}
 
@@ -141,22 +141,22 @@ func (l *Blnk) inflightTransactionNeedsShadowWork(ctx context.Context, txn *mode
 		dst, err := l.datasource.GetBalanceByIDLite(txn.Destination)
 		if err != nil {
 			span.RecordError(err)
-			return true, fmt.Errorf("failed to check destination lineage eligibility: %w", err)
+			return true
 		}
-		return dst != nil && dst.TrackFundLineage, nil
+		return dst != nil && dst.TrackFundLineage
 	}
 
 	// Only real balance IDs can track lineage; @ indicators (e.g. @world) cannot.
 	if strings.HasPrefix(txn.Source, "@") {
-		return false, nil
+		return false
 	}
 
 	src, err := l.datasource.GetBalanceByIDLite(txn.Source)
 	if err != nil {
 		span.RecordError(err)
-		return true, fmt.Errorf("failed to check source lineage eligibility: %w", err)
+		return true
 	}
-	return src != nil && src.TrackFundLineage, nil
+	return src != nil && src.TrackFundLineage
 }
 
 // queueShadowWork processes shadow commit or void work synchronously first, and queues
@@ -176,8 +176,7 @@ func (l *Blnk) inflightTransactionNeedsShadowWork(ctx context.Context, txn *mode
 // Returns:
 // - error: An error if all processing attempts failed.
 func (l *Blnk) queueShadowWork(ctx context.Context, parentTransactionID string, txn *model.Transaction, lineageType string) error {
-	needsShadow, _ := l.inflightTransactionNeedsShadowWork(ctx, txn)
-	if !needsShadow {
+	if !l.inflightTransactionNeedsShadowWork(ctx, txn) {
 		return nil
 	}
 

--- a/lineage_shadow.go
+++ b/lineage_shadow.go
@@ -116,32 +116,47 @@ func (l *Blnk) voidShadowTransactions(ctx context.Context, parentTransactionID s
 // propagate to shadow transactions. Matches PrepareLineageOutbox semantics: debit shadows
 // follow source TrackFundLineage; credit shadows require a provider and destination
 // TrackFundLineage. Shadow children never have nested shadows.
-func (l *Blnk) inflightTransactionNeedsShadowWork(ctx context.Context, txn *model.Transaction) bool {
+//
+// When a balance lookup fails, the second return value is non-nil and the bool is true
+// so callers process shadows conservatively rather than skipping and stranding inflight
+// companions after the parent is already committed or voided.
+func (l *Blnk) inflightTransactionNeedsShadowWork(ctx context.Context, txn *model.Transaction) (bool, error) {
+	ctx, span := tracer.Start(ctx, "InflightTransactionNeedsShadowWork")
+	defer span.End()
+
 	if txn == nil {
-		return false
+		return false, nil
 	}
 	if txn.MetaData != nil {
 		if _, isShadow := txn.MetaData["_lineage_type"]; isShadow {
-			return false
+			return false, nil
 		}
 		if _, hasAlloc := txn.MetaData[LineageFundAllocation]; hasAlloc {
-			return true
+			return true, nil
 		}
 	}
 
 	provider := l.getLineageProvider(txn)
 	if provider != "" {
 		dst, err := l.datasource.GetBalanceByIDLite(txn.Destination)
-		return err == nil && dst != nil && dst.TrackFundLineage
+		if err != nil {
+			span.RecordError(err)
+			return true, fmt.Errorf("failed to check destination lineage eligibility: %w", err)
+		}
+		return dst != nil && dst.TrackFundLineage, nil
 	}
 
 	// Only real balance IDs can track lineage; @ indicators (e.g. @world) cannot.
 	if strings.HasPrefix(txn.Source, "@") {
-		return false
+		return false, nil
 	}
 
 	src, err := l.datasource.GetBalanceByIDLite(txn.Source)
-	return err == nil && src != nil && src.TrackFundLineage
+	if err != nil {
+		span.RecordError(err)
+		return true, fmt.Errorf("failed to check source lineage eligibility: %w", err)
+	}
+	return src != nil && src.TrackFundLineage, nil
 }
 
 // queueShadowWork processes shadow commit or void work synchronously first, and queues
@@ -161,7 +176,8 @@ func (l *Blnk) inflightTransactionNeedsShadowWork(ctx context.Context, txn *mode
 // Returns:
 // - error: An error if all processing attempts failed.
 func (l *Blnk) queueShadowWork(ctx context.Context, parentTransactionID string, txn *model.Transaction, lineageType string) error {
-	if !l.inflightTransactionNeedsShadowWork(ctx, txn) {
+	needsShadow, _ := l.inflightTransactionNeedsShadowWork(ctx, txn)
+	if !needsShadow {
 		return nil
 	}
 

--- a/lineage_shadow.go
+++ b/lineage_shadow.go
@@ -112,18 +112,59 @@ func (l *Blnk) voidShadowTransactions(ctx context.Context, parentTransactionID s
 	return nil
 }
 
+// inflightTransactionNeedsShadowWork reports whether an inflight commit or void should
+// propagate to shadow transactions. Matches PrepareLineageOutbox semantics: debit shadows
+// follow source TrackFundLineage; credit shadows require a provider and destination
+// TrackFundLineage. Shadow children never have nested shadows.
+func (l *Blnk) inflightTransactionNeedsShadowWork(ctx context.Context, txn *model.Transaction) bool {
+	if txn == nil {
+		return false
+	}
+	if txn.MetaData != nil {
+		if _, isShadow := txn.MetaData["_lineage_type"]; isShadow {
+			return false
+		}
+		if _, hasAlloc := txn.MetaData[LineageFundAllocation]; hasAlloc {
+			return true
+		}
+	}
+
+	provider := l.getLineageProvider(txn)
+	if provider != "" {
+		dst, err := l.datasource.GetBalanceByIDLite(txn.Destination)
+		return err == nil && dst != nil && dst.TrackFundLineage
+	}
+
+	// Only real balance IDs can track lineage; @ indicators (e.g. @world) cannot.
+	if strings.HasPrefix(txn.Source, "@") {
+		return false
+	}
+
+	src, err := l.datasource.GetBalanceByIDLite(txn.Source)
+	return err == nil && src != nil && src.TrackFundLineage
+}
+
 // queueShadowWork processes shadow commit or void work synchronously first, and queues
 // to outbox for retry only if there are failures. This provides both immediate processing
 // and guaranteed delivery for failed operations.
 //
+// parentTransactionID is the original inflight transaction ID. Callers must pass the ID
+// captured before finalizeCommitment/finalizeVoidTransaction reassign txn.TransactionID
+// to the commit/void child row — shadows are keyed by _shadow_for on that original ID.
+//
 // Parameters:
 // - ctx context.Context: The context for the operation.
-// - parentTransactionID string: The parent transaction ID whose shadows need processing.
+// - parentTransactionID string: The original inflight parent transaction ID.
+// - txn *model.Transaction: The parent inflight transaction (for lineage eligibility).
 // - lineageType string: Either LineageTypeShadowCommit or LineageTypeShadowVoid.
 //
 // Returns:
 // - error: An error if all processing attempts failed.
-func (l *Blnk) queueShadowWork(ctx context.Context, parentTransactionID string, lineageType string) error {
+func (l *Blnk) queueShadowWork(ctx context.Context, parentTransactionID string, txn *model.Transaction, lineageType string) error {
+	if !l.inflightTransactionNeedsShadowWork(ctx, txn) {
+		return nil
+	}
+
 	ctx, span := tracer.Start(ctx, "QueueShadowWork")
 	defer span.End()
 

--- a/lineage_test.go
+++ b/lineage_test.go
@@ -18,6 +18,7 @@ package blnk
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"testing"
 	"time"
@@ -26,6 +27,7 @@ import (
 	"github.com/blnkfinance/blnk/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetLineageProvider(t *testing.T) {
@@ -1251,6 +1253,7 @@ func TestInflightTransactionNeedsShadowWork(t *testing.T) {
 		txn         *model.Transaction
 		setupMock   func(*mocks.MockDataSource)
 		expectNeeds bool
+		expectErr   bool
 	}{
 		{
 			name: "typical inflight from @world without lineage metadata",
@@ -1354,6 +1357,35 @@ func TestInflightTransactionNeedsShadowWork(t *testing.T) {
 			},
 			expectNeeds: false,
 		},
+		{
+			name: "destination lookup error proceeds conservatively",
+			txn: &model.Transaction{
+				TransactionID: "txn_credit_err",
+				Source:        "@world",
+				Destination:   "bln_dest",
+				MetaData: map[string]interface{}{
+					LineageProviderKey: "stripe",
+				},
+			},
+			setupMock: func(m *mocks.MockDataSource) {
+				m.On("GetBalanceByIDLite", "bln_dest").Return((*model.Balance)(nil), fmt.Errorf("db timeout"))
+			},
+			expectNeeds: true,
+			expectErr:   true,
+		},
+		{
+			name: "source lookup error proceeds conservatively",
+			txn: &model.Transaction{
+				TransactionID: "txn_debit_err",
+				Source:        "bln_source",
+				Destination:   "bln_dest",
+			},
+			setupMock: func(m *mocks.MockDataSource) {
+				m.On("GetBalanceByIDLite", "bln_source").Return((*model.Balance)(nil), fmt.Errorf("db timeout"))
+			},
+			expectNeeds: true,
+			expectErr:   true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1364,10 +1396,81 @@ func TestInflightTransactionNeedsShadowWork(t *testing.T) {
 			}
 			blnkInstance := &Blnk{datasource: mockDS}
 
-			assert.Equal(t, tt.expectNeeds, blnkInstance.inflightTransactionNeedsShadowWork(ctx, tt.txn))
+			needs, err := blnkInstance.inflightTransactionNeedsShadowWork(ctx, tt.txn)
+			if tt.expectErr {
+				require.Error(t, err)
+				assert.True(t, needs, "lookup failures must proceed conservatively")
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectNeeds, needs)
+			}
 			mockDS.AssertExpectations(t)
 		})
 	}
+}
+
+func TestQueueShadowWork_eligibilityAndParentID(t *testing.T) {
+	ctx := context.Background()
+	parentInflightID := "txn_parent_inflight_original"
+
+	t.Run("skips shadow lookup when lineage is not enabled", func(t *testing.T) {
+		mockDS := new(mocks.MockDataSource)
+		blnkInstance := &Blnk{datasource: mockDS}
+
+		txn := &model.Transaction{
+			TransactionID: "txn_child_commit_row",
+			Source:        "@world",
+			Destination:   "bln_merchant",
+		}
+
+		err := blnkInstance.queueShadowWork(ctx, parentInflightID, txn, model.LineageTypeShadowCommit)
+		require.NoError(t, err)
+		mockDS.AssertNotCalled(t, "GetTransactionsByShadowFor", mock.Anything, mock.Anything)
+	})
+
+	t.Run("destination lookup error still queries shadows by original parent ID", func(t *testing.T) {
+		mockDS := new(mocks.MockDataSource)
+		blnkInstance := &Blnk{datasource: mockDS}
+
+		txn := &model.Transaction{
+			TransactionID: "txn_child_commit_row",
+			Source:        "@world",
+			Destination:   "bln_dest",
+			MetaData: map[string]interface{}{
+				LineageProviderKey: "stripe",
+			},
+		}
+
+		mockDS.On("GetBalanceByIDLite", "bln_dest").Return((*model.Balance)(nil), fmt.Errorf("db timeout"))
+		mockDS.On("GetTransactionsByShadowFor", mock.Anything, parentInflightID).Return([]model.Transaction{}, nil)
+
+		err := blnkInstance.queueShadowWork(ctx, parentInflightID, txn, model.LineageTypeShadowCommit)
+		require.NoError(t, err)
+		mockDS.AssertExpectations(t)
+	})
+
+	t.Run("fund allocation queries shadows by original parent ID not child row", func(t *testing.T) {
+		mockDS := new(mocks.MockDataSource)
+		blnkInstance := &Blnk{datasource: mockDS}
+
+		txn := &model.Transaction{
+			TransactionID: "txn_child_commit_row",
+			Source:        "bln_source",
+			Destination:   "bln_dest",
+			MetaData: map[string]interface{}{
+				LineageFundAllocation: []interface{}{
+					map[string]interface{}{"provider": "stripe", "amount": float64(50)},
+				},
+			},
+		}
+
+		mockDS.On("GetTransactionsByShadowFor", mock.Anything, parentInflightID).Return([]model.Transaction{}, nil)
+
+		err := blnkInstance.queueShadowWork(ctx, parentInflightID, txn, model.LineageTypeShadowVoid)
+		require.NoError(t, err)
+		mockDS.AssertExpectations(t)
+		mockDS.AssertNotCalled(t, "GetTransactionsByShadowFor", mock.Anything, txn.TransactionID)
+	})
 }
 
 func TestProcessLineageFromOutbox(t *testing.T) {

--- a/lineage_test.go
+++ b/lineage_test.go
@@ -1243,6 +1243,133 @@ func TestPrepareLineageOutbox(t *testing.T) {
 	}
 }
 
+func TestInflightTransactionNeedsShadowWork(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name        string
+		txn         *model.Transaction
+		setupMock   func(*mocks.MockDataSource)
+		expectNeeds bool
+	}{
+		{
+			name: "typical inflight from @world without lineage metadata",
+			txn: &model.Transaction{
+				TransactionID: "txn_inflight",
+				Source:        "@world",
+				Destination:   "bln_dest",
+			},
+			expectNeeds: false,
+		},
+		{
+			name: "shadow child transaction",
+			txn: &model.Transaction{
+				TransactionID: "txn_shadow",
+				Source:        "bln_shadow",
+				Destination:   "bln_aggregate",
+				MetaData: map[string]interface{}{
+					"_lineage_type": "release",
+					"_shadow_for":   "txn_parent",
+				},
+			},
+			expectNeeds: false,
+		},
+		{
+			name: "debit lineage stamped fund allocation",
+			txn: &model.Transaction{
+				TransactionID: "txn_debit",
+				Source:        "bln_source",
+				Destination:   "bln_dest",
+				MetaData: map[string]interface{}{
+					LineageFundAllocation: []interface{}{
+						map[string]interface{}{"provider": "stripe", "amount": float64(50)},
+					},
+				},
+			},
+			expectNeeds: true,
+		},
+		{
+			name: "credit lineage with tracking destination",
+			txn: &model.Transaction{
+				TransactionID: "txn_credit",
+				Source:        "@world",
+				Destination:   "bln_dest",
+				MetaData: map[string]interface{}{
+					LineageProviderKey: "stripe",
+				},
+			},
+			setupMock: func(m *mocks.MockDataSource) {
+				m.On("GetBalanceByIDLite", "bln_dest").Return(&model.Balance{
+					BalanceID:        "bln_dest",
+					TrackFundLineage: true,
+				}, nil)
+			},
+			expectNeeds: true,
+		},
+		{
+			name: "provider metadata but destination does not track lineage",
+			txn: &model.Transaction{
+				TransactionID: "txn_credit_no_track",
+				Source:        "@world",
+				Destination:   "bln_dest",
+				MetaData: map[string]interface{}{
+					LineageProviderKey: "stripe",
+				},
+			},
+			setupMock: func(m *mocks.MockDataSource) {
+				m.On("GetBalanceByIDLite", "bln_dest").Return(&model.Balance{
+					BalanceID:        "bln_dest",
+					TrackFundLineage: false,
+				}, nil)
+			},
+			expectNeeds: false,
+		},
+		{
+			name: "debit path source tracks lineage",
+			txn: &model.Transaction{
+				TransactionID: "txn_debit_source",
+				Source:        "bln_source",
+				Destination:   "bln_dest",
+			},
+			setupMock: func(m *mocks.MockDataSource) {
+				m.On("GetBalanceByIDLite", "bln_source").Return(&model.Balance{
+					BalanceID:        "bln_source",
+					TrackFundLineage: true,
+				}, nil)
+			},
+			expectNeeds: true,
+		},
+		{
+			name: "balance-to-balance without lineage tracking",
+			txn: &model.Transaction{
+				TransactionID: "txn_plain",
+				Source:        "bln_source",
+				Destination:   "bln_dest",
+			},
+			setupMock: func(m *mocks.MockDataSource) {
+				m.On("GetBalanceByIDLite", "bln_source").Return(&model.Balance{
+					BalanceID:        "bln_source",
+					TrackFundLineage: false,
+				}, nil)
+			},
+			expectNeeds: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockDS := new(mocks.MockDataSource)
+			if tt.setupMock != nil {
+				tt.setupMock(mockDS)
+			}
+			blnkInstance := &Blnk{datasource: mockDS}
+
+			assert.Equal(t, tt.expectNeeds, blnkInstance.inflightTransactionNeedsShadowWork(ctx, tt.txn))
+			mockDS.AssertExpectations(t)
+		})
+	}
+}
+
 func TestProcessLineageFromOutbox(t *testing.T) {
 	ctx := context.Background()
 

--- a/lineage_test.go
+++ b/lineage_test.go
@@ -1253,7 +1253,6 @@ func TestInflightTransactionNeedsShadowWork(t *testing.T) {
 		txn         *model.Transaction
 		setupMock   func(*mocks.MockDataSource)
 		expectNeeds bool
-		expectErr   bool
 	}{
 		{
 			name: "typical inflight from @world without lineage metadata",
@@ -1371,7 +1370,6 @@ func TestInflightTransactionNeedsShadowWork(t *testing.T) {
 				m.On("GetBalanceByIDLite", "bln_dest").Return((*model.Balance)(nil), fmt.Errorf("db timeout"))
 			},
 			expectNeeds: true,
-			expectErr:   true,
 		},
 		{
 			name: "source lookup error proceeds conservatively",
@@ -1384,7 +1382,6 @@ func TestInflightTransactionNeedsShadowWork(t *testing.T) {
 				m.On("GetBalanceByIDLite", "bln_source").Return((*model.Balance)(nil), fmt.Errorf("db timeout"))
 			},
 			expectNeeds: true,
-			expectErr:   true,
 		},
 	}
 
@@ -1396,14 +1393,7 @@ func TestInflightTransactionNeedsShadowWork(t *testing.T) {
 			}
 			blnkInstance := &Blnk{datasource: mockDS}
 
-			needs, err := blnkInstance.inflightTransactionNeedsShadowWork(ctx, tt.txn)
-			if tt.expectErr {
-				require.Error(t, err)
-				assert.True(t, needs, "lookup failures must proceed conservatively")
-			} else {
-				require.NoError(t, err)
-				assert.Equal(t, tt.expectNeeds, needs)
-			}
+			assert.Equal(t, tt.expectNeeds, blnkInstance.inflightTransactionNeedsShadowWork(ctx, tt.txn))
 			mockDS.AssertExpectations(t)
 		})
 	}

--- a/transaction_inflight.go
+++ b/transaction_inflight.go
@@ -228,7 +228,7 @@ func (l *Blnk) CommitInflightTransactionWithRef(ctx context.Context, transaction
 		return nil, err
 	}
 
-	if err := l.queueShadowWork(ctx, transactionID, model.LineageTypeShadowCommit); err != nil {
+	if err := l.queueShadowWork(ctx, transactionID, transaction, model.LineageTypeShadowCommit); err != nil {
 		logrus.WithError(err).WithField("transaction_id", transactionID).Error("failed to queue shadow commit")
 	}
 
@@ -267,7 +267,7 @@ func (l *Blnk) CommitInflightTransactionWithQueue(ctx context.Context, transacti
 		return nil, err
 	}
 
-	if err := l.queueShadowWork(ctx, transactionID, model.LineageTypeShadowCommit); err != nil {
+	if err := l.queueShadowWork(ctx, transactionID, transaction, model.LineageTypeShadowCommit); err != nil {
 		logrus.WithError(err).WithField("transaction_id", transactionID).Error("failed to queue shadow commit")
 	}
 
@@ -497,7 +497,7 @@ func (l *Blnk) VoidInflightTransactionWithRef(ctx context.Context, transactionID
 		return nil, err
 	}
 
-	if err := l.queueShadowWork(ctx, transactionID, model.LineageTypeShadowVoid); err != nil {
+	if err := l.queueShadowWork(ctx, transactionID, transaction, model.LineageTypeShadowVoid); err != nil {
 		logrus.WithError(err).WithField("transaction_id", transactionID).Error("failed to queue shadow void")
 	}
 


### PR DESCRIPTION

Guard queueShadowWork with the same eligibility rules as PrepareLineageOutbox so inflight commit/void no longer queries shadow companions when no balance tracks fund lineage. Pass the original inflight transaction ID explicitly after finalize reassigns txn.TransactionID to the child row.

Fixes #381