### PR TITLE
fix(queue): unblock recovery for zero-amount stuck QUEUED txns

### DIFF
--- a/api/errors.go
+++ b/api/errors.go
@@ -240,6 +240,8 @@ var messagePatterns = []messagePattern{
 	// inflight balance, so it is classified as one.
 	{[]string{"insufficient inflight"}, apierror.ErrTxnInsufficientFunds},
 	{[]string{"transaction amount must be positive"}, apierror.ErrTxnInvalidAmount},
+	{[]string{"transaction precise amount must be positive"}, apierror.ErrTxnInvalidAmount},
+	{[]string{"precise_amount must be positive"}, apierror.ErrTxnInvalidAmount},
 	{[]string{"transaction validation failed"}, apierror.ErrTxnValidation},
 	{[]string{"reference is required"}, apierror.ErrTxnValidation},
 	// Balances

--- a/api/model/model.go
+++ b/api/model/model.go
@@ -87,9 +87,8 @@ func validatePrecisionNotNegative(value interface{}) error {
 // persisted as sent. The stored record then reports the opposite sign of the
 // movement it describes, and is invisible to an `amount > 0` filter.
 //
-// Zero is left to the existing downstream handling rather than rejected
-// here, so that the current zero-amount semantics (and issue #334's request
-// to make them opt-in) are not changed by this fix.
+// Zero amount is still the sentinel for "use precise_amount instead".
+// A zero precise_amount is rejected in ValidateRecordTransaction.
 func validateAmountNotNegative(t *RecordTransaction) validation.RuleFunc {
 	return func(value interface{}) error {
 		if t.Amount < 0 {
@@ -275,6 +274,9 @@ func (t *RecordTransaction) ValidateRecordTransaction() error {
 			}
 			if t.Amount == 0 && t.PreciseAmount == nil {
 				return errors.New("either amount or precise_amount is required")
+			}
+			if t.PreciseAmount != nil && t.PreciseAmount.Sign() == 0 {
+				return errors.New("precise_amount must be positive")
 			}
 
 			// Check for high precision amounts that might lead to rounding errors

--- a/api/model/model_test.go
+++ b/api/model/model_test.go
@@ -449,6 +449,19 @@ func TestValidateRecordTransaction(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "Invalid Transaction - Zero precise_amount",
+			transaction: RecordTransaction{
+				PreciseAmount: big.NewInt(0),
+				Precision:     100,
+				Currency:      "USD",
+				Reference:     "ref_zero_precise",
+				Description:   "Test transaction",
+				Source:        "source1",
+				Destination:   "dest1",
+			},
+			wantErr: true,
+		},
+		{
 			// Zero amount alongside precise_amount is the existing sentinel
 			// for "use precise_amount"; this fix must not disturb it.
 			name: "Valid Transaction - Zero amount with positive precise_amount",

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -41,25 +41,12 @@ func utcOrNil(t *time.Time) *time.Time {
 	return &u
 }
 
-const rejectedPersistStatus = "REJECTED"
-
 // persistNumericColumns is the amount pair written to numeric columns.
-// Missing values are not coerced to zero for applied/queued rows: that hid
-// upstream bugs as valid-looking zero transactions. REJECTED is the exception,
-// because RejectTransaction materializes a zero-amount terminal child.
+// Every status requires both fields; RejectTransaction materializes them via
+// ApplyPrecision before persist. Missing values must fail, not be coerced.
 func persistNumericColumns(txn *model.Transaction) (amount string, preciseAmount string, err error) {
 	if txn == nil {
 		return "", "", fmt.Errorf("transaction is required")
-	}
-	if txn.Status == rejectedPersistStatus {
-		amount = txn.AmountString
-		if amount == "" {
-			amount = "0"
-		}
-		if txn.PreciseAmount == nil {
-			return amount, "0", nil
-		}
-		return amount, txn.PreciseAmount.String(), nil
 	}
 	if txn.AmountString == "" {
 		return "", "", fmt.Errorf("amount is required")

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -21,7 +21,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"math/big"
 	"time"
 
 	"github.com/blnkfinance/blnk/internal/apierror"
@@ -42,21 +41,33 @@ func utcOrNil(t *time.Time) *time.Time {
 	return &u
 }
 
-// persistAmountString is the value written to the numeric amount column.
-// An empty string is not valid numeric input for Postgres.
-func persistAmountString(amount string) string {
-	if amount == "" {
-		return "0"
-	}
-	return amount
-}
+const rejectedPersistStatus = "REJECTED"
 
-// persistPreciseAmount is the value written to the numeric precise_amount column.
-func persistPreciseAmount(amount *big.Int) string {
-	if amount == nil {
-		return "0"
+// persistNumericColumns is the amount pair written to numeric columns.
+// Missing values are not coerced to zero for applied/queued rows: that hid
+// upstream bugs as valid-looking zero transactions. REJECTED is the exception,
+// because RejectTransaction materializes a zero-amount terminal child.
+func persistNumericColumns(txn *model.Transaction) (amount string, preciseAmount string, err error) {
+	if txn == nil {
+		return "", "", fmt.Errorf("transaction is required")
 	}
-	return amount.String()
+	if txn.Status == rejectedPersistStatus {
+		amount = txn.AmountString
+		if amount == "" {
+			amount = "0"
+		}
+		if txn.PreciseAmount == nil {
+			return amount, "0", nil
+		}
+		return amount, txn.PreciseAmount.String(), nil
+	}
+	if txn.AmountString == "" {
+		return "", "", fmt.Errorf("amount is required")
+	}
+	if txn.PreciseAmount == nil {
+		return "", "", fmt.Errorf("precise_amount is required")
+	}
+	return txn.AmountString, txn.PreciseAmount.String(), nil
 }
 
 func (d Datasource) RecordTransaction(ctx context.Context, txn *model.Transaction) (*model.Transaction, error) {
@@ -71,11 +82,17 @@ func (d Datasource) RecordTransaction(ctx context.Context, txn *model.Transactio
 		return nil, apierror.NewAPIError(apierror.ErrInternalServer, "Failed to marshal metadata", err)
 	}
 
+	amount, preciseAmount, err := persistNumericColumns(txn)
+	if err != nil {
+		span.RecordError(err)
+		return nil, apierror.NewAPIError(apierror.ErrInternalServer, "Failed to record transaction", err)
+	}
+
 	// Execute the SQL insert statement to record the transaction
 	_, err = d.Conn.ExecContext(ctx,
 		`INSERT INTO blnk.transactions(transaction_id, parent_transaction, source, reference, amount, precise_amount, precision, currency, destination, description, status, created_at, meta_data, scheduled_for, hash, effective_date)
 		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)`,
-		txn.TransactionID, txn.ParentTransaction, txn.Source, txn.Reference, persistAmountString(txn.AmountString), persistPreciseAmount(txn.PreciseAmount), txn.Precision, txn.Currency, txn.Destination, txn.Description, txn.Status, txn.CreatedAt.UTC(), metaDataJSON, txn.ScheduledFor.UTC(), txn.Hash, utcOrNil(txn.EffectiveDate),
+		txn.TransactionID, txn.ParentTransaction, txn.Source, txn.Reference, amount, preciseAmount, txn.Precision, txn.Currency, txn.Destination, txn.Description, txn.Status, txn.CreatedAt.UTC(), metaDataJSON, txn.ScheduledFor.UTC(), txn.Hash, utcOrNil(txn.EffectiveDate),
 	)
 	// Handle errors that may occur during the execution of the query
 	if err != nil {
@@ -104,10 +121,16 @@ func recordTransactionInTx(ctx context.Context, tx *sql.Tx, txn *model.Transacti
 		return apierror.NewAPIError(apierror.ErrInternalServer, "Failed to marshal metadata", err)
 	}
 
+	amount, preciseAmount, err := persistNumericColumns(txn)
+	if err != nil {
+		span.RecordError(err)
+		return apierror.NewAPIError(apierror.ErrInternalServer, "Failed to record transaction", err)
+	}
+
 	_, err = tx.ExecContext(ctx,
 		`INSERT INTO blnk.transactions(transaction_id, parent_transaction, source, reference, amount, precise_amount, precision, currency, destination, description, status, created_at, meta_data, scheduled_for, hash, effective_date)
 		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)`,
-		txn.TransactionID, txn.ParentTransaction, txn.Source, txn.Reference, persistAmountString(txn.AmountString), persistPreciseAmount(txn.PreciseAmount), txn.Precision, txn.Currency, txn.Destination, txn.Description, txn.Status, txn.CreatedAt.UTC(), metaDataJSON, txn.ScheduledFor.UTC(), txn.Hash, utcOrNil(txn.EffectiveDate),
+		txn.TransactionID, txn.ParentTransaction, txn.Source, txn.Reference, amount, preciseAmount, txn.Precision, txn.Currency, txn.Destination, txn.Description, txn.Status, txn.CreatedAt.UTC(), metaDataJSON, txn.ScheduledFor.UTC(), txn.Hash, utcOrNil(txn.EffectiveDate),
 	)
 	if err != nil {
 		span.RecordError(err)
@@ -167,13 +190,19 @@ func recordTransactionsInTx(ctx context.Context, tx *sql.Tx, txns []*model.Trans
 			return apierror.NewAPIError(apierror.ErrInternalServer, "Failed to marshal metadata", err)
 		}
 
+		amount, preciseAmount, err := persistNumericColumns(txn)
+		if err != nil {
+			span.RecordError(err)
+			return apierror.NewAPIError(apierror.ErrInternalServer, "Failed to stream transaction copy row", err)
+		}
+
 		if _, err := stmt.ExecContext(ctx,
 			txn.TransactionID,
 			txn.ParentTransaction,
 			txn.Source,
 			txn.Reference,
-			persistAmountString(txn.AmountString),
-			persistPreciseAmount(txn.PreciseAmount),
+			amount,
+			preciseAmount,
 			txn.Precision,
 			txn.Currency,
 			txn.Destination,

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -21,6 +21,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"time"
 
 	"github.com/blnkfinance/blnk/internal/apierror"
@@ -41,6 +42,23 @@ func utcOrNil(t *time.Time) *time.Time {
 	return &u
 }
 
+// persistAmountString is the value written to the numeric amount column.
+// An empty string is not valid numeric input for Postgres.
+func persistAmountString(amount string) string {
+	if amount == "" {
+		return "0"
+	}
+	return amount
+}
+
+// persistPreciseAmount is the value written to the numeric precise_amount column.
+func persistPreciseAmount(amount *big.Int) string {
+	if amount == nil {
+		return "0"
+	}
+	return amount.String()
+}
+
 func (d Datasource) RecordTransaction(ctx context.Context, txn *model.Transaction) (*model.Transaction, error) {
 	// Start a new tracing span for the database operation
 	ctx, span := otel.Tracer("transaction.database").Start(ctx, "PersistTransaction")
@@ -57,7 +75,7 @@ func (d Datasource) RecordTransaction(ctx context.Context, txn *model.Transactio
 	_, err = d.Conn.ExecContext(ctx,
 		`INSERT INTO blnk.transactions(transaction_id, parent_transaction, source, reference, amount, precise_amount, precision, currency, destination, description, status, created_at, meta_data, scheduled_for, hash, effective_date)
 		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)`,
-		txn.TransactionID, txn.ParentTransaction, txn.Source, txn.Reference, txn.AmountString, txn.PreciseAmount.String(), txn.Precision, txn.Currency, txn.Destination, txn.Description, txn.Status, txn.CreatedAt.UTC(), metaDataJSON, txn.ScheduledFor.UTC(), txn.Hash, utcOrNil(txn.EffectiveDate),
+		txn.TransactionID, txn.ParentTransaction, txn.Source, txn.Reference, persistAmountString(txn.AmountString), persistPreciseAmount(txn.PreciseAmount), txn.Precision, txn.Currency, txn.Destination, txn.Description, txn.Status, txn.CreatedAt.UTC(), metaDataJSON, txn.ScheduledFor.UTC(), txn.Hash, utcOrNil(txn.EffectiveDate),
 	)
 	// Handle errors that may occur during the execution of the query
 	if err != nil {
@@ -89,7 +107,7 @@ func recordTransactionInTx(ctx context.Context, tx *sql.Tx, txn *model.Transacti
 	_, err = tx.ExecContext(ctx,
 		`INSERT INTO blnk.transactions(transaction_id, parent_transaction, source, reference, amount, precise_amount, precision, currency, destination, description, status, created_at, meta_data, scheduled_for, hash, effective_date)
 		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)`,
-		txn.TransactionID, txn.ParentTransaction, txn.Source, txn.Reference, txn.AmountString, txn.PreciseAmount.String(), txn.Precision, txn.Currency, txn.Destination, txn.Description, txn.Status, txn.CreatedAt.UTC(), metaDataJSON, txn.ScheduledFor.UTC(), txn.Hash, utcOrNil(txn.EffectiveDate),
+		txn.TransactionID, txn.ParentTransaction, txn.Source, txn.Reference, persistAmountString(txn.AmountString), persistPreciseAmount(txn.PreciseAmount), txn.Precision, txn.Currency, txn.Destination, txn.Description, txn.Status, txn.CreatedAt.UTC(), metaDataJSON, txn.ScheduledFor.UTC(), txn.Hash, utcOrNil(txn.EffectiveDate),
 	)
 	if err != nil {
 		span.RecordError(err)
@@ -154,8 +172,8 @@ func recordTransactionsInTx(ctx context.Context, tx *sql.Tx, txns []*model.Trans
 			txn.ParentTransaction,
 			txn.Source,
 			txn.Reference,
-			txn.AmountString,
-			txn.PreciseAmount.String(),
+			persistAmountString(txn.AmountString),
+			persistPreciseAmount(txn.PreciseAmount),
 			txn.Precision,
 			txn.Currency,
 			txn.Destination,

--- a/database/transaction_recovery.go
+++ b/database/transaction_recovery.go
@@ -36,12 +36,15 @@ func (d Datasource) GetStuckQueuedTransactions(ctx context.Context, threshold ti
 
 	cutoff := time.Now().UTC().Add(-threshold)
 
+	// Leave the parent in this set until a terminal child exists. Metadata
+	// flags must not hide a QUEUED row with no lineage: recovery has to retry
+	// a failed REJECTED write, and operators can still find it here or via
+	// POST /transactions/recover.
 	rows, err := d.Conn.QueryContext(ctx, `
 		SELECT transaction_id, parent_transaction, source, reference, amount, COALESCE(precise_amount::text, '0'), precision, currency, destination, description, status, created_at, meta_data, scheduled_for, hash
 		FROM blnk.transactions t
 		WHERE t.status = 'QUEUED'
 		  AND t.created_at < $1
-		  AND COALESCE(t.meta_data->>'recovery_status', '') <> 'unrecoverable'
 		  AND NOT EXISTS (
 		      SELECT 1 FROM blnk.transactions child
 		      WHERE child.parent_transaction = t.transaction_id

--- a/database/transaction_recovery.go
+++ b/database/transaction_recovery.go
@@ -37,10 +37,11 @@ func (d Datasource) GetStuckQueuedTransactions(ctx context.Context, threshold ti
 	cutoff := time.Now().UTC().Add(-threshold)
 
 	rows, err := d.Conn.QueryContext(ctx, `
-		SELECT transaction_id, parent_transaction, source, reference, amount, precise_amount, precision, currency, destination, description, status, created_at, meta_data, scheduled_for, hash
+		SELECT transaction_id, parent_transaction, source, reference, amount, COALESCE(precise_amount::text, '0'), precision, currency, destination, description, status, created_at, meta_data, scheduled_for, hash
 		FROM blnk.transactions t
 		WHERE t.status = 'QUEUED'
 		  AND t.created_at < $1
+		  AND COALESCE(t.meta_data->>'recovery_status', '') <> 'unrecoverable'
 		  AND NOT EXISTS (
 		      SELECT 1 FROM blnk.transactions child
 		      WHERE child.parent_transaction = t.transaction_id

--- a/database/transactions_test.go
+++ b/database/transactions_test.go
@@ -146,12 +146,45 @@ func TestRecordTransaction_Failure(t *testing.T) {
 	assert.NoError(t, err)
 
 	mock.ExpectExec("INSERT INTO blnk.transactions").
-		WithArgs(transaction.TransactionID, transaction.ParentTransaction, transaction.Source, transaction.Reference, transaction.Amount, transaction.PreciseAmount.String(), transaction.Precision, transaction.Currency, transaction.Destination, transaction.Description, transaction.Status, transaction.CreatedAt, metaDataJSON, transaction.ScheduledFor, transaction.Hash, transaction.EffectiveDate).
+		WithArgs(transaction.TransactionID, transaction.ParentTransaction, transaction.Source, transaction.Reference, persistAmountString(transaction.AmountString), persistPreciseAmount(transaction.PreciseAmount), transaction.Precision, transaction.Currency, transaction.Destination, transaction.Description, transaction.Status, transaction.CreatedAt.UTC(), metaDataJSON, transaction.ScheduledFor.UTC(), transaction.Hash, nil).
 		WillReturnError(errors.New("db error"))
 
 	_, err = ds.RecordTransaction(ctx, transaction)
 	assert.Error(t, err)
 	assert.IsType(t, apierror.APIError{}, err)
+}
+
+func TestRecordTransaction_EmptyAmountStringPersistsZero(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	ds := Datasource{Conn: db}
+	transaction := &model.Transaction{
+		TransactionID: "txn_zero",
+		Source:        "src1",
+		Reference:     "ref_zero",
+		Currency:      "WBTC",
+		Destination:   "dest1",
+		Status:        "QUEUED",
+		CreatedAt:     time.Now(),
+		MetaData:      map[string]interface{}{},
+		ScheduledFor:  time.Now(),
+		Hash:          "hash123",
+		PreciseAmount: nil,
+		Precision:     100,
+	}
+
+	metaDataJSON, err := json.Marshal(transaction.MetaData)
+	assert.NoError(t, err)
+
+	mock.ExpectExec("INSERT INTO blnk.transactions").
+		WithArgs(transaction.TransactionID, transaction.ParentTransaction, transaction.Source, transaction.Reference, "0", "0", transaction.Precision, transaction.Currency, transaction.Destination, transaction.Description, transaction.Status, transaction.CreatedAt.UTC(), metaDataJSON, transaction.ScheduledFor.UTC(), transaction.Hash, nil).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	result, err := ds.RecordTransaction(context.Background(), transaction)
+	assert.NoError(t, err)
+	assert.Equal(t, transaction, result)
 }
 
 func TestGetTransaction_Success(t *testing.T) {

--- a/database/transactions_test.go
+++ b/database/transactions_test.go
@@ -156,8 +156,28 @@ func TestRecordTransaction_Failure(t *testing.T) {
 }
 
 func TestPersistNumericColumns(t *testing.T) {
-	t.Run("rejected missing amounts persist as zero", func(t *testing.T) {
-		amount, precise, err := persistNumericColumns(&model.Transaction{Status: "REJECTED"})
+	t.Run("rejected missing amount string is rejected", func(t *testing.T) {
+		_, _, err := persistNumericColumns(&model.Transaction{
+			Status:        "REJECTED",
+			PreciseAmount: model.Int64ToBigInt(0),
+		})
+		assert.EqualError(t, err, "amount is required")
+	})
+
+	t.Run("rejected missing precise amount is rejected", func(t *testing.T) {
+		_, _, err := persistNumericColumns(&model.Transaction{
+			Status:       "REJECTED",
+			AmountString: "10",
+		})
+		assert.EqualError(t, err, "precise_amount is required")
+	})
+
+	t.Run("rejected explicit zero is allowed", func(t *testing.T) {
+		amount, precise, err := persistNumericColumns(&model.Transaction{
+			Status:        "REJECTED",
+			AmountString:  "0",
+			PreciseAmount: model.Int64ToBigInt(0),
+		})
 		assert.NoError(t, err)
 		assert.Equal(t, "0", amount)
 		assert.Equal(t, "0", precise)
@@ -191,7 +211,7 @@ func TestPersistNumericColumns(t *testing.T) {
 	})
 }
 
-func TestRecordTransaction_RejectedAllowsZeroAmounts(t *testing.T) {
+func TestRecordTransaction_RejectedRequiresMaterializedAmounts(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
 	defer func() { _ = db.Close() }()
@@ -208,7 +228,8 @@ func TestRecordTransaction_RejectedAllowsZeroAmounts(t *testing.T) {
 		MetaData:      map[string]interface{}{},
 		ScheduledFor:  time.Now(),
 		Hash:          "hash123",
-		PreciseAmount: nil,
+		AmountString:  "0",
+		PreciseAmount: model.Int64ToBigInt(0),
 		Precision:     100,
 	}
 
@@ -224,7 +245,7 @@ func TestRecordTransaction_RejectedAllowsZeroAmounts(t *testing.T) {
 	assert.Equal(t, transaction, result)
 }
 
-func TestRecordTransaction_MissingAmountRejectedForNonRejectedStatus(t *testing.T) {
+func TestRecordTransaction_MissingAmountRejectedForAllStatuses(t *testing.T) {
 	cases := []struct {
 		name string
 		txn  *model.Transaction
@@ -247,6 +268,17 @@ func TestRecordTransaction_MissingAmountRejectedForNonRejectedStatus(t *testing.
 				Reference:     "ref_applied_missing",
 				AmountString:  "10",
 				Status:        "APPLIED",
+				CreatedAt:     time.Now(),
+				ScheduledFor:  time.Now(),
+			},
+		},
+		{
+			name: "rejected partial numeric fields",
+			txn: &model.Transaction{
+				TransactionID: "txn_rejected_partial",
+				Reference:     "ref_rejected_partial",
+				AmountString:  "10",
+				Status:        "REJECTED",
 				CreatedAt:     time.Now(),
 				ScheduledFor:  time.Now(),
 			},

--- a/database/transactions_test.go
+++ b/database/transactions_test.go
@@ -128,6 +128,7 @@ func TestRecordTransaction_Failure(t *testing.T) {
 		Source:            "src1",
 		Reference:         "ref123",
 		Amount:            1000,
+		AmountString:      "1000",
 		Currency:          "USD",
 		Destination:       "dest1",
 		Description:       "Test Transaction",
@@ -146,7 +147,7 @@ func TestRecordTransaction_Failure(t *testing.T) {
 	assert.NoError(t, err)
 
 	mock.ExpectExec("INSERT INTO blnk.transactions").
-		WithArgs(transaction.TransactionID, transaction.ParentTransaction, transaction.Source, transaction.Reference, persistAmountString(transaction.AmountString), persistPreciseAmount(transaction.PreciseAmount), transaction.Precision, transaction.Currency, transaction.Destination, transaction.Description, transaction.Status, transaction.CreatedAt.UTC(), metaDataJSON, transaction.ScheduledFor.UTC(), transaction.Hash, nil).
+		WithArgs(transaction.TransactionID, transaction.ParentTransaction, transaction.Source, transaction.Reference, transaction.AmountString, transaction.PreciseAmount.String(), transaction.Precision, transaction.Currency, transaction.Destination, transaction.Description, transaction.Status, transaction.CreatedAt.UTC(), metaDataJSON, transaction.ScheduledFor.UTC(), transaction.Hash, nil).
 		WillReturnError(errors.New("db error"))
 
 	_, err = ds.RecordTransaction(ctx, transaction)
@@ -154,19 +155,55 @@ func TestRecordTransaction_Failure(t *testing.T) {
 	assert.IsType(t, apierror.APIError{}, err)
 }
 
-func TestRecordTransaction_EmptyAmountStringPersistsZero(t *testing.T) {
+func TestPersistNumericColumns(t *testing.T) {
+	t.Run("rejected missing amounts persist as zero", func(t *testing.T) {
+		amount, precise, err := persistNumericColumns(&model.Transaction{Status: "REJECTED"})
+		assert.NoError(t, err)
+		assert.Equal(t, "0", amount)
+		assert.Equal(t, "0", precise)
+	})
+
+	t.Run("queued missing amount string is rejected", func(t *testing.T) {
+		_, _, err := persistNumericColumns(&model.Transaction{
+			Status:        "QUEUED",
+			PreciseAmount: model.Int64ToBigInt(1000),
+		})
+		assert.EqualError(t, err, "amount is required")
+	})
+
+	t.Run("applied nil precise amount is rejected", func(t *testing.T) {
+		_, _, err := persistNumericColumns(&model.Transaction{
+			Status:       "APPLIED",
+			AmountString: "10",
+		})
+		assert.EqualError(t, err, "precise_amount is required")
+	})
+
+	t.Run("queued explicit zero is allowed for legacy rows", func(t *testing.T) {
+		amount, precise, err := persistNumericColumns(&model.Transaction{
+			Status:        "QUEUED",
+			AmountString:  "0",
+			PreciseAmount: model.Int64ToBigInt(0),
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, "0", amount)
+		assert.Equal(t, "0", precise)
+	})
+}
+
+func TestRecordTransaction_RejectedAllowsZeroAmounts(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
 	defer func() { _ = db.Close() }()
 
 	ds := Datasource{Conn: db}
 	transaction := &model.Transaction{
-		TransactionID: "txn_zero",
+		TransactionID: "txn_rejected_zero",
 		Source:        "src1",
-		Reference:     "ref_zero",
+		Reference:     "ref_rejected_zero",
 		Currency:      "WBTC",
 		Destination:   "dest1",
-		Status:        "QUEUED",
+		Status:        "REJECTED",
 		CreatedAt:     time.Now(),
 		MetaData:      map[string]interface{}{},
 		ScheduledFor:  time.Now(),
@@ -185,6 +222,50 @@ func TestRecordTransaction_EmptyAmountStringPersistsZero(t *testing.T) {
 	result, err := ds.RecordTransaction(context.Background(), transaction)
 	assert.NoError(t, err)
 	assert.Equal(t, transaction, result)
+}
+
+func TestRecordTransaction_MissingAmountRejectedForNonRejectedStatus(t *testing.T) {
+	cases := []struct {
+		name string
+		txn  *model.Transaction
+	}{
+		{
+			name: "queued missing amount string",
+			txn: &model.Transaction{
+				TransactionID: "txn_queued_missing",
+				Reference:     "ref_queued_missing",
+				Status:        "QUEUED",
+				CreatedAt:     time.Now(),
+				ScheduledFor:  time.Now(),
+				PreciseAmount: model.Int64ToBigInt(0),
+			},
+		},
+		{
+			name: "applied nil precise amount",
+			txn: &model.Transaction{
+				TransactionID: "txn_applied_missing",
+				Reference:     "ref_applied_missing",
+				AmountString:  "10",
+				Status:        "APPLIED",
+				CreatedAt:     time.Now(),
+				ScheduledFor:  time.Now(),
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			assert.NoError(t, err)
+			defer func() { _ = db.Close() }()
+
+			ds := Datasource{Conn: db}
+			_, err = ds.RecordTransaction(context.Background(), tc.txn)
+			assert.Error(t, err)
+			assert.IsType(t, apierror.APIError{}, err)
+			assert.NoError(t, mock.ExpectationsWereMet(), "missing amount fields must fail before SQL")
+		})
+	}
 }
 
 func TestGetTransaction_Success(t *testing.T) {

--- a/model/model.go
+++ b/model/model.go
@@ -304,6 +304,10 @@ func applyPrecisionLogic(transaction *Transaction) *big.Int {
 	}
 
 	transaction.PreciseAmount = convertDecimalToPrecise(transaction)
+	// Always materialize AmountString, including for a precise amount of 0.
+	// The persist path writes AmountString into a numeric column; leaving it
+	// blank makes Postgres reject the insert with invalid input syntax.
+	convertPreciseToDecimal(transaction)
 	return transaction.PreciseAmount
 }
 
@@ -436,6 +440,12 @@ func convertDecimalToPrecise(transaction *Transaction) *big.Int {
 	result.SetString(preciseAmount.String(), 10)
 
 	return result
+}
+
+// ValidateAmount is the exported ingest check used by QueueTransaction so
+// zero/empty amounts never land on the queue.
+func (transaction *Transaction) ValidateAmount() error {
+	return transaction.validate()
 }
 
 // validate checks if the transaction has a positive amount.

--- a/model/mutation_killers_test.go
+++ b/model/mutation_killers_test.go
@@ -121,6 +121,7 @@ func TestApplyPrecision_ZeroPreciseAmountFallsThroughToAmount(t *testing.T) {
 	txn := &Transaction{PreciseAmount: big.NewInt(0), Amount: 5, Precision: 100}
 	got := ApplyPrecision(txn)
 	assert.Equal(t, "500", got.String())
+	assert.Equal(t, "5", txn.AmountString)
 }
 
 func TestValidate_ZeroAmountRejected(t *testing.T) {

--- a/model/precision_edge_test.go
+++ b/model/precision_edge_test.go
@@ -135,12 +135,18 @@ func TestApplyPrecision_EdgeCases(t *testing.T) {
 		assert.Equal(t, "42", got.String())
 	})
 
-	t.Run("existing positive precise amount drives the decimal amount", func(t *testing.T) {
-		txn := &Transaction{PreciseAmount: big.NewInt(1001), Precision: 100}
+	t.Run("zero precise amount fills AmountString", func(t *testing.T) {
+		txn := &Transaction{PreciseAmount: big.NewInt(0), Amount: 0, Precision: 100}
 		got := ApplyPrecision(txn)
-		assert.Equal(t, "1001", got.String())
-		assert.Equal(t, 10.01, txn.Amount)
-		assert.Equal(t, "10.01", txn.AmountString)
+		assert.Equal(t, "0", got.String())
+		assert.Equal(t, "0", txn.AmountString)
+	})
+
+	t.Run("amount-only conversion fills AmountString in one pass", func(t *testing.T) {
+		txn := &Transaction{Amount: 10, Precision: 100}
+		got := ApplyPrecision(txn)
+		assert.Equal(t, "1000", got.String())
+		assert.Equal(t, "10", txn.AmountString)
 	})
 
 	t.Run("float-hostile decimal amounts convert exactly", func(t *testing.T) {

--- a/model/precision_edge_test.go
+++ b/model/precision_edge_test.go
@@ -149,6 +149,14 @@ func TestApplyPrecision_EdgeCases(t *testing.T) {
 		assert.Equal(t, "10", txn.AmountString)
 	})
 
+	t.Run("existing positive precise amount drives the decimal amount", func(t *testing.T) {
+		txn := &Transaction{PreciseAmount: big.NewInt(1001), Precision: 100}
+		got := ApplyPrecision(txn)
+		assert.Equal(t, "1001", got.String())
+		assert.Equal(t, 10.01, txn.Amount)
+		assert.Equal(t, "10.01", txn.AmountString)
+	})
+
 	t.Run("float-hostile decimal amounts convert exactly", func(t *testing.T) {
 		// All of these are classic binary-float traps. The decimal-based
 		// conversion must produce the exact minor-unit integer.

--- a/queue_recovery.go
+++ b/queue_recovery.go
@@ -18,6 +18,8 @@ package blnk
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"sync"
 	"time"
 
@@ -124,41 +126,54 @@ func (p *QueuedTransactionRecoveryProcessor) run(ctx context.Context) {
 
 // processBatch performs one periodic stuck-queue recovery pass using the configured threshold.
 func (p *QueuedTransactionRecoveryProcessor) processBatch(ctx context.Context) {
-	p.recoverWithThreshold(ctx, p.stuckThreshold)
+	recovered, err := p.recoverWithThreshold(ctx, p.stuckThreshold)
+	if err != nil {
+		logrus.Errorf("stuck queue recovery pass recovered %d with failures: %v", recovered, err)
+	}
 }
 
 // RecoverQueuedTransactions triggers an immediate recovery of stuck queued transactions
 // using the provided threshold. This is exposed for the manual trigger API endpoint.
+// recovered is the number of stuck rows successfully resolved; err is non-nil when
+// any row in the batch could not be recovered.
 func (b *Blnk) RecoverQueuedTransactions(ctx context.Context, threshold time.Duration) (int, error) {
 	if threshold < 2*time.Minute {
 		threshold = 2 * time.Minute
 	}
 
 	processor := NewQueuedTransactionRecoveryProcessor(b)
-	return processor.recoverWithThreshold(ctx, threshold), nil
+	return processor.recoverWithThreshold(ctx, threshold)
 }
 
 // recoverWithThreshold loads currently stuck queued transactions and reprocesses them serially.
-func (p *QueuedTransactionRecoveryProcessor) recoverWithThreshold(ctx context.Context, threshold time.Duration) int {
+func (p *QueuedTransactionRecoveryProcessor) recoverWithThreshold(ctx context.Context, threshold time.Duration) (int, error) {
 	stuckTxns, err := p.blnk.datasource.GetStuckQueuedTransactions(ctx, threshold, p.batchSize)
 	if err != nil {
 		logrus.Errorf("failed to get stuck queued transactions: %v", err)
-		return 0
+		return 0, err
 	}
 
 	if len(stuckTxns) == 0 {
-		return 0
+		return 0, nil
 	}
 
 	logrus.Infof("Processing %d stuck queued transactions with %d workers (threshold=%v)", len(stuckTxns), p.maxWorkers, threshold)
 
+	var recovered int
+	var failures []error
 	for _, txn := range stuckTxns {
 		if err := p.processStuckTransaction(ctx, txn); err != nil {
 			logrus.Errorf("failed to process stuck transaction %s: %v", txn.TransactionID, err)
+			failures = append(failures, fmt.Errorf("%s: %w", txn.TransactionID, err))
+			continue
 		}
+		recovered++
 	}
 
-	return len(stuckTxns)
+	if len(failures) > 0 {
+		return recovered, fmt.Errorf("recovery failed for %d of %d stuck transactions: %w", len(failures), len(stuckTxns), errors.Join(failures...))
+	}
+	return recovered, nil
 }
 
 // processStuckTransaction replays one stuck queued transaction, preserving the existing recovery

--- a/queue_recovery.go
+++ b/queue_recovery.go
@@ -26,6 +26,13 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	recoveryStatusRecovered        = "recovered"
+	recoveryStatusFailed           = "failed"
+	recoveryStatusAlreadyProcessed = "already_processed"
+	recoveryStatusUnrecoverable    = "unrecoverable"
+)
+
 type QueuedTransactionRecoveryProcessor struct {
 	blnk                     *Blnk
 	batchSize                int
@@ -173,17 +180,14 @@ func (p *QueuedTransactionRecoveryProcessor) processStuckTransaction(ctx context
 	}
 	attempts++
 
+	if isZeroPreciseAmount(stuckTxn) {
+		logrus.Warnf("Stuck transaction %s has a zero amount, rejecting", stuckTxn.TransactionID)
+		return p.rejectStuckTransaction(ctx, stuckTxn, attempts, "zero amount")
+	}
+
 	if attempts > p.maxRecoveryAttempts {
 		logrus.Warnf("Stuck transaction %s exceeded max recovery attempts (%d), rejecting", stuckTxn.TransactionID, p.maxRecoveryAttempts)
-		rejectionCopy := createQueueCopy(stuckTxn, stuckTxn.Reference)
-		_, err := p.blnk.RejectTransaction(ctx, rejectionCopy, "exceeded max queued recovery attempts")
-		if err != nil {
-			if isReferenceAlreadyUsedError(err) {
-				return nil
-			}
-			return err
-		}
-		return nil
+		return p.rejectStuckTransaction(ctx, stuckTxn, attempts, "exceeded max queued recovery attempts")
 	}
 
 	if stuckTxn.Atomic {
@@ -206,11 +210,11 @@ func (p *QueuedTransactionRecoveryProcessor) processStuckTransaction(ctx context
 	if err != nil {
 		if isReferenceAlreadyUsedError(err) {
 			logrus.Infof("Stuck transaction %s already processed (reference %s already used)", stuckTxn.TransactionID, queueCopy.Reference)
-			p.updateRecoveryMetadata(ctx, stuckTxn, attempts, "already_processed")
+			p.updateRecoveryMetadata(ctx, stuckTxn, attempts, recoveryStatusAlreadyProcessed)
 			return nil
 		}
 
-		p.updateRecoveryMetadata(ctx, stuckTxn, attempts, "failed")
+		p.updateRecoveryMetadata(ctx, stuckTxn, attempts, recoveryStatusFailed)
 		return err
 	}
 
@@ -219,7 +223,24 @@ func (p *QueuedTransactionRecoveryProcessor) processStuckTransaction(ctx context
 	} else {
 		logrus.Infof("Successfully recovered stuck transaction %s via queue copy %s", stuckTxn.TransactionID, queueCopy.TransactionID)
 	}
-	p.updateRecoveryMetadata(ctx, stuckTxn, attempts, "recovered")
+	p.updateRecoveryMetadata(ctx, stuckTxn, attempts, recoveryStatusRecovered)
+	return nil
+}
+
+// rejectStuckTransaction writes a REJECTED child for a stuck QUEUED parent.
+// If that insert still fails, the parent is marked unrecoverable so it no
+// longer occupies the oldest-100 recovery window forever.
+func (p *QueuedTransactionRecoveryProcessor) rejectStuckTransaction(ctx context.Context, stuckTxn *model.Transaction, attempts int, reason string) error {
+	rejectionCopy := createQueueCopy(stuckTxn, stuckTxn.Reference)
+	_, err := p.blnk.RejectTransaction(ctx, rejectionCopy, reason)
+	if err != nil {
+		if isReferenceAlreadyUsedError(err) {
+			return nil
+		}
+		p.updateRecoveryMetadata(ctx, stuckTxn, attempts, recoveryStatusUnrecoverable)
+		logrus.Errorf("failed to reject stuck transaction %s: %v; marking unrecoverable so it no longer blocks recovery", stuckTxn.TransactionID, err)
+		return nil
+	}
 	return nil
 }
 
@@ -247,4 +268,8 @@ func (p *QueuedTransactionRecoveryProcessor) updateRecoveryMetadata(ctx context.
 
 func isReferenceAlreadyUsedError(err error) bool {
 	return IsDuplicateReferenceError(err)
+}
+
+func isZeroPreciseAmount(txn *model.Transaction) bool {
+	return txn != nil && txn.PreciseAmount != nil && txn.PreciseAmount.Sign() <= 0
 }

--- a/queue_recovery.go
+++ b/queue_recovery.go
@@ -30,7 +30,6 @@ const (
 	recoveryStatusRecovered        = "recovered"
 	recoveryStatusFailed           = "failed"
 	recoveryStatusAlreadyProcessed = "already_processed"
-	recoveryStatusUnrecoverable    = "unrecoverable"
 )
 
 type QueuedTransactionRecoveryProcessor struct {
@@ -182,12 +181,12 @@ func (p *QueuedTransactionRecoveryProcessor) processStuckTransaction(ctx context
 
 	if isZeroPreciseAmount(stuckTxn) {
 		logrus.Warnf("Stuck transaction %s has a zero amount, rejecting", stuckTxn.TransactionID)
-		return p.rejectStuckTransaction(ctx, stuckTxn, attempts, "zero amount")
+		return p.rejectStuckTransaction(ctx, stuckTxn, "zero amount")
 	}
 
 	if attempts > p.maxRecoveryAttempts {
 		logrus.Warnf("Stuck transaction %s exceeded max recovery attempts (%d), rejecting", stuckTxn.TransactionID, p.maxRecoveryAttempts)
-		return p.rejectStuckTransaction(ctx, stuckTxn, attempts, "exceeded max queued recovery attempts")
+		return p.rejectStuckTransaction(ctx, stuckTxn, "exceeded max queued recovery attempts")
 	}
 
 	if stuckTxn.Atomic {
@@ -228,18 +227,19 @@ func (p *QueuedTransactionRecoveryProcessor) processStuckTransaction(ctx context
 }
 
 // rejectStuckTransaction writes a REJECTED child for a stuck QUEUED parent.
-// If that insert still fails, the parent is marked unrecoverable so it no
-// longer occupies the oldest-100 recovery window forever.
-func (p *QueuedTransactionRecoveryProcessor) rejectStuckTransaction(ctx context.Context, stuckTxn *model.Transaction, attempts int, reason string) error {
+// A failed write is returned so the parent stays in the stuck set (QUEUED,
+// no child) and recovery can retry. Do not metadata-exclude a parent that
+// still has no terminal child: that would leave it QUEUED forever with no
+// lineage and no automatic retry.
+func (p *QueuedTransactionRecoveryProcessor) rejectStuckTransaction(ctx context.Context, stuckTxn *model.Transaction, reason string) error {
 	rejectionCopy := createQueueCopy(stuckTxn, stuckTxn.Reference)
 	_, err := p.blnk.RejectTransaction(ctx, rejectionCopy, reason)
 	if err != nil {
 		if isReferenceAlreadyUsedError(err) {
 			return nil
 		}
-		p.updateRecoveryMetadata(ctx, stuckTxn, attempts, recoveryStatusUnrecoverable)
-		logrus.Errorf("failed to reject stuck transaction %s: %v; marking unrecoverable so it no longer blocks recovery", stuckTxn.TransactionID, err)
-		return nil
+		logrus.Errorf("failed to reject stuck transaction %s: %v; leaving QUEUED so recovery can retry", stuckTxn.TransactionID, err)
+		return err
 	}
 	return nil
 }
@@ -263,6 +263,7 @@ func (p *QueuedTransactionRecoveryProcessor) updateRecoveryMetadata(ctx context.
 
 	if err := p.blnk.datasource.UpdateTransactionMetadata(ctx, txn.TransactionID, txn.MetaData); err != nil {
 		logrus.Errorf("failed to update recovery metadata for transaction %s: %v", txn.TransactionID, err)
+		return
 	}
 }
 

--- a/queue_recovery_test.go
+++ b/queue_recovery_test.go
@@ -2,6 +2,8 @@ package blnk
 
 import (
 	"context"
+	"errors"
+	"math/big"
 	"testing"
 
 	dbmocks "github.com/blnkfinance/blnk/database/mocks"
@@ -9,7 +11,23 @@ import (
 	"github.com/blnkfinance/blnk/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
+
+func positiveStuckTxn() *model.Transaction {
+	return &model.Transaction{
+		TransactionID: "txn_parent",
+		Reference:     "ref_1",
+		Source:        "bln_source",
+		Destination:   "bln_dest",
+		Currency:      "USD",
+		Amount:        100,
+		PreciseAmount: big.NewInt(10000),
+		Precision:     100,
+		Status:        StatusQueued,
+		MetaData:      map[string]interface{}{},
+	}
+}
 
 func TestNewQueuedTransactionRecoveryProcessor_UsesSingleWorker(t *testing.T) {
 	processor := NewQueuedTransactionRecoveryProcessor(&Blnk{})
@@ -23,15 +41,7 @@ func TestProcessStuckTransaction_UsesCoalescingBeforeDirectReplay(t *testing.T) 
 	blnk := &Blnk{datasource: mockDS}
 	processor := NewQueuedTransactionRecoveryProcessor(blnk)
 
-	stuckTxn := &model.Transaction{
-		TransactionID: "txn_parent",
-		Reference:     "ref_1",
-		Source:        "bln_source",
-		Destination:   "bln_dest",
-		Currency:      "USD",
-		Status:        StatusQueued,
-		MetaData:      map[string]interface{}{},
-	}
+	stuckTxn := positiveStuckTxn()
 
 	var hotLane bool
 	processor.processQueuedTransaction = func(ctx context.Context, txn *model.Transaction, gotHotLane bool) (transactionExecutionResult, error) {
@@ -40,7 +50,7 @@ func TestProcessStuckTransaction_UsesCoalescingBeforeDirectReplay(t *testing.T) 
 	}
 
 	mockDS.On("UpdateTransactionMetadata", mock.Anything, stuckTxn.TransactionID, mock.MatchedBy(func(metadata map[string]interface{}) bool {
-		return metadata["recovery_status"] == "recovered" && metadata["recovery_attempts"] == 1
+		return metadata["recovery_status"] == recoveryStatusRecovered && metadata["recovery_attempts"] == 1
 	})).Return(nil).Once()
 
 	err := processor.processStuckTransaction(context.Background(), stuckTxn)
@@ -54,16 +64,9 @@ func TestProcessStuckTransaction_UsesHotLaneCoalescingWhenMarkedHot(t *testing.T
 	blnk := &Blnk{datasource: mockDS}
 	processor := NewQueuedTransactionRecoveryProcessor(blnk)
 
-	stuckTxn := &model.Transaction{
-		TransactionID: "txn_parent",
-		Reference:     "ref_1",
-		Source:        "bln_source",
-		Destination:   "bln_dest",
-		Currency:      "USD",
-		Status:        StatusQueued,
-		MetaData: map[string]interface{}{
-			hotpairs.QueueLaneMetaKey: hotpairs.LaneHot,
-		},
+	stuckTxn := positiveStuckTxn()
+	stuckTxn.MetaData = map[string]interface{}{
+		hotpairs.QueueLaneMetaKey: hotpairs.LaneHot,
 	}
 
 	var hotLane bool
@@ -73,7 +76,7 @@ func TestProcessStuckTransaction_UsesHotLaneCoalescingWhenMarkedHot(t *testing.T
 	}
 
 	mockDS.On("UpdateTransactionMetadata", mock.Anything, stuckTxn.TransactionID, mock.MatchedBy(func(metadata map[string]interface{}) bool {
-		return metadata["recovery_status"] == "recovered" && metadata["recovery_attempts"] == 1
+		return metadata["recovery_status"] == recoveryStatusRecovered && metadata["recovery_attempts"] == 1
 	})).Return(nil).Once()
 
 	err := processor.processStuckTransaction(context.Background(), stuckTxn)
@@ -87,15 +90,7 @@ func TestProcessStuckTransaction_FallsBackToDirectReplayWhenBatchNotHandled(t *t
 	blnk := &Blnk{datasource: mockDS}
 	processor := NewQueuedTransactionRecoveryProcessor(blnk)
 
-	stuckTxn := &model.Transaction{
-		TransactionID: "txn_parent",
-		Reference:     "ref_1",
-		Source:        "bln_source",
-		Destination:   "bln_dest",
-		Currency:      "USD",
-		Status:        StatusQueued,
-		MetaData:      map[string]interface{}{},
-	}
+	stuckTxn := positiveStuckTxn()
 
 	var hotLane bool
 	processor.processQueuedTransaction = func(ctx context.Context, txn *model.Transaction, gotHotLane bool) (transactionExecutionResult, error) {
@@ -104,11 +99,86 @@ func TestProcessStuckTransaction_FallsBackToDirectReplayWhenBatchNotHandled(t *t
 	}
 
 	mockDS.On("UpdateTransactionMetadata", mock.Anything, stuckTxn.TransactionID, mock.MatchedBy(func(metadata map[string]interface{}) bool {
-		return metadata["recovery_status"] == "recovered" && metadata["recovery_attempts"] == 1
+		return metadata["recovery_status"] == recoveryStatusRecovered && metadata["recovery_attempts"] == 1
 	})).Return(nil).Once()
 
 	err := processor.processStuckTransaction(context.Background(), stuckTxn)
 	assert.NoError(t, err)
 	assert.False(t, hotLane)
 	mockDS.AssertExpectations(t)
+}
+
+func TestProcessStuckTransaction_ZeroAmountFillsNumericAmountOnReject(t *testing.T) {
+	mockDS := &dbmocks.MockDataSource{}
+	blnk := &Blnk{datasource: mockDS}
+	processor := NewQueuedTransactionRecoveryProcessor(blnk)
+
+	stuckTxn := &model.Transaction{
+		TransactionID: "txn_zero",
+		Reference:     "starbank_dust",
+		Source:        "bln_source",
+		Destination:   "bln_dest",
+		Currency:      "WBTC",
+		Amount:        0,
+		PreciseAmount: big.NewInt(0),
+		Precision:     100,
+		Status:        StatusQueued,
+		MetaData: map[string]interface{}{
+			"recovery_attempts": 3,
+		},
+	}
+
+	var recorded *model.Transaction
+	mockDS.On("RecordTransaction", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			recorded = args.Get(1).(*model.Transaction)
+		}).
+		Return(&model.Transaction{}, errors.New(`pq: invalid input syntax for type numeric: ""`)).Once()
+
+	mockDS.On("UpdateTransactionMetadata", mock.Anything, stuckTxn.TransactionID, mock.MatchedBy(func(metadata map[string]interface{}) bool {
+		return metadata["recovery_status"] == recoveryStatusUnrecoverable
+	})).Return(nil).Once()
+
+	err := processor.processStuckTransaction(context.Background(), stuckTxn)
+	require.NoError(t, err, "a failed reject must not keep the parent in the retry loop")
+	require.NotNil(t, recorded)
+	assert.Equal(t, StatusRejected, recorded.Status)
+	assert.Equal(t, "0", recorded.AmountString)
+	assert.Equal(t, "0", recorded.PreciseAmount.String())
+	mockDS.AssertExpectations(t)
+}
+
+func TestProcessStuckTransaction_RejectFailureMarksUnrecoverable(t *testing.T) {
+	mockDS := &dbmocks.MockDataSource{}
+	blnk := &Blnk{datasource: mockDS}
+	processor := NewQueuedTransactionRecoveryProcessor(blnk)
+
+	stuckTxn := positiveStuckTxn()
+	stuckTxn.MetaData = map[string]interface{}{"recovery_attempts": 3}
+
+	mockDS.On("RecordTransaction", mock.Anything, mock.Anything).
+		Return(&model.Transaction{}, errors.New("db unavailable")).Once()
+	mockDS.On("UpdateTransactionMetadata", mock.Anything, stuckTxn.TransactionID, mock.MatchedBy(func(metadata map[string]interface{}) bool {
+		return metadata["recovery_status"] == recoveryStatusUnrecoverable && metadata["recovery_attempts"] == 4
+	})).Return(nil).Once()
+
+	err := processor.processStuckTransaction(context.Background(), stuckTxn)
+	require.NoError(t, err)
+	mockDS.AssertExpectations(t)
+}
+
+func TestQueueTransaction_RejectsZeroAmount(t *testing.T) {
+	b := &Blnk{}
+	_, err := b.QueueTransaction(context.Background(), &model.Transaction{
+		Amount:        0,
+		PreciseAmount: big.NewInt(0),
+		Precision:     100,
+		Currency:      "WBTC",
+		Reference:     "ref_zero_ingest",
+		Source:        "bln_source",
+		Destination:   "bln_dest",
+		Description:   "StarBank shadow mirror (trade)",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be positive")
 }

--- a/queue_recovery_test.go
+++ b/queue_recovery_test.go
@@ -133,22 +133,20 @@ func TestProcessStuckTransaction_ZeroAmountFillsNumericAmountOnReject(t *testing
 		Run(func(args mock.Arguments) {
 			recorded = args.Get(1).(*model.Transaction)
 		}).
-		Return(&model.Transaction{}, errors.New(`pq: invalid input syntax for type numeric: ""`)).Once()
-
-	mockDS.On("UpdateTransactionMetadata", mock.Anything, stuckTxn.TransactionID, mock.MatchedBy(func(metadata map[string]interface{}) bool {
-		return metadata["recovery_status"] == recoveryStatusUnrecoverable
-	})).Return(nil).Once()
+		Return(&model.Transaction{}, errors.New("db unavailable")).Once()
 
 	err := processor.processStuckTransaction(context.Background(), stuckTxn)
-	require.NoError(t, err, "a failed reject must not keep the parent in the retry loop")
+	require.Error(t, err, "a failed reject must stay visible so recovery can retry")
+	assert.Contains(t, err.Error(), "db unavailable")
 	require.NotNil(t, recorded)
 	assert.Equal(t, StatusRejected, recorded.Status)
 	assert.Equal(t, "0", recorded.AmountString)
 	assert.Equal(t, "0", recorded.PreciseAmount.String())
+	mockDS.AssertNotCalled(t, "UpdateTransactionMetadata", mock.Anything, mock.Anything, mock.Anything)
 	mockDS.AssertExpectations(t)
 }
 
-func TestProcessStuckTransaction_RejectFailureMarksUnrecoverable(t *testing.T) {
+func TestProcessStuckTransaction_RejectFailureRemainsRetryable(t *testing.T) {
 	mockDS := &dbmocks.MockDataSource{}
 	blnk := &Blnk{datasource: mockDS}
 	processor := NewQueuedTransactionRecoveryProcessor(blnk)
@@ -158,12 +156,31 @@ func TestProcessStuckTransaction_RejectFailureMarksUnrecoverable(t *testing.T) {
 
 	mockDS.On("RecordTransaction", mock.Anything, mock.Anything).
 		Return(&model.Transaction{}, errors.New("db unavailable")).Once()
-	mockDS.On("UpdateTransactionMetadata", mock.Anything, stuckTxn.TransactionID, mock.MatchedBy(func(metadata map[string]interface{}) bool {
-		return metadata["recovery_status"] == recoveryStatusUnrecoverable && metadata["recovery_attempts"] == 4
-	})).Return(nil).Once()
 
 	err := processor.processStuckTransaction(context.Background(), stuckTxn)
-	require.NoError(t, err)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "db unavailable")
+	mockDS.AssertNotCalled(t, "UpdateTransactionMetadata", mock.Anything, mock.Anything, mock.Anything)
+	mockDS.AssertExpectations(t)
+}
+
+func TestProcessStuckTransaction_MetadataUpdateFailureKeepsTxnRetryable(t *testing.T) {
+	mockDS := &dbmocks.MockDataSource{}
+	blnk := &Blnk{datasource: mockDS}
+	processor := NewQueuedTransactionRecoveryProcessor(blnk)
+
+	stuckTxn := positiveStuckTxn()
+	processor.processQueuedTransaction = func(ctx context.Context, txn *model.Transaction, hotLane bool) (transactionExecutionResult, error) {
+		return transactionExecutionResult{}, errors.New("lock contention")
+	}
+
+	mockDS.On("UpdateTransactionMetadata", mock.Anything, stuckTxn.TransactionID, mock.MatchedBy(func(metadata map[string]interface{}) bool {
+		return metadata["recovery_status"] == recoveryStatusFailed
+	})).Return(errors.New("metadata write failed")).Once()
+
+	err := processor.processStuckTransaction(context.Background(), stuckTxn)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "lock contention", "the original recovery error must remain so the parent is retried")
 	mockDS.AssertExpectations(t)
 }
 

--- a/queue_recovery_test.go
+++ b/queue_recovery_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"math/big"
 	"testing"
+	"time"
 
 	dbmocks "github.com/blnkfinance/blnk/database/mocks"
 	"github.com/blnkfinance/blnk/internal/hotpairs"
@@ -198,4 +199,38 @@ func TestQueueTransaction_RejectsZeroAmount(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "must be positive")
+}
+
+func TestRecoverWithThreshold_CountsOnlySuccessfulRecoveries(t *testing.T) {
+	mockDS := &dbmocks.MockDataSource{}
+	blnk := &Blnk{datasource: mockDS}
+	processor := NewQueuedTransactionRecoveryProcessor(blnk)
+
+	okTxn := positiveStuckTxn()
+	failTxn := positiveStuckTxn()
+	failTxn.TransactionID = "txn_fail"
+	failTxn.Reference = "ref_fail"
+
+	mockDS.On("GetStuckQueuedTransactions", mock.Anything, mock.Anything, 100).
+		Return([]*model.Transaction{okTxn, failTxn}, nil).Once()
+
+	processor.processQueuedTransaction = func(ctx context.Context, txn *model.Transaction, hotLane bool) (transactionExecutionResult, error) {
+		if txn.ParentTransaction == failTxn.TransactionID {
+			return transactionExecutionResult{}, errors.New("lock contention")
+		}
+		return transactionExecutionResult{mode: transactionExecutionModeSingle, transaction: txn}, nil
+	}
+
+	mockDS.On("UpdateTransactionMetadata", mock.Anything, okTxn.TransactionID, mock.MatchedBy(func(metadata map[string]interface{}) bool {
+		return metadata["recovery_status"] == recoveryStatusRecovered
+	})).Return(nil).Once()
+	mockDS.On("UpdateTransactionMetadata", mock.Anything, failTxn.TransactionID, mock.MatchedBy(func(metadata map[string]interface{}) bool {
+		return metadata["recovery_status"] == recoveryStatusFailed
+	})).Return(nil).Once()
+
+	recovered, err := processor.recoverWithThreshold(context.Background(), time.Hour)
+	assert.Equal(t, 1, recovered)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "recovery failed for 1 of 2 stuck transactions")
+	mockDS.AssertExpectations(t)
 }

--- a/queue_recovery_zero_amount_test.go
+++ b/queue_recovery_zero_amount_test.go
@@ -26,7 +26,7 @@ func TestRecoverZeroAmountQueuedTransactionWritesRejectedChild(t *testing.T) {
 		Source:        src.BalanceID,
 		Destination:   dst.BalanceID,
 		Amount:        0,
-		AmountString:  "",
+		AmountString:  "0",
 		PreciseAmount: big.NewInt(0),
 		Precision:     100,
 		Currency:      "WBTC",

--- a/queue_recovery_zero_amount_test.go
+++ b/queue_recovery_zero_amount_test.go
@@ -1,0 +1,60 @@
+package blnk
+
+import (
+	"context"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/blnkfinance/blnk/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecoverZeroAmountQueuedTransactionWritesRejectedChild(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping zero-amount recovery integration test in short mode")
+	}
+
+	b, ds := newCoreTestBlnk(t)
+	src, dst := newBalancePair(t, ds)
+	ctx := context.Background()
+
+	parent := &model.Transaction{
+		TransactionID: model.GenerateUUIDWithSuffix("txn"),
+		Reference:     "starbank_dust_" + model.GenerateUUIDWithSuffix("ref"),
+		Source:        src.BalanceID,
+		Destination:   dst.BalanceID,
+		Amount:        0,
+		AmountString:  "",
+		PreciseAmount: big.NewInt(0),
+		Precision:     100,
+		Currency:      "WBTC",
+		Description:   "StarBank shadow mirror (trade)",
+		Status:        StatusQueued,
+		CreatedAt:     time.Now().UTC().Add(-3 * time.Hour),
+		MetaData: map[string]interface{}{
+			"recovery_attempts": 3,
+		},
+	}
+
+	_, err := ds.RecordTransaction(ctx, parent)
+	require.NoError(t, err, "parent QUEUED row must persist with amount 0")
+
+	processor := NewQueuedTransactionRecoveryProcessor(b)
+	require.NoError(t, processor.processStuckTransaction(ctx, parent))
+
+	children, err := ds.GetTransactionsByParent(ctx, parent.TransactionID, 10, 0)
+	require.NoError(t, err)
+	require.Len(t, children, 1, "recovery must write a REJECTED child")
+	assert.Equal(t, StatusRejected, children[0].Status)
+	assert.Equal(t, 0.0, children[0].Amount)
+	assert.Equal(t, "0", children[0].PreciseAmount.String())
+	assert.Equal(t, parent.TransactionID, children[0].ParentTransaction)
+
+	stuck, err := ds.GetStuckQueuedTransactions(ctx, 2*time.Hour, 100)
+	require.NoError(t, err)
+	for _, txn := range stuck {
+		assert.NotEqual(t, parent.TransactionID, txn.TransactionID, "rejected zero-amount parent must leave the stuck set")
+	}
+}

--- a/transaction.go
+++ b/transaction.go
@@ -77,6 +77,15 @@ const (
 type transactionExecutionPlan struct {
 	mode        transactionExecutionMode
 	transaction *model.Transaction
+	// viaQueue is true when this plan originated from queued transaction
+	// processing (ProcessQueuedTransaction), as opposed to a direct
+	// RecordTransaction call (e.g. a skip_queue split leg). It controls how a
+	// zero-amount transaction is handled: queued processing must persist a
+	// REJECTED record so a stuck QUEUED parent gets a terminal child instead
+	// of looping forever in recovery, while a direct/split-leg zero-amount
+	// leg (a legitimate rounding remainder, see issue #142/#334) is still
+	// discarded silently without persisting anything.
+	viaQueue bool
 }
 
 type transactionExecutionResult struct {

--- a/transaction_core_coverage_test.go
+++ b/transaction_core_coverage_test.go
@@ -488,3 +488,82 @@ func TestProcessQueuedTransaction_AppliesAndIsIdempotent(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "8000", dstFinal.Balance.String(), "balance must be unchanged after a duplicate replay")
 }
+
+// --- zero-amount viaQueue semantics ------------------------------------------
+
+// TestRecordTransaction_DirectZeroAmountIsDiscardedNotRejected locks in the issue #142/#334
+// semantics: a zero-amount transaction reaching RecordTransaction directly (e.g. a split leg
+// whose share rounds down to zero) must still be discarded silently, not persisted as a
+// REJECTED record. Only queue-originated processing (see the sibling test below) needs to
+// persist a REJECTED child, because only a QUEUED row can get stuck in recovery.
+func TestRecordTransaction_DirectZeroAmountIsDiscardedNotRejected(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	b, ds := newCoreTestBlnk(t)
+	src, dst := newBalancePair(t, ds)
+	ctx := context.Background()
+
+	leg := &model.Transaction{
+		TransactionID: model.GenerateUUIDWithSuffix("txn"),
+		Reference:     "split_leg_zero_" + model.GenerateUUIDWithSuffix("ref"),
+		Source:        src.BalanceID,
+		Destination:   dst.BalanceID,
+		Amount:        0,
+		PreciseAmount: big.NewInt(0),
+		Precision:     100,
+		Currency:      "USD",
+		Status:        StatusApplied,
+		SkipQueue:     true,
+	}
+
+	result, err := b.RecordTransaction(ctx, leg)
+	require.NoError(t, err, "a zero-amount direct leg must be discarded without error, not rejected")
+	assert.Equal(t, StatusApplied, result.Status, "the discarded transaction keeps its original status, it is not flipped to REJECTED")
+
+	children, err := ds.GetTransactionsByParent(ctx, leg.TransactionID, 10, 0)
+	require.NoError(t, err)
+	assert.Empty(t, children, "a discarded zero-amount leg must not persist a REJECTED child")
+}
+
+// TestProcessQueuedTransaction_ZeroAmountIsRejectedAndPersisted verifies the queue-originated
+// counterpart: a zero-amount transaction processed via the queue worker must persist a
+// REJECTED child so the parent gets a terminal child and never becomes a stuck-queue
+// recovery candidate.
+func TestProcessQueuedTransaction_ZeroAmountIsRejectedAndPersisted(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	b, ds := newCoreTestBlnk(t)
+	src, dst := newBalancePair(t, ds)
+	ctx := context.Background()
+
+	parent := &model.Transaction{
+		TransactionID: model.GenerateUUIDWithSuffix("txn"),
+		Reference:     "queued_zero_" + model.GenerateUUIDWithSuffix("ref"),
+		Source:        src.BalanceID,
+		Destination:   dst.BalanceID,
+		Amount:        0,
+		AmountString:  "0",
+		PreciseAmount: big.NewInt(0),
+		Precision:     100,
+		Currency:      "USD",
+		Status:        StatusQueued,
+		MetaData:      map[string]interface{}{},
+	}
+
+	_, err := ds.RecordTransaction(ctx, parent)
+	require.NoError(t, err, "parent QUEUED row must persist with amount 0")
+
+	queueCopy := createQueueCopy(parent, parent.Reference)
+	result, err := b.ProcessQueuedTransaction(ctx, queueCopy, false)
+	require.NoError(t, err)
+	assert.Equal(t, StatusRejected, result.Status)
+
+	children, err := ds.GetTransactionsByParent(ctx, parent.TransactionID, 10, 0)
+	require.NoError(t, err)
+	require.Len(t, children, 1, "queue processing of a zero-amount row must write a REJECTED child")
+	assert.Equal(t, StatusRejected, children[0].Status)
+}

--- a/transaction_core_coverage_test.go
+++ b/transaction_core_coverage_test.go
@@ -89,9 +89,8 @@ func recordAppliedTxn(t *testing.T, b *Blnk, src, dst string, amount float64) *m
 		Status:         StatusApplied,
 	}
 	// Direct RecordTransaction (unlike the queue flow) neither assigns a
-	// TransactionID nor applies precision twice: the ID must be preset, and
-	// priming PreciseAmount makes the in-flow ApplyPrecision take the
-	// precise->decimal branch that fills AmountString.
+	// TransactionID nor applies precision: the ID must be preset. One
+	// ApplyPrecision pass fills PreciseAmount and AmountString.
 	model.ApplyPrecision(draft)
 	txn, err := b.RecordTransaction(context.Background(), draft)
 	require.NoError(t, err)
@@ -177,10 +176,7 @@ func TestRefundTransaction_RejectedTransactionFails(t *testing.T) {
 		Currency:      "USD",
 		CreatedAt:     time.Now(),
 	}
-	// Two passes: the first fills PreciseAmount, the second takes the
-	// precise->decimal branch that fills AmountString (RejectTransaction
-	// persists directly without the queue flow's metadata preparation).
-	model.ApplyPrecision(queued)
+	// ApplyPrecision fills PreciseAmount and AmountString in one pass.
 	model.ApplyPrecision(queued)
 	rej, err := b.RejectTransaction(context.Background(), queued, "insufficient funds")
 	require.NoError(t, err)
@@ -255,7 +251,6 @@ func TestRefundTransaction_RejectsNonRefundableStatus(t *testing.T) {
 				Status:        status,
 				CreatedAt:     time.Now(),
 			}
-			model.ApplyPrecision(draft)
 			model.ApplyPrecision(draft)
 			persisted, err := ds.RecordTransaction(context.Background(), draft)
 			require.NoError(t, err)

--- a/transaction_execution.go
+++ b/transaction_execution.go
@@ -507,6 +507,16 @@ func (l *Blnk) recordTransactionSingle(ctx context.Context, transaction *model.T
 			return nil, err
 		}
 
+		if isZeroPreciseAmount(transaction) {
+			rejected, err := l.RejectTransaction(ctx, transaction, "zero amount")
+			if err != nil {
+				span.RecordError(err)
+				return nil, err
+			}
+			span.AddEvent("Zero-amount transaction rejected", trace.WithAttributes(attribute.String("transaction.id", rejected.TransactionID)))
+			return rejected, nil
+		}
+
 		// Process the balances by applying the transaction
 		if err := l.processBalances(ctx, transaction, sourceBalance, destinationBalance); err != nil {
 			span.RecordError(err)
@@ -515,8 +525,13 @@ func (l *Blnk) recordTransactionSingle(ctx context.Context, transaction *model.T
 
 		work, skipPersist := l.buildTransactionExecutionWork(ctx, transaction, sourceBalance, destinationBalance)
 		if skipPersist {
-			span.AddEvent("Transaction with zero amount discarded, not persisted", trace.WithAttributes(attribute.String("transaction.id", work.transaction.TransactionID)))
-			return work.transaction, nil
+			rejected, err := l.RejectTransaction(ctx, work.transaction, "zero amount")
+			if err != nil {
+				span.RecordError(err)
+				return nil, err
+			}
+			span.AddEvent("Zero-amount transaction rejected instead of discarded", trace.WithAttributes(attribute.String("transaction.id", rejected.TransactionID)))
+			return rejected, nil
 		}
 
 		work, err = l.persistSingleTransactionExecutionWork(ctx, work)

--- a/transaction_execution.go
+++ b/transaction_execution.go
@@ -386,9 +386,9 @@ func (r transactionExecutionResult) usedCoalescing() bool {
 func (l *Blnk) planTransactionExecution(transaction *model.Transaction, allowQueuedBatch, hotLane bool) transactionExecutionPlan {
 	if allowQueuedBatch {
 		if hotLane {
-			return transactionExecutionPlan{mode: transactionExecutionModeHotQueuedBatch, transaction: transaction}
+			return transactionExecutionPlan{mode: transactionExecutionModeHotQueuedBatch, transaction: transaction, viaQueue: true}
 		}
-		return transactionExecutionPlan{mode: transactionExecutionModeQueuedBatch, transaction: transaction}
+		return transactionExecutionPlan{mode: transactionExecutionModeQueuedBatch, transaction: transaction, viaQueue: true}
 	}
 
 	return transactionExecutionPlan{mode: transactionExecutionModeSingle, transaction: transaction}
@@ -409,7 +409,10 @@ func (l *Blnk) executeTransactionPlan(ctx context.Context, plan transactionExecu
 				transaction: plan.transaction,
 			}, nil
 		}
-		return l.executeTransactionPlan(ctx, l.planTransactionExecution(plan.transaction, false, false))
+		// Falling back from a queued batch to single-transaction processing;
+		// this is still queue-originated work, so keep viaQueue true rather
+		// than re-deriving the plan from scratch.
+		return l.executeTransactionPlan(ctx, transactionExecutionPlan{mode: transactionExecutionModeSingle, transaction: plan.transaction, viaQueue: true})
 	case transactionExecutionModeHotQueuedBatch:
 		handled, err := l.TryRecordQueuedTransactionBatchForHotLane(ctx, plan.transaction)
 		if err != nil {
@@ -421,9 +424,9 @@ func (l *Blnk) executeTransactionPlan(ctx context.Context, plan transactionExecu
 				transaction: plan.transaction,
 			}, nil
 		}
-		return l.executeTransactionPlan(ctx, l.planTransactionExecution(plan.transaction, false, false))
+		return l.executeTransactionPlan(ctx, transactionExecutionPlan{mode: transactionExecutionModeSingle, transaction: plan.transaction, viaQueue: true})
 	case transactionExecutionModeSingle:
-		transaction, err := l.recordTransactionSingle(ctx, plan.transaction)
+		transaction, err := l.recordTransactionSingle(ctx, plan.transaction, plan.viaQueue)
 		if err != nil {
 			return transactionExecutionResult{}, err
 		}
@@ -432,7 +435,7 @@ func (l *Blnk) executeTransactionPlan(ctx context.Context, plan transactionExecu
 			transaction: transaction,
 		}, nil
 	default:
-		transaction, err := l.recordTransactionSingle(ctx, plan.transaction)
+		transaction, err := l.recordTransactionSingle(ctx, plan.transaction, plan.viaQueue)
 		if err != nil {
 			return transactionExecutionResult{}, err
 		}
@@ -485,9 +488,39 @@ func (l *Blnk) RecordTransaction(ctx context.Context, transaction *model.Transac
 	return result.transaction, nil
 }
 
+// handleZeroAmountTransaction resolves a zero-amount transaction encountered during single
+// processing.
+//
+// Queue-originated processing (viaQueue=true) must persist a REJECTED record: a QUEUED parent
+// with no terminal child is picked up by stuck-queue recovery forever (see
+// GetStuckQueuedTransactions), so silently discarding it here would recreate the original
+// stuck-recovery bug this behavior exists to fix.
+//
+// Direct/split-leg processing (viaQueue=false) preserves the original semantics from issue
+// #142/#334: a leg that legitimately rounds down to zero (e.g. a small share of a split
+// transaction) is discarded without persisting anything and without an error, since it was
+// never queued and so can never get stuck.
+func (l *Blnk) handleZeroAmountTransaction(ctx context.Context, span trace.Span, transaction *model.Transaction, viaQueue bool, rejectedEventName string) (*model.Transaction, error) {
+	if !viaQueue {
+		span.AddEvent("Zero-amount transaction discarded, not persisted", trace.WithAttributes(attribute.String("transaction.id", transaction.TransactionID)))
+		return transaction, nil
+	}
+
+	rejected, err := l.RejectTransaction(ctx, transaction, "zero amount")
+	if err != nil {
+		span.RecordError(err)
+		return nil, err
+	}
+	span.AddEvent(rejectedEventName, trace.WithAttributes(attribute.String("transaction.id", rejected.TransactionID)))
+	return rejected, nil
+}
+
 // recordTransactionSingle preserves the existing direct transaction-processing semantics by
 // running the single-transaction flow under the balance lock.
-func (l *Blnk) recordTransactionSingle(ctx context.Context, transaction *model.Transaction) (*model.Transaction, error) {
+//
+// viaQueue indicates whether this call originated from queued transaction processing, which
+// controls how a zero-amount transaction is resolved; see handleZeroAmountTransaction.
+func (l *Blnk) recordTransactionSingle(ctx context.Context, transaction *model.Transaction, viaQueue bool) (*model.Transaction, error) {
 	ctx, span := tracer.Start(ctx, "RecordTransaction")
 	defer span.End()
 
@@ -508,13 +541,7 @@ func (l *Blnk) recordTransactionSingle(ctx context.Context, transaction *model.T
 		}
 
 		if isZeroPreciseAmount(transaction) {
-			rejected, err := l.RejectTransaction(ctx, transaction, "zero amount")
-			if err != nil {
-				span.RecordError(err)
-				return nil, err
-			}
-			span.AddEvent("Zero-amount transaction rejected", trace.WithAttributes(attribute.String("transaction.id", rejected.TransactionID)))
-			return rejected, nil
+			return l.handleZeroAmountTransaction(ctx, span, transaction, viaQueue, "Zero-amount transaction rejected")
 		}
 
 		// Process the balances by applying the transaction
@@ -525,13 +552,7 @@ func (l *Blnk) recordTransactionSingle(ctx context.Context, transaction *model.T
 
 		work, skipPersist := l.buildTransactionExecutionWork(ctx, transaction, sourceBalance, destinationBalance)
 		if skipPersist {
-			rejected, err := l.RejectTransaction(ctx, work.transaction, "zero amount")
-			if err != nil {
-				span.RecordError(err)
-				return nil, err
-			}
-			span.AddEvent("Zero-amount transaction rejected instead of discarded", trace.WithAttributes(attribute.String("transaction.id", rejected.TransactionID)))
-			return rejected, nil
+			return l.handleZeroAmountTransaction(ctx, span, work.transaction, viaQueue, "Zero-amount transaction rejected instead of discarded")
 		}
 
 		work, err = l.persistSingleTransactionExecutionWork(ctx, work)

--- a/transaction_queue.go
+++ b/transaction_queue.go
@@ -73,6 +73,10 @@ func (l *Blnk) QueueTransaction(ctx context.Context, transaction *model.Transact
 	// Initialize transaction metadata and status
 	originalRef := transaction.Reference
 	setTransactionMetadata(transaction)
+	if err := transaction.ValidateAmount(); err != nil {
+		span.RecordError(err)
+		return nil, err
+	}
 	setTransactionStatus(transaction)
 	originalTxnID := transaction.TransactionID
 

--- a/transaction_rejection.go
+++ b/transaction_rejection.go
@@ -44,6 +44,10 @@ func (l *Blnk) RejectTransaction(ctx context.Context, transaction *model.Transac
 	}
 	transaction.MetaData["blnk_rejection_reason"] = reason
 
+	// Fill AmountString (including "0") before insert. Recovery copies of
+	// zero-amount QUEUED parents otherwise persist "" into a numeric column.
+	model.ApplyPrecision(transaction)
+
 	// Persist the transaction with the updated status and metadata
 	transaction, err := l.datasource.RecordTransaction(ctx, transaction)
 	if err != nil {

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -221,14 +221,16 @@ func TestRecordTransaction(t *testing.T) {
 		sqlmock.AnyArg(), // version
 	).WillReturnResult(sqlmock.NewResult(1, 1))
 
-	// Expect transaction insertion within the same atomic transaction
+	// Expect transaction insertion within the same atomic transaction.
+	// RecordTransaction applies precision before persist, so amount is the
+	// materialised AmountString ("10"), not the empty value on the input txn.
 	expectedSQL := `INSERT INTO blnk.transactions(transaction_id, parent_transaction, source, reference, amount, precise_amount, precision, currency, destination, description, status, created_at, meta_data, scheduled_for, hash, effective_date) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)`
 	mock.ExpectExec(regexp.QuoteMeta(expectedSQL)).WithArgs(
 		sqlmock.AnyArg(), // transaction_id
 		sqlmock.AnyArg(), // parent_transaction
 		source,           // source
 		reference,        // reference
-		txn.AmountString, // amount
+		"10",             // amount (filled by ApplyPrecision)
 		"1000",           // precise amount
 		txn.Precision,    // precision
 		txn.Currency,     // currency


### PR DESCRIPTION
Reject zero amounts at ingest and ensure AmountString/precise_amount never persist as empty numerics so stuck-queue recovery can write REJECTED children instead of looping forever.