### PR TITLE
feat(monitors): edge-triggered balance monitors, on by default

### DIFF
--- a/api/balance.go
+++ b/api/balance.go
@@ -321,8 +321,18 @@ func (a Api) UpdateBalanceMonitor(c *gin.Context) {
 		return
 	}
 
+	// This handler binds the internal model rather than a request struct, so the
+	// trigger is resolved here or the update path becomes the one way to put an
+	// unvalidated value in front of the table's check constraint.
+	trigger, err := model.NormalizeTrigger(monitor.Trigger)
+	if err != nil {
+		respondCode(c, apierror.ErrGenValidation, err.Error(), nil, withLegacyKey("errors"))
+		return
+	}
+	monitor.Trigger = trigger
+
 	monitor.MonitorID = id
-	err := a.blnk.UpdateMonitor(c.Request.Context(), &monitor)
+	err = a.blnk.UpdateMonitor(c.Request.Context(), &monitor)
 	if err != nil {
 		respondError(c, err, withUpgrade(apierror.ErrGenNotFound, apierror.ErrBalMonitorNotFound))
 		return

--- a/api/balance_monitor_concurrency_test.go
+++ b/api/balance_monitor_concurrency_test.go
@@ -1,0 +1,203 @@
+/*
+Copyright 2024 Blnk Finance Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	blnkservice "github.com/blnkfinance/blnk"
+	model2 "github.com/blnkfinance/blnk/api/model"
+	"github.com/blnkfinance/blnk/internal/request"
+	"github.com/blnkfinance/blnk/model"
+)
+
+// TestBalanceMonitorEdge_ConcurrentTransactions is the whole point of the
+// design, exercised through the product rather than the datasource: monitor
+// checks are dispatched into detached goroutines once the balance lock is
+// released, so several of them evaluate the same crossing at once. The consumer
+// must still be told once.
+func TestBalanceMonitorEdge_ConcurrentTransactions(t *testing.T) {
+	e := setupMonitorE2E(t)
+
+	funding := e.newBalance(t)
+	wallet := e.newBalance(t)
+	monitor := e.createMonitor(t, wallet.BalanceID, model.TriggerEdge, 500)
+
+	const senders = 12
+
+	var wg sync.WaitGroup
+	for i := 0; i < senders; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			payloadBytes, _ := request.ToJsonReq(&model2.RecordTransaction{
+				Amount:         200,
+				Precision:      1,
+				Reference:      gofakeit.UUID(),
+				Description:    "concurrent monitor crossing",
+				Currency:       "USD",
+				Source:         funding.BalanceID,
+				Destination:    wallet.BalanceID,
+				SkipQueue:      true,
+				AllowOverDraft: true,
+			})
+			resp, _ := SetUpTestRequest(TestRequest{
+				Payload: payloadBytes,
+				Method:  "POST",
+				Route:   "/transactions",
+				Router:  e.router,
+			})
+			assert.Equal(t, http.StatusCreated, resp.Code)
+		}()
+	}
+	wg.Wait()
+
+	// Every one of those transactions left the wallet past the threshold, so
+	// most of the evaluations saw a true condition.
+	e.awaitWebhooks(t, 1)
+	e.settle()
+	assert.Equal(t, 1, e.webhooks(), "%d concurrent transactions past the threshold must produce one alert", senders)
+	assert.True(t, e.monitorState(t, monitor.MonitorID))
+}
+
+// TestBalanceMonitorEdge_MixedTriggersOnOneBalance pins that the two modes stay
+// independent when they watch the same balance.
+func TestBalanceMonitorEdge_MixedTriggersOnOneBalance(t *testing.T) {
+	e := setupMonitorE2E(t)
+
+	funding := e.newBalance(t)
+	wallet := e.newBalance(t)
+	edge := e.createMonitor(t, wallet.BalanceID, model.TriggerEdge, 500)
+	level := e.createMonitor(t, wallet.BalanceID, model.TriggerLevel, 500)
+
+	e.transfer(t, funding.BalanceID, wallet.BalanceID, 600) // crossing: edge + level
+	e.awaitWebhooks(t, 2)
+
+	e.transfer(t, funding.BalanceID, wallet.BalanceID, 100) // still past: level only
+	e.awaitWebhooks(t, 3)
+
+	e.transfer(t, funding.BalanceID, wallet.BalanceID, 100) // still past: level only
+	e.awaitWebhooks(t, 4)
+
+	// The totals above could be satisfied by the wrong split, so pin each
+	// monitor's own count: that is what "independent" means here.
+	assert.Equal(t, 1, e.webhooksFor(edge.MonitorID), "the edge monitor owes one alert, on the crossing")
+	assert.Equal(t, 3, e.webhooksFor(level.MonitorID), "the level monitor owes one per update while the condition holds")
+
+	assert.True(t, e.monitorState(t, edge.MonitorID))
+	assert.False(t, e.monitorState(t, level.MonitorID), "a level monitor keeps no state")
+}
+
+// TestBalanceMonitorEdge_InflightCommit pins that the inflight settlement path
+// reaches the monitors too. It arrives by way of RecordTransaction, so it shares
+// the post-commit work, but it is the path a real wallet balance actually moves
+// on and is worth holding still.
+func TestBalanceMonitorEdge_InflightCommit(t *testing.T) {
+	e := setupMonitorE2E(t)
+
+	funding := e.newBalance(t)
+	wallet := e.newBalance(t)
+	monitor := e.createMonitor(t, wallet.BalanceID, model.TriggerEdge, 500)
+
+	payloadBytes, _ := request.ToJsonReq(&model2.RecordTransaction{
+		Amount:         900,
+		Precision:      1,
+		Reference:      gofakeit.UUID(),
+		Description:    "inflight crossing",
+		Currency:       "USD",
+		Source:         funding.BalanceID,
+		Destination:    wallet.BalanceID,
+		Inflight:       true,
+		SkipQueue:      true,
+		AllowOverDraft: true,
+	})
+	var queued model.Transaction
+	resp, _ := SetUpTestRequest(TestRequest{
+		Payload:  payloadBytes,
+		Response: &queued,
+		Method:   "POST",
+		Route:    "/transactions",
+		Router:   e.router,
+	})
+	require.Equal(t, http.StatusCreated, resp.Code)
+	require.NotEmpty(t, queued.TransactionID)
+
+	// Inflight money is not the balance, so nothing has crossed yet.
+	e.settle()
+	assert.Equal(t, 0, e.webhooks(), "an inflight transaction has not moved the balance")
+
+	commitBytes, _ := request.ToJsonReq(&model2.InflightUpdate{Status: blnkservice.InflightActionCommit, SkipQueue: true})
+	commitResp, _ := SetUpTestRequest(TestRequest{
+		Payload: commitBytes,
+		Method:  "PUT",
+		Route:   fmt.Sprintf("/transactions/inflight/%s", queued.TransactionID),
+		Router:  e.router,
+	})
+	require.Equal(t, http.StatusOK, commitResp.Code)
+
+	e.awaitWebhooks(t, 1)
+	assert.True(t, e.monitorState(t, monitor.MonitorID))
+}
+
+// TestBalanceMonitorEdge_WebhookPayload checks what a consumer actually
+// receives, not just that something was queued.
+func TestBalanceMonitorEdge_WebhookPayload(t *testing.T) {
+	e := setupMonitorE2E(t)
+
+	funding := e.newBalance(t)
+	wallet := e.newBalance(t)
+	monitor := e.createMonitor(t, wallet.BalanceID, model.TriggerEdge, 500)
+
+	e.transfer(t, funding.BalanceID, wallet.BalanceID, 900)
+	e.awaitWebhooks(t, 1)
+
+	tasks := e.pendingTasks()
+
+	// NewWebhook serialises its payload under "data", not "payload".
+	var payload struct {
+		Event string               `json:"event"`
+		Data  model.BalanceMonitor `json:"data"`
+	}
+	found := false
+	for _, task := range tasks {
+		var probe struct {
+			Event string `json:"event"`
+		}
+		if err := json.Unmarshal(task.Payload, &probe); err != nil || probe.Event != "balance.monitor" {
+			continue
+		}
+		require.NoError(t, json.Unmarshal(task.Payload, &payload))
+		found = true
+		break
+	}
+	require.True(t, found, "no balance.monitor task on the queue")
+
+	assert.Equal(t, monitor.MonitorID, payload.Data.MonitorID)
+	assert.Equal(t, wallet.BalanceID, payload.Data.BalanceID)
+	assert.Equal(t, model.TriggerEdge, payload.Data.Trigger)
+	assert.True(t, payload.Data.ConditionState, "the alert says the monitor is now triggered")
+	assert.Equal(t, "balance", payload.Data.Condition.Field)
+	assert.Equal(t, ">", payload.Data.Condition.Operator)
+}

--- a/api/balance_monitor_defects_e2e_test.go
+++ b/api/balance_monitor_defects_e2e_test.go
@@ -45,13 +45,16 @@ func execSQL(t *testing.T, cnf *config.Configuration, statement string, args ...
 
 // A monitor written before the precision migration carries NULLs. Reading it
 // used to fail, and because checkBalanceMonitors gives up when the fetch
-// errors, that one row silenced every other monitor on the same balance.
+// errors, that one row silenced every other monitor on the same balance. This
+// is the symptom an operator would actually see.
 func TestBalanceMonitor_LegacyRowDoesNotSilenceItsSiblings(t *testing.T) {
 	e := setupMonitorE2E(t)
 	funding, wallet := e.newBalance(t), e.newBalance(t)
 
-	e.createMonitorOn(t, wallet.BalanceID, "balance", ">", 500)
+	healthy := e.createMonitorOn(t, wallet.BalanceID, model.TriggerEdge, "balance", ">", 500)
 
+	// The shape a row created before precision and precise_value existed still
+	// has today: both columns NULL.
 	legacyID := model.GenerateUUIDWithSuffix("mon")
 	execSQL(t, e.cnf, `
 		INSERT INTO blnk.balance_monitors (monitor_id, balance_id, field, operator, value, description, call_back_url, created_at)
@@ -62,15 +65,57 @@ func TestBalanceMonitor_LegacyRowDoesNotSilenceItsSiblings(t *testing.T) {
 
 	// Both monitors watch the same threshold, so both owe one alert.
 	e.awaitWebhooks(t, 2)
+	assert.True(t, e.monitorState(t, healthy.MonitorID),
+		"a legacy sibling must not stop a healthy monitor from working")
+	assert.True(t, e.monitorState(t, legacyID), "and the legacy monitor itself must work")
 }
 
-// The monitor cache is keyed by balance, so a moved monitor kept firing on the
-// balance it left until that balance's cached list expired.
-func TestBalanceMonitor_MovedMonitorStopsAlertingOnTheOldBalance(t *testing.T) {
+// A moved edge monitor stops alerting on the balance it left and starts on the
+// one it joined. This one holds even with a stale cached list, because the
+// balance guard on the state write rejects the stale evaluation; the cache fix
+// is what covers the level case below.
+func TestBalanceMonitor_MovedMonitorFollowsItsBalance(t *testing.T) {
 	e := setupMonitorE2E(t)
 	funding, oldWallet, newWallet := e.newBalance(t), e.newBalance(t), e.newBalance(t)
 
-	created := e.createMonitorOn(t, oldWallet.BalanceID, "balance", ">", 500)
+	created := e.createMonitorOn(t, oldWallet.BalanceID, model.TriggerEdge, "balance", ">", 500)
+
+	// Warm the old balance's cached monitor list.
+	e.transfer(t, funding.BalanceID, oldWallet.BalanceID, 100)
+	e.settle()
+	require.Equal(t, 0, e.webhooks())
+
+	payloadBytes, _ := request.ToJsonReq(&model.BalanceMonitor{
+		BalanceID: newWallet.BalanceID,
+		Trigger:   model.TriggerEdge,
+		Condition: model.AlertCondition{Field: "balance", Operator: ">", Value: 500, Precision: 1},
+	})
+	resp, _ := SetUpTestRequest(TestRequest{
+		Payload: payloadBytes, Method: "PUT",
+		Route: fmt.Sprintf("/balance-monitors/%s", created.MonitorID), Router: e.router,
+	})
+	require.Equal(t, http.StatusOK, resp.Code)
+
+	// The balance it left must no longer produce alerts.
+	e.transfer(t, funding.BalanceID, oldWallet.BalanceID, 900)
+	e.settle()
+	assert.Equal(t, 0, e.webhooks(), "a moved monitor must stop watching the balance it left")
+
+	// The balance it joined must.
+	e.transfer(t, funding.BalanceID, newWallet.BalanceID, 900)
+	e.awaitWebhooks(t, 1)
+	assert.True(t, e.monitorState(t, created.MonitorID))
+}
+
+// The balance guard covers an edge monitor moved between balances, because the
+// stale evaluation cannot win the state write. A level monitor keeps no state,
+// so nothing stops it firing on the balance it left -- only invalidating that
+// balance's cached list does.
+func TestBalanceMonitor_MovedLevelMonitorStopsAlertingOnTheOldBalance(t *testing.T) {
+	e := setupMonitorE2E(t)
+	funding, oldWallet, newWallet := e.newBalance(t), e.newBalance(t), e.newBalance(t)
+
+	created := e.createMonitorOn(t, oldWallet.BalanceID, model.TriggerLevel, "balance", ">", 500)
 
 	// Put the old balance's monitor list in the cache.
 	e.transfer(t, funding.BalanceID, oldWallet.BalanceID, 100)
@@ -79,6 +124,7 @@ func TestBalanceMonitor_MovedMonitorStopsAlertingOnTheOldBalance(t *testing.T) {
 
 	payloadBytes, _ := request.ToJsonReq(&model.BalanceMonitor{
 		BalanceID: newWallet.BalanceID,
+		Trigger:   model.TriggerLevel,
 		Condition: model.AlertCondition{Field: "balance", Operator: ">", Value: 500, Precision: 1},
 	})
 	resp, _ := SetUpTestRequest(TestRequest{
@@ -89,12 +135,14 @@ func TestBalanceMonitor_MovedMonitorStopsAlertingOnTheOldBalance(t *testing.T) {
 
 	e.transfer(t, funding.BalanceID, oldWallet.BalanceID, 900)
 	e.settle()
-	assert.Equal(t, 0, e.webhooks(), "a moved monitor must not keep alerting on the balance it left")
+	assert.Equal(t, 0, e.webhooks(), "a moved level monitor must not keep alerting on the balance it left")
 
 	e.transfer(t, funding.BalanceID, newWallet.BalanceID, 900)
 	e.awaitWebhooks(t, 1)
 }
 
+// A fractional threshold is a normal thing to want and used to fail at the
+// database with a 500.
 func TestBalanceMonitor_FractionalThresholdEndToEnd(t *testing.T) {
 	e := setupMonitorE2E(t)
 	funding, wallet := e.newBalance(t), e.newBalance(t)
@@ -118,13 +166,16 @@ func TestBalanceMonitor_FractionalThresholdEndToEnd(t *testing.T) {
 
 	e.transferPrecise(t, funding.BalanceID, wallet.BalanceID, 0.20, 100)
 	e.awaitWebhooks(t, 1)
+	assert.True(t, e.monitorState(t, created.MonitorID))
 }
 
+// A zero threshold is the most natural monitor there is and used to be
+// rejected outright.
 func TestBalanceMonitor_ZeroThresholdEndToEnd(t *testing.T) {
 	e := setupMonitorE2E(t)
 	funding, wallet := e.newBalance(t), e.newBalance(t)
 
-	e.createMonitorOn(t, wallet.BalanceID, "balance", ">", 0)
+	created := e.createMonitorOn(t, wallet.BalanceID, model.TriggerEdge, "balance", ">", 0)
 
 	e.transfer(t, wallet.BalanceID, funding.BalanceID, 100)
 	e.settle()
@@ -132,8 +183,11 @@ func TestBalanceMonitor_ZeroThresholdEndToEnd(t *testing.T) {
 
 	e.transfer(t, funding.BalanceID, wallet.BalanceID, 200)
 	e.awaitWebhooks(t, 1)
+	assert.True(t, e.monitorState(t, created.MonitorID))
 }
 
+// The list endpoint used to report a different threshold from the detail
+// endpoint, because it did not select precision.
 func TestBalanceMonitor_ListAndDetailAgreeOnThreshold(t *testing.T) {
 	e := setupMonitorE2E(t)
 	wallet := e.newBalance(t)

--- a/api/balance_monitor_defects_e2e_test.go
+++ b/api/balance_monitor_defects_e2e_test.go
@@ -1,0 +1,189 @@
+/*
+Copyright 2024 Blnk Finance Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	model2 "github.com/blnkfinance/blnk/api/model"
+	"github.com/blnkfinance/blnk/config"
+	"github.com/blnkfinance/blnk/database"
+	"github.com/blnkfinance/blnk/internal/request"
+	"github.com/blnkfinance/blnk/model"
+)
+
+// execSQL runs a statement directly against the test database, for setting up
+// rows the API deliberately cannot produce.
+func execSQL(t *testing.T, cnf *config.Configuration, statement string, args ...interface{}) {
+	t.Helper()
+
+	ds, err := database.GetDBConnection(cnf)
+	require.NoError(t, err)
+	_, err = ds.Conn.ExecContext(context.Background(), statement, args...)
+	require.NoError(t, err)
+}
+
+// A monitor written before the precision migration carries NULLs. Reading it
+// used to fail, and because checkBalanceMonitors gives up when the fetch
+// errors, that one row silenced every other monitor on the same balance.
+func TestBalanceMonitor_LegacyRowDoesNotSilenceItsSiblings(t *testing.T) {
+	e := setupMonitorE2E(t)
+	funding, wallet := e.newBalance(t), e.newBalance(t)
+
+	e.createMonitorOn(t, wallet.BalanceID, "balance", ">", 500)
+
+	legacyID := model.GenerateUUIDWithSuffix("mon")
+	execSQL(t, e.cnf, `
+		INSERT INTO blnk.balance_monitors (monitor_id, balance_id, field, operator, value, description, call_back_url, created_at)
+		VALUES ($1, $2, 'balance', '>', 500, 'legacy', '', NOW())
+	`, legacyID, wallet.BalanceID)
+
+	e.transfer(t, funding.BalanceID, wallet.BalanceID, 900)
+
+	// Both monitors watch the same threshold, so both owe one alert.
+	e.awaitWebhooks(t, 2)
+}
+
+// The monitor cache is keyed by balance, so a moved monitor kept firing on the
+// balance it left until that balance's cached list expired.
+func TestBalanceMonitor_MovedMonitorStopsAlertingOnTheOldBalance(t *testing.T) {
+	e := setupMonitorE2E(t)
+	funding, oldWallet, newWallet := e.newBalance(t), e.newBalance(t), e.newBalance(t)
+
+	created := e.createMonitorOn(t, oldWallet.BalanceID, "balance", ">", 500)
+
+	// Put the old balance's monitor list in the cache.
+	e.transfer(t, funding.BalanceID, oldWallet.BalanceID, 100)
+	e.settle()
+	require.Equal(t, 0, e.webhooks())
+
+	payloadBytes, _ := request.ToJsonReq(&model.BalanceMonitor{
+		BalanceID: newWallet.BalanceID,
+		Condition: model.AlertCondition{Field: "balance", Operator: ">", Value: 500, Precision: 1},
+	})
+	resp, _ := SetUpTestRequest(TestRequest{
+		Payload: payloadBytes, Method: "PUT",
+		Route: fmt.Sprintf("/balance-monitors/%s", created.MonitorID), Router: e.router,
+	})
+	require.Equal(t, http.StatusOK, resp.Code)
+
+	e.transfer(t, funding.BalanceID, oldWallet.BalanceID, 900)
+	e.settle()
+	assert.Equal(t, 0, e.webhooks(), "a moved monitor must not keep alerting on the balance it left")
+
+	e.transfer(t, funding.BalanceID, newWallet.BalanceID, 900)
+	e.awaitWebhooks(t, 1)
+}
+
+func TestBalanceMonitor_FractionalThresholdEndToEnd(t *testing.T) {
+	e := setupMonitorE2E(t)
+	funding, wallet := e.newBalance(t), e.newBalance(t)
+
+	payloadBytes, _ := request.ToJsonReq(&model2.CreateBalanceMonitor{
+		BalanceId: wallet.BalanceID,
+		Condition: model2.MonitorCondition{Field: "balance", Operator: ">", Value: 10.5, Precision: 100},
+	})
+	var created model.BalanceMonitor
+	resp, _ := SetUpTestRequest(TestRequest{
+		Payload: payloadBytes, Response: &created,
+		Method: "POST", Route: "/balance-monitors", Router: e.router,
+	})
+	require.Equal(t, http.StatusCreated, resp.Code, "body: %s", resp.Body.String())
+	assert.Equal(t, 10.5, created.Condition.Value)
+
+	// precision 100 means the threshold is 1050 in the ledger's own units.
+	e.transferPrecise(t, funding.BalanceID, wallet.BalanceID, 10.40, 100)
+	e.settle()
+	assert.Equal(t, 0, e.webhooks(), "10.40 has not passed 10.50")
+
+	e.transferPrecise(t, funding.BalanceID, wallet.BalanceID, 0.20, 100)
+	e.awaitWebhooks(t, 1)
+}
+
+func TestBalanceMonitor_ZeroThresholdEndToEnd(t *testing.T) {
+	e := setupMonitorE2E(t)
+	funding, wallet := e.newBalance(t), e.newBalance(t)
+
+	e.createMonitorOn(t, wallet.BalanceID, "balance", ">", 0)
+
+	e.transfer(t, wallet.BalanceID, funding.BalanceID, 100)
+	e.settle()
+	assert.Equal(t, 0, e.webhooks(), "a negative balance is not above zero")
+
+	e.transfer(t, funding.BalanceID, wallet.BalanceID, 200)
+	e.awaitWebhooks(t, 1)
+}
+
+func TestBalanceMonitor_ListAndDetailAgreeOnThreshold(t *testing.T) {
+	e := setupMonitorE2E(t)
+	wallet := e.newBalance(t)
+
+	payloadBytes, _ := request.ToJsonReq(&model2.CreateBalanceMonitor{
+		BalanceId: wallet.BalanceID,
+		Condition: model2.MonitorCondition{Field: "balance", Operator: "<", Value: 100, Precision: 100},
+	})
+	var created model.BalanceMonitor
+	resp, _ := SetUpTestRequest(TestRequest{
+		Payload: payloadBytes, Response: &created,
+		Method: "POST", Route: "/balance-monitors", Router: e.router,
+	})
+	require.Equal(t, http.StatusCreated, resp.Code)
+
+	var detail model.BalanceMonitor
+	resp, _ = SetUpTestRequest(TestRequest{
+		Response: &detail, Method: "GET",
+		Route: fmt.Sprintf("/balance-monitors/%s", created.MonitorID), Router: e.router,
+	})
+	require.Equal(t, http.StatusOK, resp.Code)
+
+	var all []model.BalanceMonitor
+	resp, _ = SetUpTestRequest(TestRequest{
+		Response: &all, Method: "GET", Route: "/balance-monitors", Router: e.router,
+	})
+	require.Equal(t, http.StatusOK, resp.Code)
+
+	for _, listed := range all {
+		if listed.MonitorID != created.MonitorID {
+			continue
+		}
+		assert.Equal(t, detail.Condition.Precision, listed.Condition.Precision, "list and detail must agree on precision")
+		assert.Equal(t, detail.Condition.PreciseValue, listed.Condition.PreciseValue, "and on the threshold the ledger compares against")
+		return
+	}
+	t.Fatal("the monitor did not appear in the list endpoint")
+}
+
+// transferPrecise moves an amount at a given precision.
+func (e *monitorE2E) transferPrecise(t *testing.T, source, destination string, amount, precision float64) {
+	t.Helper()
+
+	payloadBytes, _ := request.ToJsonReq(&model2.RecordTransaction{
+		Amount: amount, Precision: precision, Reference: model.GenerateUUIDWithSuffix("ref"),
+		Description: "precise", Currency: "USD", Source: source, Destination: destination,
+		SkipQueue: true, AllowOverDraft: true,
+	})
+	resp, _ := SetUpTestRequest(TestRequest{
+		Payload: payloadBytes, Method: "POST", Route: "/transactions", Router: e.router,
+	})
+	require.Equal(t, http.StatusCreated, resp.Code, "body: %s", resp.Body.String())
+}

--- a/api/balance_monitor_e2e_test.go
+++ b/api/balance_monitor_e2e_test.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2024 Blnk Finance Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/gin-gonic/gin"
+	"github.com/hibiken/asynq"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blnkfinance/blnk"
+	model2 "github.com/blnkfinance/blnk/api/model"
+	"github.com/blnkfinance/blnk/config"
+	"github.com/blnkfinance/blnk/internal/request"
+	"github.com/blnkfinance/blnk/model"
+)
+
+// monitorE2E drives the whole path a real deployment takes: an HTTP request,
+// the ledger, the post-commit monitor check, and the webhook task that a worker
+// would pick up.
+type monitorE2E struct {
+	router    *gin.Engine
+	blnk      *blnk.Blnk
+	cnf       *config.Configuration
+	inspector *asynq.Inspector
+	queue     string
+}
+
+func setupMonitorE2E(t *testing.T) *monitorE2E {
+	t.Helper()
+
+	queue := fmt.Sprintf("monitor_e2e_%d", time.Now().UnixNano())
+	router, b, cnf := setupRouterWithConfig(t, func(cfg *config.Configuration) {
+		cfg.Queue.WebhookQueue = queue
+		// SendWebhook returns early when no URL is set, so the queue would stay
+		// empty however correct the monitor logic was.
+		cfg.Notification = config.Notification{Webhook: config.WebhookConfig{Url: "http://127.0.0.1:1/webhook"}}
+	})
+
+	inspector := asynq.NewInspector(asynq.RedisClientOpt{Addr: "localhost:6379"})
+	t.Cleanup(func() { _ = inspector.Close() })
+
+	return &monitorE2E{router: router, blnk: b, cnf: cnf, inspector: inspector, queue: queue}
+}
+
+// pendingTasks returns every pending task on this harness's queue. The ledger
+// puts its own webhooks on the same queue and a busy test overruns a single
+// page, so this pages to the end rather than sampling the first one.
+func (e *monitorE2E) pendingTasks() []*asynq.TaskInfo {
+	const pageSize = 200
+
+	var all []*asynq.TaskInfo
+	for page := 1; ; page++ {
+		batch, err := e.inspector.ListPendingTasks(e.queue, asynq.PageSize(pageSize), asynq.Page(page))
+		if err != nil {
+			return all
+		}
+		all = append(all, batch...)
+		if len(batch) < pageSize {
+			return all
+		}
+	}
+}
+
+// webhooks counts the balance.monitor tasks waiting on the queue. The payload,
+// not the queue depth, is what the assertions are about.
+func (e *monitorE2E) webhooks() int {
+	count := 0
+	for _, task := range e.pendingTasks() {
+		var hook struct {
+			Event string `json:"event"`
+		}
+		if err := json.Unmarshal(task.Payload, &hook); err != nil {
+			continue
+		}
+		if hook.Event == "balance.monitor" {
+			count++
+		}
+	}
+	return count
+}
+
+// awaitWebhooks waits for the detached post-commit goroutines to settle.
+func (e *monitorE2E) awaitWebhooks(t *testing.T, want int) {
+	t.Helper()
+	require.Eventually(t, func() bool { return e.webhooks() == want }, 5*time.Second, 25*time.Millisecond,
+		"expected %d webhooks, queue holds %d", want, e.webhooks())
+}
+
+// settle gives any further goroutine a chance to enqueue, so a test that asserts
+// "no more webhooks" is not just winning a race.
+func (e *monitorE2E) settle() { time.Sleep(300 * time.Millisecond) }
+
+func (e *monitorE2E) newBalance(t *testing.T) model.Balance {
+	t.Helper()
+
+	ledger, err := e.blnk.CreateLedger(model.Ledger{Name: gofakeit.Name()})
+	require.NoError(t, err)
+
+	balance, err := e.blnk.CreateBalance(context.Background(), model.Balance{LedgerID: ledger.LedgerID, Currency: "USD"})
+	require.NoError(t, err)
+
+	return balance
+}
+
+func (e *monitorE2E) createMonitorOn(t *testing.T, balanceID, field, operator string, value float64) model.BalanceMonitor {
+	t.Helper()
+
+	payloadBytes, _ := request.ToJsonReq(&model2.CreateBalanceMonitor{
+		BalanceId: balanceID,
+		Condition: model2.MonitorCondition{Field: field, Operator: operator, Value: value, Precision: 1},
+	})
+
+	var monitor model.BalanceMonitor
+	resp, _ := SetUpTestRequest(TestRequest{
+		Payload: payloadBytes, Response: &monitor,
+		Method: "POST", Route: "/balance-monitors", Router: e.router,
+	})
+	require.Equal(t, http.StatusCreated, resp.Code)
+	return monitor
+}
+
+// transfer moves amount from source to destination synchronously, so the
+// monitor check has run by the time the request returns.
+func (e *monitorE2E) transfer(t *testing.T, source, destination string, amount float64) {
+	t.Helper()
+
+	payloadBytes, _ := request.ToJsonReq(&model2.RecordTransaction{
+		Amount:      amount,
+		Precision:   1,
+		Reference:   gofakeit.UUID(),
+		Description: "monitor e2e",
+		Currency:    "USD",
+		Source:      source,
+		Destination: destination,
+		SkipQueue:   true,
+		// The funding balance is a plain ledger balance, not @world, so the
+		// debits that move the wallet have to be allowed to take it negative.
+		AllowOverDraft: true,
+	})
+
+	resp, _ := SetUpTestRequest(TestRequest{
+		Payload: payloadBytes,
+		Method:  "POST",
+		Route:   "/transactions",
+		Router:  e.router,
+	})
+	require.Equal(t, http.StatusCreated, resp.Code)
+}

--- a/api/balance_monitor_e2e_test.go
+++ b/api/balance_monitor_e2e_test.go
@@ -21,12 +21,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/gin-gonic/gin"
 	"github.com/hibiken/asynq"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/blnkfinance/blnk"
@@ -101,6 +103,18 @@ func (e *monitorE2E) webhooks() int {
 	return count
 }
 
+// webhooksFor counts the alerts owed to one monitor, so a test with several
+// monitors on a queue can pin each one's share rather than only the total.
+func (e *monitorE2E) webhooksFor(monitorID string) int {
+	count := 0
+	for _, task := range e.pendingTasks() {
+		if strings.Contains(string(task.Payload), monitorID) {
+			count++
+		}
+	}
+	return count
+}
+
 // awaitWebhooks waits for the detached post-commit goroutines to settle.
 func (e *monitorE2E) awaitWebhooks(t *testing.T, want int) {
 	t.Helper()
@@ -124,20 +138,25 @@ func (e *monitorE2E) newBalance(t *testing.T) model.Balance {
 	return balance
 }
 
-func (e *monitorE2E) createMonitorOn(t *testing.T, balanceID, field, operator string, value float64) model.BalanceMonitor {
+func (e *monitorE2E) createMonitor(t *testing.T, balanceID, trigger string, value float64) model.BalanceMonitor {
 	t.Helper()
 
 	payloadBytes, _ := request.ToJsonReq(&model2.CreateBalanceMonitor{
 		BalanceId: balanceID,
-		Condition: model2.MonitorCondition{Field: field, Operator: operator, Value: value, Precision: 1},
+		Trigger:   trigger,
+		Condition: model2.MonitorCondition{Field: "balance", Operator: ">", Value: value, Precision: 1},
 	})
 
 	var monitor model.BalanceMonitor
 	resp, _ := SetUpTestRequest(TestRequest{
-		Payload: payloadBytes, Response: &monitor,
-		Method: "POST", Route: "/balance-monitors", Router: e.router,
+		Payload:  payloadBytes,
+		Response: &monitor,
+		Method:   "POST",
+		Route:    "/balance-monitors",
+		Router:   e.router,
 	})
 	require.Equal(t, http.StatusCreated, resp.Code)
+
 	return monitor
 }
 
@@ -167,4 +186,84 @@ func (e *monitorE2E) transfer(t *testing.T, source, destination string, amount f
 		Router:  e.router,
 	})
 	require.Equal(t, http.StatusCreated, resp.Code)
+}
+
+func (e *monitorE2E) monitorState(t *testing.T, monitorID string) bool {
+	t.Helper()
+	monitor, err := e.blnk.GetMonitorByID(context.Background(), monitorID)
+	require.NoError(t, err)
+	return monitor.ConditionState
+}
+
+// TestBalanceMonitorEdge_EndToEnd walks a balance across its threshold twice
+// over six transactions and asserts the consumer is told twice, not five times.
+func TestBalanceMonitorEdge_EndToEnd(t *testing.T) {
+	e := setupMonitorE2E(t)
+
+	funding := e.newBalance(t)
+	wallet := e.newBalance(t)
+	monitor := e.createMonitor(t, wallet.BalanceID, model.TriggerEdge, 500)
+
+	require.Equal(t, 0, e.webhooks())
+	require.False(t, e.monitorState(t, monitor.MonitorID))
+
+	// Below the threshold: nothing to say.
+	e.transfer(t, funding.BalanceID, wallet.BalanceID, 300)
+	e.settle()
+	assert.Equal(t, 0, e.webhooks())
+	assert.False(t, e.monitorState(t, monitor.MonitorID))
+
+	// The crossing.
+	e.transfer(t, funding.BalanceID, wallet.BalanceID, 300)
+	e.awaitWebhooks(t, 1)
+	assert.True(t, e.monitorState(t, monitor.MonitorID), "the monitor is left triggered")
+
+	// Still past the threshold, so the consumer already knows.
+	e.transfer(t, funding.BalanceID, wallet.BalanceID, 300)
+	e.settle()
+	assert.Equal(t, 1, e.webhooks(), "an edge monitor stays quiet while the condition holds")
+
+	// Back under: re-arm, silently.
+	e.transfer(t, wallet.BalanceID, funding.BalanceID, 400)
+	e.settle()
+	assert.Equal(t, 1, e.webhooks(), "recovering is not an alert")
+	assert.False(t, e.monitorState(t, monitor.MonitorID), "the monitor re-arms")
+
+	// The second crossing.
+	e.transfer(t, funding.BalanceID, wallet.BalanceID, 300)
+	e.awaitWebhooks(t, 2)
+	assert.True(t, e.monitorState(t, monitor.MonitorID))
+}
+
+// TestBalanceMonitorLevel_EndToEnd runs the identical ledger activity against a
+// level-triggered monitor, which is what today's behaviour looks like and what
+// the opt-in still has to deliver.
+func TestBalanceMonitorLevel_EndToEnd(t *testing.T) {
+	e := setupMonitorE2E(t)
+
+	funding := e.newBalance(t)
+	wallet := e.newBalance(t)
+	monitor := e.createMonitor(t, wallet.BalanceID, model.TriggerLevel, 500)
+
+	require.Equal(t, 0, e.webhooks())
+
+	e.transfer(t, funding.BalanceID, wallet.BalanceID, 300)
+	e.settle()
+	assert.Equal(t, 0, e.webhooks())
+
+	e.transfer(t, funding.BalanceID, wallet.BalanceID, 300)
+	e.awaitWebhooks(t, 1)
+
+	e.transfer(t, funding.BalanceID, wallet.BalanceID, 300)
+	e.awaitWebhooks(t, 2)
+
+	e.transfer(t, wallet.BalanceID, funding.BalanceID, 400)
+	e.settle()
+	assert.Equal(t, 2, e.webhooks())
+
+	e.transfer(t, funding.BalanceID, wallet.BalanceID, 300)
+	e.awaitWebhooks(t, 3)
+
+	assert.False(t, e.monitorState(t, monitor.MonitorID),
+		"a level monitor keeps no state, so nothing writes to it")
 }

--- a/api/balance_monitor_matrix_test.go
+++ b/api/balance_monitor_matrix_test.go
@@ -1,0 +1,377 @@
+/*
+Copyright 2024 Blnk Finance Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	blnkservice "github.com/blnkfinance/blnk"
+	model2 "github.com/blnkfinance/blnk/api/model"
+	"github.com/blnkfinance/blnk/internal/request"
+	"github.com/blnkfinance/blnk/model"
+)
+
+// createMonitorOn is createMonitor with the condition field and operator open,
+// so the matrix can cover every combination the ledger supports.
+func (e *monitorE2E) createMonitorOn(t *testing.T, balanceID, trigger, field, operator string, value float64) model.BalanceMonitor {
+	t.Helper()
+
+	payloadBytes, _ := request.ToJsonReq(&model2.CreateBalanceMonitor{
+		BalanceId: balanceID,
+		Trigger:   trigger,
+		Condition: model2.MonitorCondition{Field: field, Operator: operator, Value: value, Precision: 1},
+	})
+
+	var monitor model.BalanceMonitor
+	resp, _ := SetUpTestRequest(TestRequest{
+		Payload: payloadBytes, Response: &monitor,
+		Method: "POST", Route: "/balance-monitors", Router: e.router,
+	})
+	require.Equal(t, http.StatusCreated, resp.Code)
+	return monitor
+}
+
+// TestBalanceMonitorEdge_EveryConditionField covers all six fields
+// CheckCondition understands, each driven by the ledger movement that actually
+// changes it.
+func TestBalanceMonitorEdge_EveryConditionField(t *testing.T) {
+	t.Run("credit_balance", func(t *testing.T) {
+		e := setupMonitorE2E(t)
+		funding, wallet := e.newBalance(t), e.newBalance(t)
+		m := e.createMonitorOn(t, wallet.BalanceID, model.TriggerEdge, "credit_balance", ">", 500)
+
+		e.transfer(t, funding.BalanceID, wallet.BalanceID, 300)
+		e.settle()
+		assert.Equal(t, 0, e.webhooks())
+
+		e.transfer(t, funding.BalanceID, wallet.BalanceID, 300)
+		e.awaitWebhooks(t, 1)
+
+		// credit_balance only ever grows, so it can never re-arm.
+		e.transfer(t, wallet.BalanceID, funding.BalanceID, 400)
+		e.settle()
+		assert.Equal(t, 1, e.webhooks(), "a debit does not reduce credit_balance, so nothing re-arms")
+		assert.True(t, e.monitorState(t, m.MonitorID))
+	})
+
+	t.Run("debit_balance", func(t *testing.T) {
+		e := setupMonitorE2E(t)
+		funding, wallet := e.newBalance(t), e.newBalance(t)
+		e.createMonitorOn(t, wallet.BalanceID, model.TriggerEdge, "debit_balance", ">", 500)
+
+		e.transfer(t, funding.BalanceID, wallet.BalanceID, 900)
+		e.settle()
+		assert.Equal(t, 0, e.webhooks(), "crediting the wallet does not move its debit_balance")
+
+		e.transfer(t, wallet.BalanceID, funding.BalanceID, 600)
+		e.awaitWebhooks(t, 1)
+	})
+
+	t.Run("inflight_credit_balance fires before the commit", func(t *testing.T) {
+		e := setupMonitorE2E(t)
+		funding, wallet := e.newBalance(t), e.newBalance(t)
+		m := e.createMonitorOn(t, wallet.BalanceID, model.TriggerEdge, "inflight_credit_balance", ">", 500)
+
+		txn := e.inflight(t, funding.BalanceID, wallet.BalanceID, 900)
+		e.awaitWebhooks(t, 1)
+		assert.True(t, e.monitorState(t, m.MonitorID), "money in flight is what this monitor watches")
+
+		// Committing drains the inflight balance, which re-arms the monitor.
+		e.settleInflight(t, txn, blnkservice.InflightActionCommit)
+		e.settle()
+		assert.Equal(t, 1, e.webhooks())
+		assert.False(t, e.monitorState(t, m.MonitorID), "a commit drains inflight, so the monitor re-arms")
+	})
+
+	t.Run("inflight_balance re-arms on void", func(t *testing.T) {
+		e := setupMonitorE2E(t)
+		funding, wallet := e.newBalance(t), e.newBalance(t)
+		m := e.createMonitorOn(t, wallet.BalanceID, model.TriggerEdge, "inflight_balance", ">", 500)
+
+		txn := e.inflight(t, funding.BalanceID, wallet.BalanceID, 900)
+		e.awaitWebhooks(t, 1)
+
+		e.settleInflight(t, txn, blnkservice.InflightActionVoid)
+		e.settle()
+		assert.Equal(t, 1, e.webhooks(), "voiding is not an alert")
+		assert.False(t, e.monitorState(t, m.MonitorID), "a void releases inflight, so the monitor re-arms")
+	})
+
+	t.Run("inflight_debit_balance on the source", func(t *testing.T) {
+		e := setupMonitorE2E(t)
+		funding, wallet := e.newBalance(t), e.newBalance(t)
+		e.createMonitorOn(t, funding.BalanceID, model.TriggerEdge, "inflight_debit_balance", ">", 500)
+
+		e.inflight(t, funding.BalanceID, wallet.BalanceID, 900)
+		e.awaitWebhooks(t, 1)
+	})
+}
+
+// TestBalanceMonitorEdge_EveryOperator drives each operator across its own
+// threshold. Equality and inequality have the least obvious crossing
+// semantics, so they matter most.
+func TestBalanceMonitorEdge_EveryOperator(t *testing.T) {
+	cases := []struct {
+		operator string
+		value    float64
+		steps    []float64 // signed transfers into the wallet
+		want     int
+		reason   string
+	}{
+		{">", 500, []float64{300, 300, 300}, 1, "one upward crossing"},
+		{">=", 600, []float64{300, 300, 300}, 1, "reaching the threshold counts"},
+		{"<", 100, []float64{300, -250, -100}, 1, "one downward crossing"},
+		{"<=", 50, []float64{300, -250, -50}, 1, "reaching the threshold counts"},
+		{"=", 600, []float64{300, 300, 300}, 1, "true only at exactly 600, so one crossing"},
+		{"!=", 0, []float64{300, -300, 300}, 2, "leaves zero, returns to zero, leaves again"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.operator, func(t *testing.T) {
+			e := setupMonitorE2E(t)
+			funding, wallet := e.newBalance(t), e.newBalance(t)
+			e.createMonitorOn(t, wallet.BalanceID, model.TriggerEdge, "balance", tc.operator, tc.value)
+
+			for _, amount := range tc.steps {
+				if amount > 0 {
+					e.transfer(t, funding.BalanceID, wallet.BalanceID, amount)
+				} else {
+					e.transfer(t, wallet.BalanceID, funding.BalanceID, -amount)
+				}
+			}
+
+			e.awaitWebhooks(t, tc.want)
+			e.settle()
+			assert.Equal(t, tc.want, e.webhooks(), "operator %q: %s", tc.operator, tc.reason)
+		})
+	}
+}
+
+// TestBalanceMonitorEdge_BulkBatch covers the coalescing post-commit path,
+// which is a different caller from the single-transaction one. A batch that
+// coalesces several transactions on one balance updates it once, so it must
+// alert once.
+func TestBalanceMonitorEdge_BulkBatch(t *testing.T) {
+	e := setupMonitorE2E(t)
+	funding, wallet := e.newBalance(t), e.newBalance(t)
+	m := e.createMonitorOn(t, wallet.BalanceID, model.TriggerEdge, "balance", ">", 500)
+
+	items := make([]*model2.RecordTransaction, 0, 6)
+	for i := 0; i < 6; i++ {
+		items = append(items, &model2.RecordTransaction{
+			Amount: 200, Precision: 1, Reference: gofakeit.UUID(), Description: "bulk",
+			Currency: "USD", Source: funding.BalanceID, Destination: wallet.BalanceID,
+			AllowOverDraft: true,
+		})
+	}
+	payloadBytes, _ := request.ToJsonReq(&model2.BulkTransactionRequest{Transactions: items, SkipQueue: true})
+	resp, _ := SetUpTestRequest(TestRequest{
+		Payload: payloadBytes, Method: "POST", Route: "/transactions/bulk", Router: e.router,
+	})
+	require.Contains(t, []int{http.StatusOK, http.StatusCreated}, resp.Code, "bulk batch rejected: %s", resp.Body.String())
+
+	e.awaitWebhooks(t, 1)
+	e.settle()
+	assert.Equal(t, 1, e.webhooks(), "a batch that crosses the threshold once must alert once")
+	assert.True(t, e.monitorState(t, m.MonitorID))
+}
+
+// TestBalanceMonitorEdge_OverdraftThreshold covers a negative threshold, which
+// is what a credit line actually needs.
+func TestBalanceMonitorEdge_OverdraftThreshold(t *testing.T) {
+	e := setupMonitorE2E(t)
+	funding, wallet := e.newBalance(t), e.newBalance(t)
+	e.createMonitorOn(t, wallet.BalanceID, model.TriggerEdge, "balance", "<", -500)
+
+	e.transfer(t, wallet.BalanceID, funding.BalanceID, 300)
+	e.settle()
+	assert.Equal(t, 0, e.webhooks(), "-300 has not breached the credit line")
+
+	e.transfer(t, wallet.BalanceID, funding.BalanceID, 300)
+	e.awaitWebhooks(t, 1)
+
+	e.transfer(t, funding.BalanceID, wallet.BalanceID, 400)
+	e.settle()
+	assert.Equal(t, 1, e.webhooks(), "back inside the line is not an alert")
+
+	e.transfer(t, wallet.BalanceID, funding.BalanceID, 400)
+	e.awaitWebhooks(t, 2)
+}
+
+// TestBalanceMonitorEdge_ManyMonitorsOnOneBalance checks that every monitor on
+// a balance is evaluated, not just the first, and that each owns its own edge.
+func TestBalanceMonitorEdge_ManyMonitorsOnOneBalance(t *testing.T) {
+	e := setupMonitorE2E(t)
+	funding, wallet := e.newBalance(t), e.newBalance(t)
+
+	const monitors = 12
+	for i := 0; i < monitors; i++ {
+		e.createMonitorOn(t, wallet.BalanceID, model.TriggerEdge, "balance", ">", float64(100*i+50))
+	}
+
+	// One transaction past every threshold: each monitor owes exactly one alert.
+	e.transfer(t, funding.BalanceID, wallet.BalanceID, 5000)
+	e.awaitWebhooks(t, monitors)
+	e.settle()
+	assert.Equal(t, monitors, e.webhooks())
+
+	e.transfer(t, funding.BalanceID, wallet.BalanceID, 1000)
+	e.settle()
+	assert.Equal(t, monitors, e.webhooks(), "still past every threshold, so nothing more to say")
+}
+
+// TestBalanceMonitorEdge_CreatedWhileConditionAlreadyHolds pins the documented
+// creation rule: a monitor starts armed, so one whose condition already holds
+// alerts on its balance's next transaction and then goes quiet.
+func TestBalanceMonitorEdge_CreatedWhileConditionAlreadyHolds(t *testing.T) {
+	e := setupMonitorE2E(t)
+	funding, wallet := e.newBalance(t), e.newBalance(t)
+
+	e.transfer(t, funding.BalanceID, wallet.BalanceID, 900)
+	e.settle()
+
+	m := e.createMonitorOn(t, wallet.BalanceID, model.TriggerEdge, "balance", ">", 500)
+	assert.False(t, m.ConditionState, "a new monitor starts armed")
+	e.settle()
+	assert.Equal(t, 0, e.webhooks(), "creating a monitor does not evaluate it")
+
+	e.transfer(t, funding.BalanceID, wallet.BalanceID, 1)
+	e.awaitWebhooks(t, 1)
+	e.settle()
+	assert.Equal(t, 1, e.webhooks(), "and it settles after the one catch-up alert")
+}
+
+// TestBalanceMonitorEdge_DuplicateMonitors checks that two identical monitors
+// on one balance keep separate state.
+func TestBalanceMonitorEdge_DuplicateMonitors(t *testing.T) {
+	e := setupMonitorE2E(t)
+	funding, wallet := e.newBalance(t), e.newBalance(t)
+	first := e.createMonitorOn(t, wallet.BalanceID, model.TriggerEdge, "balance", ">", 500)
+	second := e.createMonitorOn(t, wallet.BalanceID, model.TriggerEdge, "balance", ">", 500)
+
+	e.transfer(t, funding.BalanceID, wallet.BalanceID, 900)
+	e.awaitWebhooks(t, 2)
+	assert.True(t, e.monitorState(t, first.MonitorID))
+	assert.True(t, e.monitorState(t, second.MonitorID))
+}
+
+// TestBalanceMonitor_GetEndpointsReportTriggerAndState covers the read surface
+// a consumer uses to answer "why is this monitor quiet?".
+func TestBalanceMonitor_GetEndpointsReportTriggerAndState(t *testing.T) {
+	e := setupMonitorE2E(t)
+	funding, wallet := e.newBalance(t), e.newBalance(t)
+	created := e.createMonitorOn(t, wallet.BalanceID, model.TriggerEdge, "balance", ">", 500)
+
+	e.transfer(t, funding.BalanceID, wallet.BalanceID, 900)
+	e.awaitWebhooks(t, 1)
+
+	var one model.BalanceMonitor
+	resp, _ := SetUpTestRequest(TestRequest{
+		Response: &one, Method: "GET",
+		Route: fmt.Sprintf("/balance-monitors/%s", created.MonitorID), Router: e.router,
+	})
+	require.Equal(t, http.StatusOK, resp.Code)
+	assert.Equal(t, model.TriggerEdge, one.Trigger)
+	assert.True(t, one.ConditionState, "the detail endpoint reports the monitor is triggered")
+
+	var byBalance []model.BalanceMonitor
+	resp, _ = SetUpTestRequest(TestRequest{
+		Response: &byBalance, Method: "GET",
+		Route: fmt.Sprintf("/balance-monitors/balances/%s", wallet.BalanceID), Router: e.router,
+	})
+	require.Equal(t, http.StatusOK, resp.Code)
+	require.Len(t, byBalance, 1)
+	assert.Equal(t, model.TriggerEdge, byBalance[0].Trigger)
+	assert.True(t, byBalance[0].ConditionState)
+
+	var all []model.BalanceMonitor
+	resp, _ = SetUpTestRequest(TestRequest{
+		Response: &all, Method: "GET", Route: "/balance-monitors", Router: e.router,
+	})
+	require.Equal(t, http.StatusOK, resp.Code)
+	found := false
+	for _, m := range all {
+		if m.MonitorID == created.MonitorID {
+			assert.Equal(t, model.TriggerEdge, m.Trigger)
+			assert.True(t, m.ConditionState)
+			found = true
+		}
+	}
+	assert.True(t, found, "the list endpoint must report the same monitor")
+}
+
+// TestBalanceMonitorEdge_DeleteWhileTriggered checks a triggered monitor can
+// still be removed and stops alerting.
+func TestBalanceMonitorEdge_DeleteWhileTriggered(t *testing.T) {
+	e := setupMonitorE2E(t)
+	funding, wallet := e.newBalance(t), e.newBalance(t)
+	created := e.createMonitorOn(t, wallet.BalanceID, model.TriggerEdge, "balance", ">", 500)
+
+	e.transfer(t, funding.BalanceID, wallet.BalanceID, 900)
+	e.awaitWebhooks(t, 1)
+
+	resp, _ := SetUpTestRequest(TestRequest{
+		Method: "DELETE", Route: fmt.Sprintf("/balance-monitors/%s", created.MonitorID), Router: e.router,
+	})
+	require.Equal(t, http.StatusOK, resp.Code)
+
+	e.transfer(t, wallet.BalanceID, funding.BalanceID, 800)
+	e.transfer(t, funding.BalanceID, wallet.BalanceID, 800)
+	e.settle()
+	assert.Equal(t, 1, e.webhooks(), "a deleted monitor alerts no further")
+
+	_, err := e.blnk.GetMonitorByID(context.Background(), created.MonitorID)
+	assert.Error(t, err)
+}
+
+// inflight records a transaction that holds its amount in flight and returns it.
+func (e *monitorE2E) inflight(t *testing.T, source, destination string, amount float64) model.Transaction {
+	t.Helper()
+
+	payloadBytes, _ := request.ToJsonReq(&model2.RecordTransaction{
+		Amount: amount, Precision: 1, Reference: gofakeit.UUID(), Description: "inflight",
+		Currency: "USD", Source: source, Destination: destination,
+		Inflight: true, SkipQueue: true, AllowOverDraft: true,
+	})
+
+	var txn model.Transaction
+	resp, _ := SetUpTestRequest(TestRequest{
+		Payload: payloadBytes, Response: &txn,
+		Method: "POST", Route: "/transactions", Router: e.router,
+	})
+	require.Equal(t, http.StatusCreated, resp.Code)
+	require.NotEmpty(t, txn.TransactionID)
+	return txn
+}
+
+func (e *monitorE2E) settleInflight(t *testing.T, txn model.Transaction, action string) {
+	t.Helper()
+
+	payloadBytes, _ := request.ToJsonReq(&model2.InflightUpdate{Status: action, SkipQueue: true})
+	resp, _ := SetUpTestRequest(TestRequest{
+		Payload: payloadBytes, Method: "PUT",
+		Route: fmt.Sprintf("/transactions/inflight/%s", txn.TransactionID), Router: e.router,
+	})
+	require.Equal(t, http.StatusOK, resp.Code, "inflight %s failed: %s", action, resp.Body.String())
+}

--- a/api/balance_monitor_property_test.go
+++ b/api/balance_monitor_property_test.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2024 Blnk Finance Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blnkfinance/blnk/model"
+)
+
+// ledgerWalk is a random but fully determined sequence of transfers, together
+// with the balance the wallet holds after each one.
+type ledgerWalk struct {
+	amounts  []float64 // positive credits the wallet, negative debits it
+	balances []int64
+}
+
+func newLedgerWalk(seed int64, steps int) ledgerWalk {
+	rng := rand.New(rand.NewSource(seed))
+	walk := ledgerWalk{}
+	balance := int64(0)
+	for i := 0; i < steps; i++ {
+		amount := float64(rng.Intn(400) + 50)
+		if rng.Intn(2) == 0 {
+			amount = -amount
+		}
+		balance += int64(amount)
+		walk.amounts = append(walk.amounts, amount)
+		walk.balances = append(walk.balances, balance)
+	}
+	return walk
+}
+
+// expectedEdges counts false -> true transitions of "balance > threshold",
+// which is the number of alerts an edge monitor owes the consumer.
+func (w ledgerWalk) expectedEdges(threshold int64) int {
+	count, previous := 0, false
+	for _, balance := range w.balances {
+		current := balance > threshold
+		if current && !previous {
+			count++
+		}
+		previous = current
+	}
+	return count
+}
+
+// expectedLevels counts every step where the condition holds, which is what a
+// level monitor owes.
+func (w ledgerWalk) expectedLevels(threshold int64) int {
+	count := 0
+	for _, balance := range w.balances {
+		if balance > threshold {
+			count++
+		}
+	}
+	return count
+}
+
+// TestBalanceMonitor_AlertCountMatchesTheLedgerWalk drives randomised ledger
+// activity and checks the alert count against a definition of the semantics
+// computed independently of the implementation. Hand-picked sequences only
+// prove the cases someone thought of; this one wanders across the threshold in
+// ways nobody chose.
+func TestBalanceMonitor_AlertCountMatchesTheLedgerWalk(t *testing.T) {
+	const threshold = 500
+
+	for _, seed := range []int64{1, 7, 13, 42, 99} {
+		walk := newLedgerWalk(seed, 14)
+
+		t.Run("edge", func(t *testing.T) {
+			e := setupMonitorE2E(t)
+			funding := e.newBalance(t)
+			wallet := e.newBalance(t)
+			monitor := e.createMonitor(t, wallet.BalanceID, model.TriggerEdge, threshold)
+
+			for _, amount := range walk.amounts {
+				if amount > 0 {
+					e.transfer(t, funding.BalanceID, wallet.BalanceID, amount)
+				} else {
+					e.transfer(t, wallet.BalanceID, funding.BalanceID, -amount)
+				}
+			}
+
+			want := walk.expectedEdges(threshold)
+			e.awaitWebhooks(t, want)
+			e.settle()
+			assert.Equal(t, want, e.webhooks(),
+				"seed %d: %d transactions crossing %d must alert on each false->true transition only",
+				seed, len(walk.amounts), threshold)
+
+			finalState := walk.balances[len(walk.balances)-1] > threshold
+			assert.Equal(t, finalState, e.monitorState(t, monitor.MonitorID),
+				"seed %d: the stored state must match the final balance", seed)
+		})
+
+		t.Run("level", func(t *testing.T) {
+			e := setupMonitorE2E(t)
+			funding := e.newBalance(t)
+			wallet := e.newBalance(t)
+			e.createMonitor(t, wallet.BalanceID, model.TriggerLevel, threshold)
+
+			for _, amount := range walk.amounts {
+				if amount > 0 {
+					e.transfer(t, funding.BalanceID, wallet.BalanceID, amount)
+				} else {
+					e.transfer(t, wallet.BalanceID, funding.BalanceID, -amount)
+				}
+			}
+
+			want := walk.expectedLevels(threshold)
+			e.awaitWebhooks(t, want)
+			e.settle()
+			assert.Equal(t, want, e.webhooks(),
+				"seed %d: level triggering alerts on every update while the condition holds", seed)
+		})
+	}
+}
+
+// TestBalanceMonitor_EdgeIsNeverNoisierThanLevel is the property the whole
+// change exists to deliver, stated directly.
+func TestBalanceMonitor_EdgeIsNeverNoisierThanLevel(t *testing.T) {
+	const threshold = 500
+
+	for _, seed := range []int64{3, 21, 55} {
+		walk := newLedgerWalk(seed, 16)
+		edges := walk.expectedEdges(threshold)
+		levels := walk.expectedLevels(threshold)
+		require.LessOrEqual(t, edges, levels, "seed %d: the walk itself must satisfy the property", seed)
+
+		e := setupMonitorE2E(t)
+		funding := e.newBalance(t)
+		edgeWallet := e.newBalance(t)
+		levelWallet := e.newBalance(t)
+		e.createMonitor(t, edgeWallet.BalanceID, model.TriggerEdge, threshold)
+		e.createMonitor(t, levelWallet.BalanceID, model.TriggerLevel, threshold)
+
+		for _, wallet := range []string{edgeWallet.BalanceID, levelWallet.BalanceID} {
+			for _, amount := range walk.amounts {
+				if amount > 0 {
+					e.transfer(t, funding.BalanceID, wallet, amount)
+				} else {
+					e.transfer(t, wallet, funding.BalanceID, -amount)
+				}
+			}
+		}
+
+		e.awaitWebhooks(t, edges+levels)
+		e.settle()
+		assert.Equal(t, edges+levels, e.webhooks(), "seed %d", seed)
+	}
+}

--- a/api/balance_monitor_trigger_api_test.go
+++ b/api/balance_monitor_trigger_api_test.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2024 Blnk Finance Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"net/http"
+	"testing"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blnkfinance/blnk"
+	model2 "github.com/blnkfinance/blnk/api/model"
+	"github.com/blnkfinance/blnk/internal/request"
+	"github.com/blnkfinance/blnk/model"
+)
+
+// newMonitorTestBalance creates the ledger and balance a monitor needs.
+func newMonitorTestBalance(t *testing.T, b *blnk.Blnk) model.Balance {
+	t.Helper()
+
+	ledger, err := b.CreateLedger(model.Ledger{Name: gofakeit.Name()})
+	require.NoError(t, err)
+
+	balance, err := b.CreateBalance(context.Background(), model.Balance{
+		LedgerID: ledger.LedgerID,
+		Currency: gofakeit.CurrencyShort(),
+	})
+	require.NoError(t, err)
+
+	return balance
+}
+
+func TestCreateBalanceMonitor_Trigger(t *testing.T) {
+	router, b, err := setupRouter()
+	require.NoError(t, err)
+
+	balance := newMonitorTestBalance(t, b)
+
+	tests := []struct {
+		name            string
+		trigger         string
+		expectedCode    int
+		expectedTrigger string
+	}{
+		{name: "Omitted trigger defaults to edge", trigger: "", expectedCode: http.StatusCreated, expectedTrigger: model.TriggerEdge},
+		{name: "Edge accepted", trigger: model.TriggerEdge, expectedCode: http.StatusCreated, expectedTrigger: model.TriggerEdge},
+		{name: "Level accepted", trigger: model.TriggerLevel, expectedCode: http.StatusCreated, expectedTrigger: model.TriggerLevel},
+		{name: "Unknown trigger rejected", trigger: "sometimes", expectedCode: http.StatusBadRequest},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payload := model2.CreateBalanceMonitor{
+				BalanceId: balance.BalanceID,
+				Trigger:   tt.trigger,
+				Condition: model2.MonitorCondition{
+					Field:     "balance",
+					Operator:  "<",
+					Value:     1000,
+					Precision: 100,
+				},
+			}
+
+			payloadBytes, _ := request.ToJsonReq(&payload)
+			var response model.BalanceMonitor
+			resp, _ := SetUpTestRequest(TestRequest{
+				Payload:  payloadBytes,
+				Response: &response,
+				Method:   "POST",
+				Route:    "/balance-monitors",
+				Router:   router,
+			})
+
+			assert.Equal(t, tt.expectedCode, resp.Code)
+			if tt.expectedCode == http.StatusCreated {
+				assert.Equal(t, tt.expectedTrigger, response.Trigger)
+				assert.False(t, response.ConditionState, "a new monitor starts armed")
+			}
+		})
+	}
+}
+
+func TestUpdateBalanceMonitor_Trigger(t *testing.T) {
+	router, b, err := setupRouter()
+	require.NoError(t, err)
+
+	balance := newMonitorTestBalance(t, b)
+
+	monitor, err := b.CreateMonitor(context.Background(), model.BalanceMonitor{
+		BalanceID: balance.BalanceID,
+		Trigger:   model.TriggerEdge,
+		Condition: model.AlertCondition{
+			Field:        "balance",
+			Operator:     "<",
+			Value:        1000,
+			Precision:    100,
+			PreciseValue: big.NewInt(100000),
+		},
+	})
+	require.NoError(t, err)
+
+	t.Run("Unknown trigger rejected", func(t *testing.T) {
+		payloadBytes, _ := request.ToJsonReq(&model.BalanceMonitor{
+			BalanceID: balance.BalanceID,
+			Trigger:   "occasionally",
+			Condition: model.AlertCondition{Field: "balance", Operator: "<", Value: 1000},
+		})
+		resp, _ := SetUpTestRequest(TestRequest{
+			Payload: payloadBytes,
+			Method:  "PUT",
+			Route:   fmt.Sprintf("/balance-monitors/%s", monitor.MonitorID),
+			Router:  router,
+		})
+		assert.Equal(t, http.StatusBadRequest, resp.Code)
+	})
+
+	t.Run("Switching to level and back", func(t *testing.T) {
+		for _, trigger := range []string{model.TriggerLevel, model.TriggerEdge} {
+			payloadBytes, _ := request.ToJsonReq(&model.BalanceMonitor{
+				BalanceID: balance.BalanceID,
+				Trigger:   trigger,
+				Condition: model.AlertCondition{Field: "balance", Operator: "<", Value: 1000},
+			})
+			resp, _ := SetUpTestRequest(TestRequest{
+				Payload: payloadBytes,
+				Method:  "PUT",
+				Route:   fmt.Sprintf("/balance-monitors/%s", monitor.MonitorID),
+				Router:  router,
+			})
+			require.Equal(t, http.StatusOK, resp.Code)
+
+			stored, err := b.GetMonitorByID(context.Background(), monitor.MonitorID)
+			require.NoError(t, err)
+			assert.Equal(t, trigger, stored.Trigger)
+		}
+	})
+
+	t.Run("Omitted trigger falls back to edge", func(t *testing.T) {
+		payloadBytes, _ := request.ToJsonReq(&model.BalanceMonitor{
+			BalanceID: balance.BalanceID,
+			Condition: model.AlertCondition{Field: "balance", Operator: "<", Value: 1000},
+		})
+		resp, _ := SetUpTestRequest(TestRequest{
+			Payload: payloadBytes,
+			Method:  "PUT",
+			Route:   fmt.Sprintf("/balance-monitors/%s", monitor.MonitorID),
+			Router:  router,
+		})
+		require.Equal(t, http.StatusOK, resp.Code)
+
+		stored, err := b.GetMonitorByID(context.Background(), monitor.MonitorID)
+		require.NoError(t, err)
+		assert.Equal(t, model.TriggerEdge, stored.Trigger)
+	})
+}

--- a/api/model/balance.go
+++ b/api/model/balance.go
@@ -27,10 +27,10 @@ type CreateBalance struct {
 }
 
 type CreateBalanceMonitor struct {
-	BalanceId   string                 `json:"balance_id"`
-	Condition   MonitorCondition       `json:"condition"`
-	CallBackURL string                 `json:"call_back_url"`
-	MetaData    map[string]interface{} `json:"meta_data"`
+	BalanceId   string           `json:"balance_id"`
+	Condition   MonitorCondition `json:"condition"`
+	CallBackURL string           `json:"call_back_url"`
+	Description string           `json:"description"`
 }
 
 type MonitorCondition struct {

--- a/api/model/balance.go
+++ b/api/model/balance.go
@@ -31,6 +31,9 @@ type CreateBalanceMonitor struct {
 	Condition   MonitorCondition `json:"condition"`
 	CallBackURL string           `json:"call_back_url"`
 	Description string           `json:"description"`
+	// Trigger is "edge" (default) or "level". Edge alerts once when the
+	// condition becomes true; level alerts on every transaction while it holds.
+	Trigger string `json:"trigger"`
 }
 
 type MonitorCondition struct {

--- a/api/model/model.go
+++ b/api/model/model.go
@@ -254,6 +254,14 @@ func (b *CreateBalanceMonitor) ValidateCreateBalanceMonitor() error {
 			// Call the ValidateMonitorCondition method
 			return condition.ValidateMonitorCondition()
 		})),
+		validation.Field(&b.Trigger, validation.By(func(value interface{}) error {
+			trigger, ok := value.(string)
+			if !ok {
+				return errors.New("invalid trigger type")
+			}
+			_, err := model.NormalizeTrigger(trigger)
+			return err
+		})),
 	)
 }
 
@@ -376,7 +384,7 @@ func (b *CreateBalanceMonitor) ToBalanceMonitor() model.BalanceMonitor {
 		Operator:  b.Condition.Operator,
 		Value:     b.Condition.Value,
 		Precision: b.Condition.Precision,
-	}, CallBackURL: b.CallBackURL, Description: b.Description}
+	}, CallBackURL: b.CallBackURL, Description: b.Description, Trigger: b.Trigger}
 }
 
 func (a *CreateAccount) ToAccount() model.Account {

--- a/api/model/model.go
+++ b/api/model/model.go
@@ -260,9 +260,13 @@ func (b *CreateBalanceMonitor) ValidateCreateBalanceMonitor() error {
 func (c *MonitorCondition) ValidateMonitorCondition() error {
 	return validation.ValidateStruct(c,
 		validation.Field(&c.Field, validation.Required, validation.In("debit_balance", "credit_balance", "balance", "inflight_debit_balance", "inflight_credit_balance", "inflight_balance")),
-		validation.Field(&c.Operator, validation.Required),
+		validation.Field(&c.Operator, validation.Required, validation.In(">", "<", ">=", "<=", "=", "!=")),
 		validation.Field(&c.Precision, validation.Required, validation.By(validatePrecisionNotNegative)),
-		validation.Field(&c.Value, validation.Required),
+		// Value is deliberately not Required: ozzo treats a zero number as
+		// absent, which made every threshold at zero unexpressible -- no
+		// "balance > 0", no "balance != 0", no "balance <= 0". Precision keeps
+		// the rule because a zero multiplier is meaningless, a zero threshold
+		// is not.
 	)
 }
 
@@ -372,7 +376,7 @@ func (b *CreateBalanceMonitor) ToBalanceMonitor() model.BalanceMonitor {
 		Operator:  b.Condition.Operator,
 		Value:     b.Condition.Value,
 		Precision: b.Condition.Precision,
-	}, CallBackURL: b.CallBackURL}
+	}, CallBackURL: b.CallBackURL, Description: b.Description}
 }
 
 func (a *CreateAccount) ToAccount() model.Account {

--- a/api/model/model_test.go
+++ b/api/model/model_test.go
@@ -856,6 +856,37 @@ func TestToBalanceMonitor(t *testing.T) {
 	assert.Equal(t, createMonitor.Condition.Operator, monitor.Condition.Operator)
 	assert.Equal(t, createMonitor.Condition.Value, monitor.Condition.Value)
 	assert.Equal(t, createMonitor.Condition.Precision, monitor.Condition.Precision)
+	// The request struct carries the caller's choice through untouched;
+	// model.NormalizeTrigger is the one place that resolves an unset one.
+	assert.Empty(t, monitor.Trigger)
+}
+
+func TestToBalanceMonitor_KeepsAnExplicitTrigger(t *testing.T) {
+	createMonitor := CreateBalanceMonitor{
+		BalanceId: "bln_test_123",
+		Trigger:   model.TriggerLevel,
+		Condition: MonitorCondition{Field: "balance", Operator: ">", Value: 1000, Precision: 100},
+	}
+
+	assert.Equal(t, model.TriggerLevel, createMonitor.ToBalanceMonitor().Trigger)
+}
+
+func TestValidateCreateBalanceMonitor_Trigger(t *testing.T) {
+	base := func(trigger string) CreateBalanceMonitor {
+		return CreateBalanceMonitor{
+			BalanceId: "bln_test_123",
+			Trigger:   trigger,
+			Condition: MonitorCondition{Field: "balance", Operator: ">", Value: 1000, Precision: 100},
+		}
+	}
+
+	for _, trigger := range []string{"", model.TriggerEdge, model.TriggerLevel} {
+		monitor := base(trigger)
+		assert.NoError(t, monitor.ValidateCreateBalanceMonitor(), "trigger %q must be accepted", trigger)
+	}
+
+	monitor := base("sometimes")
+	assert.Error(t, monitor.ValidateCreateBalanceMonitor())
 }
 
 func TestValidateMonitorCondition_AllowsAZeroThreshold(t *testing.T) {
@@ -896,6 +927,21 @@ func TestToBalanceMonitor_CarriesDescription(t *testing.T) {
 
 	assert.Equal(t, "low balance alert", createMonitor.ToBalanceMonitor().Description,
 		"description is a column and is settable on update, so create must be able to set it too")
+}
+
+func TestNormalizeTriggerIsTheOnlyDefault(t *testing.T) {
+	trigger, err := model.NormalizeTrigger("")
+	assert.NoError(t, err)
+	assert.Equal(t, model.TriggerEdge, trigger, "an unset trigger resolves to edge")
+
+	for _, valid := range []string{model.TriggerEdge, model.TriggerLevel} {
+		trigger, err := model.NormalizeTrigger(valid)
+		assert.NoError(t, err)
+		assert.Equal(t, valid, trigger, "an explicit trigger is carried through untouched")
+	}
+
+	_, err = model.NormalizeTrigger("sometimes")
+	assert.Error(t, err)
 }
 
 // TestSplitOnOneSideValidation pins that a transaction cannot split both

--- a/api/model/model_test.go
+++ b/api/model/model_test.go
@@ -858,6 +858,46 @@ func TestToBalanceMonitor(t *testing.T) {
 	assert.Equal(t, createMonitor.Condition.Precision, monitor.Condition.Precision)
 }
 
+func TestValidateMonitorCondition_AllowsAZeroThreshold(t *testing.T) {
+	// "balance > 0" and "balance != 0" are the most natural monitors there are,
+	// and a validator that treats zero as absent made all of them impossible.
+	for _, operator := range []string{">", "<", ">=", "<=", "=", "!="} {
+		condition := MonitorCondition{Field: "balance", Operator: operator, Value: 0, Precision: 100}
+		assert.NoError(t, condition.ValidateMonitorCondition(), "zero is a threshold like any other (%s)", operator)
+	}
+}
+
+func TestValidateMonitorCondition_RejectsUnsupportedOperators(t *testing.T) {
+	base := func(operator string) MonitorCondition {
+		return MonitorCondition{Field: "balance", Operator: operator, Value: 100, Precision: 100}
+	}
+
+	// The whole set the table's check constraint stores, all of which
+	// model.compare can now evaluate.
+	for _, operator := range []string{">", "<", ">=", "<=", "=", "!="} {
+		condition := base(operator)
+		assert.NoError(t, condition.ValidateMonitorCondition(), "operator %q must be accepted", operator)
+	}
+
+	// An operator the ledger cannot evaluate used to be stored happily and then
+	// never fire, which is worse than a rejection.
+	for _, operator := range []string{"==", "=>", "gt", "~"} {
+		condition := base(operator)
+		assert.Error(t, condition.ValidateMonitorCondition(), "operator %q must be rejected", operator)
+	}
+}
+
+func TestToBalanceMonitor_CarriesDescription(t *testing.T) {
+	createMonitor := CreateBalanceMonitor{
+		BalanceId:   "bln_test_123",
+		Description: "low balance alert",
+		Condition:   MonitorCondition{Field: "balance", Operator: "<", Value: 1000, Precision: 100},
+	}
+
+	assert.Equal(t, "low balance alert", createMonitor.ToBalanceMonitor().Description,
+		"description is a column and is settable on update, so create must be able to set it too")
+}
+
 // TestSplitOnOneSideValidation pins that a transaction cannot split both
 // sides at once. SplitTransactionPrecise distributes over Sources when they
 // are present and Destinations otherwise, clearing both on the legs it

--- a/balance.go
+++ b/balance.go
@@ -77,7 +77,7 @@ func NewBalanceTracker() *model.BalanceTracker {
 // - ctx context.Context: The context for the operation.
 // - updatedBalance *model.Balance: A pointer to the updated Balance model.
 func (l *Blnk) checkBalanceMonitors(ctx context.Context, updatedBalance *model.Balance) {
-	_, span := balanceTracer.Start(ctx, "CheckBalanceMonitors")
+	ctx, span := balanceTracer.Start(ctx, "CheckBalanceMonitors")
 	defer span.End()
 
 	// Fetch monitors using cache (avoids DB query on every transaction)
@@ -90,19 +90,53 @@ func (l *Blnk) checkBalanceMonitors(ctx context.Context, updatedBalance *model.B
 
 	// Check each monitor's condition
 	for _, monitor := range monitors {
-		if monitor.CheckCondition(updatedBalance) {
-			span.AddEvent(fmt.Sprintf("Condition met for balance: %s", monitor.MonitorID))
-			go func(monitor model.BalanceMonitor) {
-				err := l.SendWebhook(NewWebhook{
-					Event:   "balance.monitor",
-					Payload: monitor,
-				})
-				if err != nil {
+		met := monitor.CheckCondition(updatedBalance)
+
+		if monitor.TriggerMode() == model.TriggerLevel {
+			if met {
+				span.AddEvent(fmt.Sprintf("Condition met for balance: %s", monitor.MonitorID))
+				if err := l.sendMonitorWebhook(monitor); err != nil {
 					notification.NotifyError(err)
 				}
-			}(monitor)
+			}
+			continue
+		}
+
+		// Edge: the state transition decides, not the condition. The cached
+		// monitor is only trusted for its trigger mode and condition; the state
+		// lives in the database, where concurrent evaluations of the same
+		// balance serialise against each other.
+		owned, err := l.datasource.TransitionMonitorState(ctx, monitor.MonitorID, updatedBalance.BalanceID, met, updatedBalance.Version)
+		if err != nil {
+			span.RecordError(err)
+			notification.NotifyError(err)
+			continue
+		}
+		if !owned || !met {
+			continue
+		}
+
+		span.AddEvent(fmt.Sprintf("Condition crossed for balance: %s", monitor.MonitorID))
+		monitor.ConditionState = true
+		if err := l.sendMonitorWebhook(monitor); err != nil {
+			notification.NotifyError(err)
+			// An edge fires once, so a transition that could not be handed off
+			// has to be given back or the crossing is lost for good.
+			if releaseErr := l.datasource.ReleaseMonitorState(ctx, monitor.MonitorID, updatedBalance.BalanceID, updatedBalance.Version); releaseErr != nil {
+				span.RecordError(releaseErr)
+				notification.NotifyError(releaseErr)
+			}
 		}
 	}
+}
+
+// sendMonitorWebhook enqueues the balance.monitor notification for a monitor
+// whose condition has been met.
+func (l *Blnk) sendMonitorWebhook(monitor model.BalanceMonitor) error {
+	return l.SendWebhook(NewWebhook{
+		Event:   "balance.monitor",
+		Payload: monitor,
+	})
 }
 
 // getBalanceMonitorsCached retrieves balance monitors with caching.

--- a/balance.go
+++ b/balance.go
@@ -455,16 +455,28 @@ func (l *Blnk) GetBalanceMonitors(ctx context.Context, balanceID string) ([]mode
 // Returns:
 // - error: An error if the monitor could not be updated.
 func (l *Blnk) UpdateMonitor(ctx context.Context, monitor *model.BalanceMonitor) error {
-	_, span := balanceTracer.Start(ctx, "UpdateMonitor")
+	ctx, span := balanceTracer.Start(ctx, "UpdateMonitor")
 	defer span.End()
 
-	err := l.datasource.UpdateMonitor(monitor)
+	// An update may move the monitor to a different balance, and the cache is
+	// keyed by balance: without the previous ID the monitor stays in the old
+	// balance's cached list and keeps being evaluated against a balance it no
+	// longer watches.
+	previous, err := l.datasource.GetMonitorByID(monitor.MonitorID)
 	if err != nil {
 		span.RecordError(err)
 		return err
 	}
 
+	if err := l.datasource.UpdateMonitor(monitor); err != nil {
+		span.RecordError(err)
+		return err
+	}
+
 	_ = l.cache.Delete(ctx, "monitors:"+monitor.BalanceID)
+	if previous.BalanceID != monitor.BalanceID {
+		_ = l.cache.Delete(ctx, "monitors:"+previous.BalanceID)
+	}
 
 	span.AddEvent("Monitor updated", trace.WithAttributes(attribute.String("monitor.id", monitor.MonitorID)))
 	return nil

--- a/balance_monitor_cache_test.go
+++ b/balance_monitor_cache_test.go
@@ -27,34 +27,8 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/blnkfinance/blnk/config"
-	"github.com/blnkfinance/blnk/database/mocks"
 	"github.com/blnkfinance/blnk/model"
 )
-
-type monitorHarness struct {
-	blnk *Blnk
-	ds   *mocks.MockDataSource
-}
-
-func newMonitorHarness(t *testing.T) *monitorHarness {
-	t.Helper()
-
-	// Stored directly rather than through MockConfig, which runs the full
-	// validation this partial test configuration cannot satisfy.
-	config.ConfigStore.Store(&config.Configuration{
-		Redis:              config.RedisConfig{Dns: "localhost:6379"},
-		Queue:              config.QueueConfig{WebhookQueue: "monitor_cache_test", TransactionQueue: "monitor_cache_test_txn", IndexQueue: "monitor_cache_test_idx", NumberOfQueues: 1},
-		Server:             config.ServerConfig{SecretKey: "some-secret"},
-		TokenizationSecret: "12345678901234567890123456789012",
-	})
-
-	ds := new(mocks.MockDataSource)
-	b, err := NewBlnk(ds)
-	require.NoError(t, err)
-
-	return &monitorHarness{blnk: b, ds: ds}
-}
 
 // recordingCache notes which keys were invalidated.
 type recordingCache struct {

--- a/balance_monitor_cache_test.go
+++ b/balance_monitor_cache_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2024 Blnk Finance Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package blnk
+
+import (
+	"context"
+	"math/big"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blnkfinance/blnk/config"
+	"github.com/blnkfinance/blnk/database/mocks"
+	"github.com/blnkfinance/blnk/model"
+)
+
+type monitorHarness struct {
+	blnk *Blnk
+	ds   *mocks.MockDataSource
+}
+
+func newMonitorHarness(t *testing.T) *monitorHarness {
+	t.Helper()
+
+	// Stored directly rather than through MockConfig, which runs the full
+	// validation this partial test configuration cannot satisfy.
+	config.ConfigStore.Store(&config.Configuration{
+		Redis:              config.RedisConfig{Dns: "localhost:6379"},
+		Queue:              config.QueueConfig{WebhookQueue: "monitor_cache_test", TransactionQueue: "monitor_cache_test_txn", IndexQueue: "monitor_cache_test_idx", NumberOfQueues: 1},
+		Server:             config.ServerConfig{SecretKey: "some-secret"},
+		TokenizationSecret: "12345678901234567890123456789012",
+	})
+
+	ds := new(mocks.MockDataSource)
+	b, err := NewBlnk(ds)
+	require.NoError(t, err)
+
+	return &monitorHarness{blnk: b, ds: ds}
+}
+
+// recordingCache notes which keys were invalidated.
+type recordingCache struct {
+	mu      sync.Mutex
+	deleted []string
+}
+
+func (c *recordingCache) Set(_ context.Context, _ string, _ interface{}, _ time.Duration) error {
+	return nil
+}
+func (c *recordingCache) Get(_ context.Context, _ string, _ interface{}) error { return nil }
+func (c *recordingCache) Delete(_ context.Context, key string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.deleted = append(c.deleted, key)
+	return nil
+}
+
+// The monitor cache is keyed by balance. An update that moves a monitor to a
+// different balance has to invalidate both, or the monitor stays in the old
+// balance's cached list and keeps being evaluated against a balance it no
+// longer watches.
+func TestUpdateMonitor_InvalidatesBothBalancesWhenMoved(t *testing.T) {
+	h := newMonitorHarness(t)
+	recorder := &recordingCache{}
+	h.blnk.cache = recorder
+
+	stored := &model.BalanceMonitor{
+		MonitorID: "mon_move",
+		BalanceID: "bln_old",
+		Condition: model.AlertCondition{Field: "balance", Operator: "<", PreciseValue: big.NewInt(100)},
+	}
+	h.ds.On("GetMonitorByID", "mon_move").Return(stored, nil).Once()
+	h.ds.On("UpdateMonitor", mock.Anything).Return(nil).Once()
+
+	moved := &model.BalanceMonitor{
+		MonitorID: "mon_move",
+		BalanceID: "bln_new",
+		Condition: model.AlertCondition{Field: "balance", Operator: "<", PreciseValue: big.NewInt(100)},
+	}
+	require.NoError(t, h.blnk.UpdateMonitor(context.Background(), moved))
+
+	assert.ElementsMatch(t, []string{"monitors:bln_new", "monitors:bln_old"}, recorder.deleted)
+	h.ds.AssertExpectations(t)
+}
+
+func TestUpdateMonitor_InvalidatesOnceWhenTheBalanceIsUnchanged(t *testing.T) {
+	h := newMonitorHarness(t)
+	recorder := &recordingCache{}
+	h.blnk.cache = recorder
+
+	stored := &model.BalanceMonitor{MonitorID: "mon_same", BalanceID: "bln_same"}
+	h.ds.On("GetMonitorByID", "mon_same").Return(stored, nil).Once()
+	h.ds.On("UpdateMonitor", mock.Anything).Return(nil).Once()
+
+	require.NoError(t, h.blnk.UpdateMonitor(context.Background(), &model.BalanceMonitor{
+		MonitorID: "mon_same", BalanceID: "bln_same",
+	}))
+
+	assert.Equal(t, []string{"monitors:bln_same"}, recorder.deleted)
+}

--- a/balance_monitor_trigger_test.go
+++ b/balance_monitor_trigger_test.go
@@ -1,0 +1,273 @@
+/*
+Copyright 2024 Blnk Finance Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package blnk
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/hibiken/asynq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blnkfinance/blnk/config"
+	"github.com/blnkfinance/blnk/database/mocks"
+	"github.com/blnkfinance/blnk/internal/cache"
+	"github.com/blnkfinance/blnk/model"
+)
+
+// noopCache stands in for the Redis-backed monitor cache. Every Get is a miss,
+// so each evaluation goes to the datasource and the test controls exactly what
+// the monitor list contains.
+type noopCache struct{}
+
+func (noopCache) Set(_ context.Context, _ string, _ interface{}, _ time.Duration) error { return nil }
+func (noopCache) Get(_ context.Context, _ string, _ interface{}) error                  { return nil }
+func (noopCache) Delete(_ context.Context, _ string) error                              { return nil }
+
+// monitorHarness is a Blnk wired to a mock datasource and a real asynq client,
+// so an enqueued balance.monitor webhook is observable through the queue rather
+// than inferred.
+type monitorHarness struct {
+	blnk      *Blnk
+	ds        *mocks.MockDataSource
+	inspector *asynq.Inspector
+	queue     string
+}
+
+func newMonitorHarness(t *testing.T) *monitorHarness {
+	t.Helper()
+
+	queue := fmt.Sprintf("edge_test_webhook_%d", time.Now().UnixNano())
+	// Stored directly rather than through MockConfig, which runs the full
+	// validation this partial test configuration cannot satisfy.
+	config.ConfigStore.Store(&config.Configuration{
+		Redis:              config.RedisConfig{Dns: "localhost:6379"},
+		Queue:              config.QueueConfig{WebhookQueue: queue, TransactionQueue: queue + "_txn", IndexQueue: queue + "_idx", NumberOfQueues: 1},
+		Server:             config.ServerConfig{SecretKey: "some-secret"},
+		TokenizationSecret: "12345678901234567890123456789012",
+		// A configured URL is what makes SendWebhook enqueue rather than
+		// return early; nothing ever delivers to it in these tests.
+		Notification: config.Notification{Webhook: config.WebhookConfig{Url: "http://127.0.0.1:1/webhook"}},
+	})
+
+	ds := new(mocks.MockDataSource)
+	b, err := NewBlnk(ds)
+	require.NoError(t, err)
+	b.cache = noopCache{}
+
+	inspector := asynq.NewInspector(asynq.RedisClientOpt{Addr: "localhost:6379"})
+	t.Cleanup(func() { _ = inspector.Close() })
+
+	return &monitorHarness{blnk: b, ds: ds, inspector: inspector, queue: queue}
+}
+
+// enqueued reports how many webhook tasks are waiting on this harness's queue.
+func (h *monitorHarness) enqueued(t *testing.T) int {
+	t.Helper()
+	info, err := h.inspector.GetQueueInfo(h.queue)
+	if err != nil {
+		// asynq reports a queue it has never seen as not found, which is the
+		// same thing as empty for our purposes.
+		return 0
+	}
+	return info.Pending + info.Active + info.Scheduled + info.Retry
+}
+
+func monitorFor(trigger string) model.BalanceMonitor {
+	return model.BalanceMonitor{
+		MonitorID: "mon_edge_test",
+		BalanceID: "bln_edge_test",
+		Trigger:   trigger,
+		Condition: model.AlertCondition{
+			Field:        "balance",
+			Operator:     "<",
+			PreciseValue: big.NewInt(100),
+		},
+	}
+}
+
+func balanceAt(value int64, version int64) *model.Balance {
+	b := &model.Balance{BalanceID: "bln_edge_test", Balance: big.NewInt(value), Version: version}
+	b.InitializeBalanceFields()
+	return b
+}
+
+func TestCheckBalanceMonitors_EdgeFiresOnceOnCrossing(t *testing.T) {
+	h := newMonitorHarness(t)
+	h.ds.On("GetBalanceMonitors", "bln_edge_test").Return([]model.BalanceMonitor{monitorFor(model.TriggerEdge)}, nil)
+
+	// The crossing: this evaluation owns the false -> true transition.
+	h.ds.On("TransitionMonitorState", mock.Anything, "mon_edge_test", "bln_edge_test", true, int64(2)).Return(true, nil).Once()
+	// Still below the threshold, so the state does not move and nothing is owned.
+	h.ds.On("TransitionMonitorState", mock.Anything, "mon_edge_test", "bln_edge_test", true, int64(3)).Return(false, nil).Once()
+	h.ds.On("TransitionMonitorState", mock.Anything, "mon_edge_test", "bln_edge_test", true, int64(4)).Return(false, nil).Once()
+
+	before := h.enqueued(t)
+	h.blnk.checkBalanceMonitors(context.Background(), balanceAt(90, 2))
+	h.blnk.checkBalanceMonitors(context.Background(), balanceAt(70, 3))
+	h.blnk.checkBalanceMonitors(context.Background(), balanceAt(55, 4))
+
+	assert.Equal(t, 1, h.enqueued(t)-before, "three transactions below the threshold must produce exactly one webhook")
+	h.ds.AssertExpectations(t)
+}
+
+func TestCheckBalanceMonitors_EdgeRearmsAndFiresAgain(t *testing.T) {
+	h := newMonitorHarness(t)
+	h.ds.On("GetBalanceMonitors", "bln_edge_test").Return([]model.BalanceMonitor{monitorFor(model.TriggerEdge)}, nil)
+
+	h.ds.On("TransitionMonitorState", mock.Anything, "mon_edge_test", "bln_edge_test", true, int64(2)).Return(true, nil).Once()
+	// Recovered: the monitor re-arms. Owning a true -> false transition must not
+	// send anything.
+	h.ds.On("TransitionMonitorState", mock.Anything, "mon_edge_test", "bln_edge_test", false, int64(3)).Return(true, nil).Once()
+	h.ds.On("TransitionMonitorState", mock.Anything, "mon_edge_test", "bln_edge_test", true, int64(4)).Return(true, nil).Once()
+
+	before := h.enqueued(t)
+	h.blnk.checkBalanceMonitors(context.Background(), balanceAt(90, 2))
+	h.blnk.checkBalanceMonitors(context.Background(), balanceAt(120, 3))
+	h.blnk.checkBalanceMonitors(context.Background(), balanceAt(85, 4))
+
+	assert.Equal(t, 2, h.enqueued(t)-before, "a monitor that recovers and crosses again must alert on the second crossing")
+	h.ds.AssertExpectations(t)
+}
+
+func TestCheckBalanceMonitors_EdgeStaleEvaluationDoesNotFire(t *testing.T) {
+	h := newMonitorHarness(t)
+	h.ds.On("GetBalanceMonitors", "bln_edge_test").Return([]model.BalanceMonitor{monitorFor(model.TriggerEdge)}, nil)
+
+	// An evaluation carrying an older balance version loses the version fence
+	// and is discarded, however true its condition looks.
+	h.ds.On("TransitionMonitorState", mock.Anything, "mon_edge_test", "bln_edge_test", true, int64(2)).Return(false, nil).Once()
+
+	before := h.enqueued(t)
+	h.blnk.checkBalanceMonitors(context.Background(), balanceAt(90, 2))
+
+	assert.Equal(t, 0, h.enqueued(t)-before)
+	h.ds.AssertExpectations(t)
+}
+
+func TestCheckBalanceMonitors_LevelFiresEveryTime(t *testing.T) {
+	h := newMonitorHarness(t)
+	h.ds.On("GetBalanceMonitors", "bln_edge_test").Return([]model.BalanceMonitor{monitorFor(model.TriggerLevel)}, nil)
+
+	before := h.enqueued(t)
+	h.blnk.checkBalanceMonitors(context.Background(), balanceAt(90, 2))
+	h.blnk.checkBalanceMonitors(context.Background(), balanceAt(70, 3))
+	h.blnk.checkBalanceMonitors(context.Background(), balanceAt(150, 4))
+
+	assert.Equal(t, 2, h.enqueued(t)-before, "level triggering alerts on every update while the condition holds")
+	h.ds.AssertNotCalled(t, "TransitionMonitorState", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestCheckBalanceMonitors_UnsetTriggerIsEdge(t *testing.T) {
+	h := newMonitorHarness(t)
+	// A row or cache entry written before the column existed decodes with an
+	// empty trigger and must behave as edge, not fall back to level.
+	h.ds.On("GetBalanceMonitors", "bln_edge_test").Return([]model.BalanceMonitor{monitorFor("")}, nil)
+	h.ds.On("TransitionMonitorState", mock.Anything, "mon_edge_test", "bln_edge_test", true, int64(2)).Return(true, nil).Once()
+	h.ds.On("TransitionMonitorState", mock.Anything, "mon_edge_test", "bln_edge_test", true, int64(3)).Return(false, nil).Once()
+
+	before := h.enqueued(t)
+	h.blnk.checkBalanceMonitors(context.Background(), balanceAt(90, 2))
+	h.blnk.checkBalanceMonitors(context.Background(), balanceAt(80, 3))
+
+	assert.Equal(t, 1, h.enqueued(t)-before)
+	h.ds.AssertExpectations(t)
+}
+
+func TestCheckBalanceMonitors_EdgeReleasesWhenTheWebhookCannotBeQueued(t *testing.T) {
+	h := newMonitorHarness(t)
+	h.ds.On("GetBalanceMonitors", "bln_edge_test").Return([]model.BalanceMonitor{monitorFor(model.TriggerEdge)}, nil)
+	h.ds.On("TransitionMonitorState", mock.Anything, "mon_edge_test", "bln_edge_test", true, int64(2)).Return(true, nil).Once()
+	h.ds.On("ReleaseMonitorState", mock.Anything, "mon_edge_test", "bln_edge_test", int64(2)).Return(nil).Once()
+
+	// An edge fires once, so a transition this process owned but could not hand
+	// off has to go back, or the crossing is lost for good.
+	require.NoError(t, h.blnk.asynqClient.Close())
+
+	h.blnk.checkBalanceMonitors(context.Background(), balanceAt(90, 2))
+
+	h.ds.AssertExpectations(t)
+}
+
+func TestCheckBalanceMonitors_EdgeTransitionErrorDoesNotFire(t *testing.T) {
+	h := newMonitorHarness(t)
+	h.ds.On("GetBalanceMonitors", "bln_edge_test").Return([]model.BalanceMonitor{monitorFor(model.TriggerEdge)}, nil)
+	h.ds.On("TransitionMonitorState", mock.Anything, "mon_edge_test", "bln_edge_test", true, int64(2)).Return(false, errors.New("boom")).Once()
+
+	before := h.enqueued(t)
+	h.blnk.checkBalanceMonitors(context.Background(), balanceAt(90, 2))
+
+	assert.Equal(t, 0, h.enqueued(t)-before, "a monitor whose state could not be written must not alert on an unproven crossing")
+	h.ds.AssertExpectations(t)
+}
+
+// preUpgradeMonitor is the shape a BalanceMonitor was cached in before the
+// trigger existed. Cache entries outlive a deploy, so the decode has to be
+// exercised, not assumed.
+type preUpgradeMonitor struct {
+	MonitorID   string               `json:"monitor_id"`
+	BalanceID   string               `json:"balance_id"`
+	Description string               `json:"description,omitempty"`
+	CallBackURL string               `json:"-"`
+	CreatedAt   time.Time            `json:"created_at"`
+	Condition   model.AlertCondition `json:"condition"`
+}
+
+func TestMonitorCache_PreUpgradeEntryDecodesAsEdge(t *testing.T) {
+	h := newMonitorHarness(t)
+	redisCache := cache.NewCacheWithClient(h.blnk.redis)
+	ctx := context.Background()
+	key := fmt.Sprintf("monitors:cache_decode_%d", time.Now().UnixNano())
+
+	require.NoError(t, redisCache.Set(ctx, key, []preUpgradeMonitor{{
+		MonitorID: "mon_old",
+		BalanceID: "bln_old",
+		Condition: model.AlertCondition{Field: "balance", Operator: "<", PreciseValue: big.NewInt(100)},
+	}}, time.Minute))
+
+	var decoded []model.BalanceMonitor
+	require.NoError(t, redisCache.Get(ctx, key, &decoded))
+	require.Len(t, decoded, 1)
+
+	assert.Empty(t, decoded[0].Trigger, "an entry written before the field existed has no trigger")
+	assert.Equal(t, model.TriggerEdge, decoded[0].TriggerMode(), "and must still be treated as edge")
+	assert.Equal(t, "mon_old", decoded[0].MonitorID)
+}
+
+func TestMonitorCache_RoundTripsTheTrigger(t *testing.T) {
+	h := newMonitorHarness(t)
+	redisCache := cache.NewCacheWithClient(h.blnk.redis)
+	ctx := context.Background()
+	key := fmt.Sprintf("monitors:cache_roundtrip_%d", time.Now().UnixNano())
+
+	require.NoError(t, redisCache.Set(ctx, key, []model.BalanceMonitor{
+		monitorFor(model.TriggerLevel),
+		monitorFor(model.TriggerEdge),
+	}, time.Minute))
+
+	var decoded []model.BalanceMonitor
+	require.NoError(t, redisCache.Get(ctx, key, &decoded))
+	require.Len(t, decoded, 2)
+	assert.Equal(t, model.TriggerLevel, decoded[0].TriggerMode())
+	assert.Equal(t, model.TriggerEdge, decoded[1].TriggerMode())
+}

--- a/balance_test.go
+++ b/balance_test.go
@@ -345,7 +345,7 @@ func TestCreateMonitor(t *testing.T) {
 	}
 	monitor := model.BalanceMonitor{BalanceID: "test-balance", Description: "Test Monitor", CallBackURL: gofakeit.URL(), Condition: model.AlertCondition{Field: "field", Operator: "operator", Value: 1000, Precision: 100, PreciseValue: big.NewInt(100000)}}
 
-	mock.ExpectExec("INSERT INTO blnk.balance_monitors").WithArgs(sqlmock.AnyArg(), monitor.BalanceID, monitor.Condition.Field, monitor.Condition.Operator, monitor.Condition.Value, monitor.Condition.Precision, monitor.Condition.PreciseValue.String(), monitor.Description, monitor.CallBackURL, sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("INSERT INTO blnk.balance_monitors").WithArgs(sqlmock.AnyArg(), monitor.BalanceID, monitor.Condition.Field, monitor.Condition.Operator, monitor.Condition.Value, monitor.Condition.Precision, monitor.Condition.PreciseValue.String(), monitor.Description, monitor.CallBackURL, sqlmock.AnyArg(), model.TriggerEdge).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	result, err := d.CreateMonitor(context.Background(), monitor)
 
@@ -369,8 +369,8 @@ func TestGetMonitorByID(t *testing.T) {
 	}
 	monitorID := "test-monitor"
 
-	rows := sqlmock.NewRows([]string{"monitor_id", "balance_id", "field", "operator", "value", "precision", "precise_value", "description", "call_back_url", "created_at"}).
-		AddRow(monitorID, gofakeit.UUID(), "field", "operator", 1000, 100, 100000, "Test Monitor", gofakeit.URL(), time.Now())
+	rows := sqlmock.NewRows([]string{"monitor_id", "balance_id", "field", "operator", "value", "precision", "precise_value", "description", "call_back_url", "created_at", "trigger_type", "condition_state"}).
+		AddRow(monitorID, gofakeit.UUID(), "field", "operator", 1000, 100, 100000, "Test Monitor", gofakeit.URL(), time.Now(), model.TriggerEdge, false)
 
 	mock.ExpectQuery("SELECT .* FROM blnk.balance_monitors WHERE monitor_id =").WithArgs(monitorID).WillReturnRows(rows)
 
@@ -394,8 +394,8 @@ func TestGetAllMonitors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating Blnk instance: %s", err)
 	}
-	rows := sqlmock.NewRows([]string{"monitor_id", "balance_id", "field", "operator", "value", "description", "call_back_url", "created_at", "precision", "precise_value"}).
-		AddRow("test-monitor", gofakeit.UUID(), "field", "operator", 100, "Test Monitor", gofakeit.URL(), time.Now(), 100, 100000)
+	rows := sqlmock.NewRows([]string{"monitor_id", "balance_id", "field", "operator", "value", "description", "call_back_url", "created_at", "trigger_type", "condition_state", "precision", "precise_value"}).
+		AddRow("test-monitor", gofakeit.UUID(), "field", "operator", 100, "Test Monitor", gofakeit.URL(), time.Now(), model.TriggerEdge, false, 100, 100000)
 
 	mock.ExpectQuery("SELECT .* FROM blnk.balance_monitors").WillReturnRows(rows)
 
@@ -420,8 +420,8 @@ func TestGetBalanceMonitors(t *testing.T) {
 		t.Fatalf("Error creating Blnk instance: %s", err)
 	}
 	balanceID := gofakeit.UUID()
-	rows := sqlmock.NewRows([]string{"monitor_id", "balance_id", "field", "operator", "value", "description", "call_back_url", "created_at", "precision", "precise_value"}).
-		AddRow("test-monitor", balanceID, "field", "operator", 100, "Test Monitor", gofakeit.URL(), time.Now(), 100, 100000)
+	rows := sqlmock.NewRows([]string{"monitor_id", "balance_id", "field", "operator", "value", "description", "call_back_url", "created_at", "precision", "precise_value", "trigger_type", "condition_state"}).
+		AddRow("test-monitor", balanceID, "field", "operator", 100, "Test Monitor", gofakeit.URL(), time.Now(), 100, 100000, model.TriggerEdge, false)
 
 	mock.ExpectQuery("SELECT .* FROM blnk.balance_monitors WHERE balance_id =").WithArgs(balanceID).WillReturnRows(rows)
 
@@ -447,11 +447,11 @@ func TestUpdateMonitor(t *testing.T) {
 	}
 	monitor := &model.BalanceMonitor{MonitorID: "test-monitor", BalanceID: "test-balance", Description: "Updated Monitor"}
 
-	previous := sqlmock.NewRows([]string{"monitor_id", "balance_id", "field", "operator", "value", "precision", "precise_value", "description", "call_back_url", "created_at"}).
-		AddRow(monitor.MonitorID, monitor.BalanceID, "balance", "<", 100, 100, 10000, "Test Monitor", gofakeit.URL(), time.Now())
+	previous := sqlmock.NewRows([]string{"monitor_id", "balance_id", "field", "operator", "value", "precision", "precise_value", "description", "call_back_url", "created_at", "trigger_type", "condition_state"}).
+		AddRow(monitor.MonitorID, monitor.BalanceID, "balance", "<", 100, 100, 10000, "Test Monitor", gofakeit.URL(), time.Now(), model.TriggerEdge, false)
 	mock.ExpectQuery("SELECT .* FROM blnk.balance_monitors WHERE monitor_id =").WithArgs(monitor.MonitorID).WillReturnRows(previous)
 
-	mock.ExpectExec("UPDATE blnk.balance_monitors").WithArgs(monitor.MonitorID, monitor.BalanceID, monitor.Condition.Field, monitor.Condition.Operator, monitor.Condition.Value, monitor.Description).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("UPDATE blnk.balance_monitors").WithArgs(monitor.MonitorID, monitor.BalanceID, monitor.Condition.Field, monitor.Condition.Operator, monitor.Condition.Value, monitor.Description, model.TriggerEdge).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	err = d.UpdateMonitor(context.Background(), monitor)
 
@@ -475,8 +475,8 @@ func TestDeleteMonitor(t *testing.T) {
 	monitorID := "test-monitor"
 	balanceID := "test-balance"
 
-	rows := sqlmock.NewRows([]string{"monitor_id", "balance_id", "field", "operator", "value", "precision", "precise_value", "description", "call_back_url", "created_at"}).
-		AddRow(monitorID, balanceID, "balance", ">", 100.0, 100.0, int64(10000), "test", "http://test.com", time.Now())
+	rows := sqlmock.NewRows([]string{"monitor_id", "balance_id", "field", "operator", "value", "precision", "precise_value", "description", "call_back_url", "created_at", "trigger_type", "condition_state"}).
+		AddRow(monitorID, balanceID, "balance", ">", 100.0, 100.0, int64(10000), "test", "http://test.com", time.Now(), model.TriggerEdge, false)
 	mock.ExpectQuery("SELECT .* FROM blnk.balance_monitors WHERE monitor_id =").
 		WithArgs(monitorID).WillReturnRows(rows)
 

--- a/balance_test.go
+++ b/balance_test.go
@@ -394,8 +394,8 @@ func TestGetAllMonitors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating Blnk instance: %s", err)
 	}
-	rows := sqlmock.NewRows([]string{"monitor_id", "balance_id", "field", "operator", "value", "description", "call_back_url", "created_at"}).
-		AddRow("test-monitor", gofakeit.UUID(), "field", "operator", 100, "Test Monitor", gofakeit.URL(), time.Now())
+	rows := sqlmock.NewRows([]string{"monitor_id", "balance_id", "field", "operator", "value", "description", "call_back_url", "created_at", "precision", "precise_value"}).
+		AddRow("test-monitor", gofakeit.UUID(), "field", "operator", 100, "Test Monitor", gofakeit.URL(), time.Now(), 100, 100000)
 
 	mock.ExpectQuery("SELECT .* FROM blnk.balance_monitors").WillReturnRows(rows)
 
@@ -447,7 +447,11 @@ func TestUpdateMonitor(t *testing.T) {
 	}
 	monitor := &model.BalanceMonitor{MonitorID: "test-monitor", BalanceID: "test-balance", Description: "Updated Monitor"}
 
-	mock.ExpectExec("UPDATE blnk.balance_monitors").WithArgs(monitor.MonitorID, monitor.BalanceID, monitor.Condition.Field, monitor.Condition.Operator, monitor.Condition.Value, monitor.Description, monitor.CallBackURL).WillReturnResult(sqlmock.NewResult(1, 1))
+	previous := sqlmock.NewRows([]string{"monitor_id", "balance_id", "field", "operator", "value", "precision", "precise_value", "description", "call_back_url", "created_at"}).
+		AddRow(monitor.MonitorID, monitor.BalanceID, "balance", "<", 100, 100, 10000, "Test Monitor", gofakeit.URL(), time.Now())
+	mock.ExpectQuery("SELECT .* FROM blnk.balance_monitors WHERE monitor_id =").WithArgs(monitor.MonitorID).WillReturnRows(previous)
+
+	mock.ExpectExec("UPDATE blnk.balance_monitors").WithArgs(monitor.MonitorID, monitor.BalanceID, monitor.Condition.Field, monitor.Condition.Operator, monitor.Condition.Value, monitor.Description).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	err = d.UpdateMonitor(context.Background(), monitor)
 
@@ -473,7 +477,7 @@ func TestDeleteMonitor(t *testing.T) {
 
 	rows := sqlmock.NewRows([]string{"monitor_id", "balance_id", "field", "operator", "value", "precision", "precise_value", "description", "call_back_url", "created_at"}).
 		AddRow(monitorID, balanceID, "balance", ">", 100.0, 100.0, int64(10000), "test", "http://test.com", time.Now())
-	mock.ExpectQuery("SELECT monitor_id, balance_id, field, operator, value, precision, precise_value, description, call_back_url, created_at FROM blnk.balance_monitors WHERE monitor_id =").
+	mock.ExpectQuery("SELECT .* FROM blnk.balance_monitors WHERE monitor_id =").
 		WithArgs(monitorID).WillReturnRows(rows)
 
 	mock.ExpectExec("DELETE FROM blnk.balance_monitors WHERE monitor_id =").WithArgs(monitorID).WillReturnResult(sqlmock.NewResult(1, 1))

--- a/database/balance.go
+++ b/database/balance.go
@@ -1125,11 +1125,17 @@ func (d Datasource) CreateMonitor(monitor model.BalanceMonitor) (model.BalanceMo
 		monitor.Condition.PreciseValue = big.NewInt(0)
 	}
 
+	trigger, err := model.NormalizeTrigger(monitor.Trigger)
+	if err != nil {
+		return model.BalanceMonitor{}, apierror.NewAPIError(apierror.ErrBadRequest, err.Error(), err)
+	}
+	monitor.Trigger = trigger
+
 	// Insert the monitor data into the balance_monitors table
-	_, err := d.Conn.ExecContext(context.Background(), `
-		INSERT INTO blnk.balance_monitors (monitor_id, balance_id, field, operator, value, precision, precise_value, description, call_back_url, created_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-	`, monitor.MonitorID, monitor.BalanceID, monitor.Condition.Field, monitor.Condition.Operator, monitor.Condition.Value, monitor.Condition.Precision, monitor.Condition.PreciseValue.String(), monitor.Description, monitor.CallBackURL, monitor.CreatedAt)
+	_, err = d.Conn.ExecContext(context.Background(), `
+		INSERT INTO blnk.balance_monitors (monitor_id, balance_id, field, operator, value, precision, precise_value, description, call_back_url, created_at, trigger_type)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+	`, monitor.MonitorID, monitor.BalanceID, monitor.Condition.Field, monitor.Condition.Operator, monitor.Condition.Value, monitor.Condition.Precision, monitor.Condition.PreciseValue.String(), monitor.Description, monitor.CallBackURL, monitor.CreatedAt, monitor.Trigger)
 	// Handle database errors
 	if err != nil {
 		pqErr, ok := err.(*pq.Error)
@@ -1168,7 +1174,7 @@ func (d Datasource) GetMonitorByID(id string) (*model.BalanceMonitor, error) {
 
 	// Query the database to get the monitor details by MonitorID
 	row := d.Conn.QueryRowContext(context.Background(), `
-		SELECT monitor_id, balance_id, field, operator, value, COALESCE(precision, 0), COALESCE(precise_value, 0), description, call_back_url, created_at
+		SELECT monitor_id, balance_id, field, operator, value, COALESCE(precision, 0), COALESCE(precise_value, 0), description, call_back_url, created_at, trigger_type, condition_state
 		FROM blnk.balance_monitors WHERE monitor_id = $1
 	`, id)
 
@@ -1178,7 +1184,7 @@ func (d Datasource) GetMonitorByID(id string) (*model.BalanceMonitor, error) {
 	condition := &model.AlertCondition{}
 
 	// Scan the result into the monitor and condition fields
-	err := row.Scan(&monitor.MonitorID, &monitor.BalanceID, &condition.Field, &condition.Operator, &condition.Value, &condition.Precision, &preciseValue, &monitor.Description, &monitor.CallBackURL, &monitor.CreatedAt)
+	err := row.Scan(&monitor.MonitorID, &monitor.BalanceID, &condition.Field, &condition.Operator, &condition.Value, &condition.Precision, &preciseValue, &monitor.Description, &monitor.CallBackURL, &monitor.CreatedAt, &monitor.Trigger, &monitor.ConditionState)
 	if err != nil {
 		// Handle the case where the monitor with the specified ID is not found
 		if err == sql.ErrNoRows {
@@ -1205,7 +1211,7 @@ func (d Datasource) GetMonitorByID(id string) (*model.BalanceMonitor, error) {
 func (d Datasource) GetAllMonitors() ([]model.BalanceMonitor, error) {
 	// Query the database for all balance monitors
 	rows, err := d.Conn.QueryContext(context.Background(), `
-		SELECT monitor_id, balance_id, field, operator, value, description, call_back_url, created_at, COALESCE(precision, 0), COALESCE(precise_value, 0)
+		SELECT monitor_id, balance_id, field, operator, value, description, call_back_url, created_at, trigger_type, condition_state, COALESCE(precision, 0), COALESCE(precise_value, 0)
 		FROM blnk.balance_monitors
 	`)
 	if err != nil {
@@ -1224,7 +1230,7 @@ func (d Datasource) GetAllMonitors() ([]model.BalanceMonitor, error) {
 		condition := model.AlertCondition{} // Create an empty AlertCondition object (part of the monitor)
 
 		// Scan the row into the monitor and condition fields
-		err = rows.Scan(&monitor.MonitorID, &monitor.BalanceID, &condition.Field, &condition.Operator, &condition.Value, &monitor.Description, &monitor.CallBackURL, &monitor.CreatedAt, &condition.Precision, &preciseValue)
+		err = rows.Scan(&monitor.MonitorID, &monitor.BalanceID, &condition.Field, &condition.Operator, &condition.Value, &monitor.Description, &monitor.CallBackURL, &monitor.CreatedAt, &monitor.Trigger, &monitor.ConditionState, &condition.Precision, &preciseValue)
 		if err != nil {
 			// Return an error if scanning fails
 			return nil, apierror.NewAPIError(apierror.ErrInternalServer, "Failed to scan monitor data", err)
@@ -1260,7 +1266,7 @@ func (d Datasource) GetAllMonitors() ([]model.BalanceMonitor, error) {
 func (d Datasource) GetBalanceMonitors(balanceID string) ([]model.BalanceMonitor, error) {
 	// Query the database for monitors associated with the given balance ID
 	rows, err := d.Conn.QueryContext(context.Background(), `
-		SELECT monitor_id, balance_id, field, operator, value, description, call_back_url, created_at, COALESCE(precision, 0), COALESCE(precise_value, 0)
+		SELECT monitor_id, balance_id, field, operator, value, description, call_back_url, created_at, COALESCE(precision, 0), COALESCE(precise_value, 0), trigger_type, condition_state
 		FROM blnk.balance_monitors WHERE balance_id = $1
 	`, balanceID)
 	if err != nil {
@@ -1279,7 +1285,7 @@ func (d Datasource) GetBalanceMonitors(balanceID string) ([]model.BalanceMonitor
 		condition := model.AlertCondition{} // Create an empty AlertCondition object (part of the monitor)
 
 		// Scan the row into the monitor and condition fields
-		err = rows.Scan(&monitor.MonitorID, &monitor.BalanceID, &condition.Field, &condition.Operator, &condition.Value, &monitor.Description, &monitor.CallBackURL, &monitor.CreatedAt, &condition.Precision, &preciseValue)
+		err = rows.Scan(&monitor.MonitorID, &monitor.BalanceID, &condition.Field, &condition.Operator, &condition.Value, &monitor.Description, &monitor.CallBackURL, &monitor.CreatedAt, &condition.Precision, &preciseValue, &monitor.Trigger, &monitor.ConditionState)
 		if err != nil {
 			// Return an error if scanning fails
 			return nil, apierror.NewAPIError(apierror.ErrInternalServer, "Failed to scan monitor data", err)
@@ -1315,12 +1321,21 @@ func (d Datasource) GetBalanceMonitors(balanceID string) ([]model.BalanceMonitor
 // Returns:
 // - error: If the update fails, an appropriate `APIError` is returned.
 func (d Datasource) UpdateMonitor(monitor *model.BalanceMonitor) error {
-	// Execute the SQL update statement, replacing the placeholder values with the monitor's data
+	trigger, err := model.NormalizeTrigger(monitor.Trigger)
+	if err != nil {
+		return apierror.NewAPIError(apierror.ErrBadRequest, err.Error(), err)
+	}
+	monitor.Trigger = trigger
+
+	// The update replaces the condition, so any state carried against the old
+	// one is meaningless: re-arm, or the first crossing of the new threshold is
+	// swallowed as a repeat of a threshold that no longer exists.
 	result, err := d.Conn.ExecContext(context.Background(), `
 		UPDATE blnk.balance_monitors
-		SET balance_id = $2, field = $3, operator = $4, value = $5, description = $6
+		SET balance_id = $2, field = $3, operator = $4, value = $5, description = $6,
+		    trigger_type = $7, condition_state = FALSE, state_version = 0, state_changed_at = NULL
 		WHERE monitor_id = $1
-	`, monitor.MonitorID, monitor.BalanceID, monitor.Condition.Field, monitor.Condition.Operator, monitor.Condition.Value, monitor.Description)
+	`, monitor.MonitorID, monitor.BalanceID, monitor.Condition.Field, monitor.Condition.Operator, monitor.Condition.Value, monitor.Description, monitor.Trigger)
 	// If an error occurred during execution, return an internal server error
 	if err != nil {
 		return apierror.NewAPIError(apierror.ErrInternalServer, "Failed to update monitor", err)
@@ -1337,6 +1352,8 @@ func (d Datasource) UpdateMonitor(monitor *model.BalanceMonitor) error {
 	if rowsAffected == 0 {
 		return apierror.NewAPIError(apierror.ErrBalMonitorNotFound, fmt.Sprintf("Monitor with ID '%s' not found", monitor.MonitorID), nil)
 	}
+
+	monitor.ConditionState = false
 
 	// Return nil if the update was successful
 	return nil
@@ -1373,6 +1390,72 @@ func (d Datasource) DeleteMonitor(id string) error {
 	}
 
 	// Return nil if the deletion was successful
+	return nil
+}
+
+// TransitionMonitorState records the truth value an evaluation observed and
+// reports whether that evaluation is the one that moved the monitor, which is
+// what entitles an edge-triggered caller to send.
+//
+// Monitor checks run in detached goroutines after the balance lock is released,
+// so evaluations of the same monitor race and arrive out of order. Both guards
+// are load-bearing:
+//
+//   - condition_state IS DISTINCT FROM $2 makes the read and the write one
+//     statement, so concurrent evaluations serialise on the row and only one of
+//     them can observe the transition.
+//   - state_version < $3 discards an evaluation a later balance version has
+//     overtaken, which would otherwise alert on a balance that has since
+//     recovered and then swallow the next real crossing.
+//   - balance_id = $4 discards an evaluation for a balance this monitor no
+//     longer watches. Versions count per balance, so without it a stale
+//     evaluation left in another balance's monitor cache could pin
+//     state_version above anything the monitor's own balance will reach for
+//     thousands of transactions, silencing it.
+//
+// balanceVersion is model.Balance.Version: bumped only after a successful
+// persist, under the optimistic lock, so it is strictly increasing per balance.
+func (d Datasource) TransitionMonitorState(ctx context.Context, monitorID, balanceID string, conditionMet bool, balanceVersion int64) (bool, error) {
+	result, err := d.Conn.ExecContext(ctx, `
+		UPDATE blnk.balance_monitors
+		SET condition_state = $2, state_version = $3, state_changed_at = NOW()
+		WHERE monitor_id = $1
+		  AND balance_id = $4
+		  AND condition_state IS DISTINCT FROM $2
+		  AND state_version < $3
+	`, monitorID, conditionMet, balanceVersion, balanceID)
+	if err != nil {
+		return false, apierror.NewAPIError(apierror.ErrInternalServer, "Failed to transition monitor state", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return false, apierror.NewAPIError(apierror.ErrInternalServer, "Failed to get rows affected", err)
+	}
+
+	return rowsAffected == 1, nil
+}
+
+// ReleaseMonitorState puts a monitor back to armed after a transition this
+// process owned could not be delivered, so the next transaction gets another
+// chance at the same crossing.
+//
+// The version guard is equality, not "less than": this undoes our own write and
+// nobody else's, and correctly does nothing once a newer evaluation has moved
+// the monitor on.
+func (d Datasource) ReleaseMonitorState(ctx context.Context, monitorID, balanceID string, balanceVersion int64) error {
+	_, err := d.Conn.ExecContext(ctx, `
+		UPDATE blnk.balance_monitors
+		SET condition_state = FALSE, state_changed_at = NOW()
+		WHERE monitor_id = $1
+		  AND balance_id = $3
+		  AND state_version = $2
+		  AND condition_state = TRUE
+	`, monitorID, balanceVersion, balanceID)
+	if err != nil {
+		return apierror.NewAPIError(apierror.ErrInternalServer, "Failed to release monitor state", err)
+	}
+
 	return nil
 }
 

--- a/database/balance.go
+++ b/database/balance.go
@@ -1168,7 +1168,7 @@ func (d Datasource) GetMonitorByID(id string) (*model.BalanceMonitor, error) {
 
 	// Query the database to get the monitor details by MonitorID
 	row := d.Conn.QueryRowContext(context.Background(), `
-		SELECT monitor_id, balance_id, field, operator, value, precision, precise_value, description, call_back_url, created_at
+		SELECT monitor_id, balance_id, field, operator, value, COALESCE(precision, 0), COALESCE(precise_value, 0), description, call_back_url, created_at
 		FROM blnk.balance_monitors WHERE monitor_id = $1
 	`, id)
 
@@ -1205,7 +1205,7 @@ func (d Datasource) GetMonitorByID(id string) (*model.BalanceMonitor, error) {
 func (d Datasource) GetAllMonitors() ([]model.BalanceMonitor, error) {
 	// Query the database for all balance monitors
 	rows, err := d.Conn.QueryContext(context.Background(), `
-		SELECT monitor_id, balance_id, field, operator, value, description, call_back_url, created_at
+		SELECT monitor_id, balance_id, field, operator, value, description, call_back_url, created_at, COALESCE(precision, 0), COALESCE(precise_value, 0)
 		FROM blnk.balance_monitors
 	`)
 	if err != nil {
@@ -1219,11 +1219,12 @@ func (d Datasource) GetAllMonitors() ([]model.BalanceMonitor, error) {
 
 	// Iterate through each row in the result set
 	for rows.Next() {
+		var preciseValue int64
 		monitor := model.BalanceMonitor{}   // Create an empty BalanceMonitor object
 		condition := model.AlertCondition{} // Create an empty AlertCondition object (part of the monitor)
 
 		// Scan the row into the monitor and condition fields
-		err = rows.Scan(&monitor.MonitorID, &monitor.BalanceID, &condition.Field, &condition.Operator, &condition.Value, &monitor.Description, &monitor.CallBackURL, &monitor.CreatedAt)
+		err = rows.Scan(&monitor.MonitorID, &monitor.BalanceID, &condition.Field, &condition.Operator, &condition.Value, &monitor.Description, &monitor.CallBackURL, &monitor.CreatedAt, &condition.Precision, &preciseValue)
 		if err != nil {
 			// Return an error if scanning fails
 			return nil, apierror.NewAPIError(apierror.ErrInternalServer, "Failed to scan monitor data", err)
@@ -1231,6 +1232,7 @@ func (d Datasource) GetAllMonitors() ([]model.BalanceMonitor, error) {
 
 		// Assign the scanned AlertCondition to the monitor
 		monitor.Condition = condition
+		monitor.Condition.PreciseValue = big.NewInt(preciseValue)
 
 		// Append the monitor to the slice
 		monitors = append(monitors, monitor)
@@ -1258,7 +1260,7 @@ func (d Datasource) GetAllMonitors() ([]model.BalanceMonitor, error) {
 func (d Datasource) GetBalanceMonitors(balanceID string) ([]model.BalanceMonitor, error) {
 	// Query the database for monitors associated with the given balance ID
 	rows, err := d.Conn.QueryContext(context.Background(), `
-		SELECT monitor_id, balance_id, field, operator, value, description, call_back_url, created_at, precision, precise_value
+		SELECT monitor_id, balance_id, field, operator, value, description, call_back_url, created_at, COALESCE(precision, 0), COALESCE(precise_value, 0)
 		FROM blnk.balance_monitors WHERE balance_id = $1
 	`, balanceID)
 	if err != nil {
@@ -1302,8 +1304,10 @@ func (d Datasource) GetBalanceMonitors(balanceID string) ([]model.BalanceMonitor
 }
 
 // UpdateMonitor updates an existing balance monitor in the database.
-// It updates fields such as `balance_id`, `field`, `operator`, `value`, `description`, and `call_back_url`
-// for the monitor identified by `monitor_id`.
+//
+// call_back_url is deliberately not written: BalanceMonitor.CallBackURL is
+// tagged json:"-", so a request can never populate it, and writing it here only
+// ever cleared the URL the monitor was created with.
 //
 // Parameters:
 // - monitor: A pointer to the `BalanceMonitor` object containing the updated values.
@@ -1314,9 +1318,9 @@ func (d Datasource) UpdateMonitor(monitor *model.BalanceMonitor) error {
 	// Execute the SQL update statement, replacing the placeholder values with the monitor's data
 	result, err := d.Conn.ExecContext(context.Background(), `
 		UPDATE blnk.balance_monitors
-		SET balance_id = $2, field = $3, operator = $4, value = $5, description = $6, call_back_url = $7
+		SET balance_id = $2, field = $3, operator = $4, value = $5, description = $6
 		WHERE monitor_id = $1
-	`, monitor.MonitorID, monitor.BalanceID, monitor.Condition.Field, monitor.Condition.Operator, monitor.Condition.Value, monitor.Description, monitor.CallBackURL)
+	`, monitor.MonitorID, monitor.BalanceID, monitor.Condition.Field, monitor.Condition.Operator, monitor.Condition.Value, monitor.Description)
 	// If an error occurred during execution, return an internal server error
 	if err != nil {
 		return apierror.NewAPIError(apierror.ErrInternalServer, "Failed to update monitor", err)

--- a/database/balance_monitor_legacy_rows_test.go
+++ b/database/balance_monitor_legacy_rows_test.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2024 Blnk Finance Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package database
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blnkfinance/blnk/model"
+)
+
+func legacyTestBalance(t *testing.T, ds Datasource) model.Balance {
+	t.Helper()
+	ledger, err := ds.CreateLedger(model.Ledger{Name: gofakeit.UUID()})
+	require.NoError(t, err)
+	balance, err := ds.CreateBalance(model.Balance{LedgerID: ledger.LedgerID, Currency: "USD"})
+	require.NoError(t, err)
+	return balance
+}
+
+// precision and precise_value were added as nullable columns, so every monitor
+// created before that migration carries NULLs. Scanning them into plain Go
+// numbers failed the whole read, and because checkBalanceMonitors gives up on
+// that error, one such row silenced every monitor on its balance.
+func TestGetMonitors_ToleratesNullPrecision_RealDB(t *testing.T) {
+	ds := openRealTestDB(t)
+	balance := legacyTestBalance(t, ds)
+
+	legacyID := model.GenerateUUIDWithSuffix("mon")
+	_, err := ds.Conn.Exec(`
+		INSERT INTO blnk.balance_monitors (monitor_id, balance_id, field, operator, value, description, call_back_url, created_at)
+		VALUES ($1, $2, 'balance', '<', 100, 'written before the precision migration', '', NOW())
+	`, legacyID, balance.BalanceID)
+	require.NoError(t, err)
+
+	one, err := ds.GetMonitorByID(legacyID)
+	require.NoError(t, err, "a legacy row must still be readable")
+	assert.Equal(t, float64(0), one.Condition.Precision)
+	assert.Equal(t, big.NewInt(0), one.Condition.PreciseValue)
+
+	monitors, err := ds.GetBalanceMonitors(balance.BalanceID)
+	require.NoError(t, err, "one legacy row must not take down the balance's whole monitor list")
+	require.Len(t, monitors, 1)
+	assert.Equal(t, legacyID, monitors[0].MonitorID)
+	assert.NotNil(t, monitors[0].Condition.PreciseValue, "a nil threshold would panic the comparison")
+
+	all, err := ds.GetAllMonitors()
+	require.NoError(t, err)
+	assert.NotEmpty(t, all)
+}
+
+// GetAllMonitors omitted precision and precise_value, so the list endpoint
+// reported a different threshold from the single-monitor endpoint.
+func TestGetAllMonitors_CarriesPrecision_RealDB(t *testing.T) {
+	ds := openRealTestDB(t)
+	balance := legacyTestBalance(t, ds)
+
+	created, err := ds.CreateMonitor(model.BalanceMonitor{
+		BalanceID: balance.BalanceID,
+		Condition: model.AlertCondition{Field: "balance", Operator: "<", Value: 100, Precision: 100, PreciseValue: big.NewInt(10000)},
+	})
+	require.NoError(t, err)
+
+	one, err := ds.GetMonitorByID(created.MonitorID)
+	require.NoError(t, err)
+
+	all, err := ds.GetAllMonitors()
+	require.NoError(t, err)
+
+	var listed *model.BalanceMonitor
+	for i := range all {
+		if all[i].MonitorID == created.MonitorID {
+			listed = &all[i]
+		}
+	}
+	require.NotNil(t, listed, "the monitor must appear in the list")
+	assert.Equal(t, one.Condition.Precision, listed.Condition.Precision)
+	assert.Equal(t, one.Condition.PreciseValue, listed.Condition.PreciseValue)
+}
+
+// BalanceMonitor.CallBackURL is tagged json:"-", so an update can never carry
+// one. Writing it anyway meant every update cleared the URL the monitor was
+// created with.
+func TestUpdateMonitor_PreservesCallbackURL_RealDB(t *testing.T) {
+	ds := openRealTestDB(t)
+	balance := legacyTestBalance(t, ds)
+
+	created, err := ds.CreateMonitor(model.BalanceMonitor{
+		BalanceID:   balance.BalanceID,
+		CallBackURL: "https://example.com/hook",
+		Condition:   model.AlertCondition{Field: "balance", Operator: "<", Value: 100, Precision: 1, PreciseValue: big.NewInt(100)},
+	})
+	require.NoError(t, err)
+
+	update := model.BalanceMonitor{
+		MonitorID: created.MonitorID,
+		BalanceID: balance.BalanceID,
+		Condition: model.AlertCondition{Field: "balance", Operator: "<", Value: 200},
+	}
+	require.NoError(t, ds.UpdateMonitor(&update))
+
+	var stored string
+	require.NoError(t, ds.Conn.QueryRow(
+		`SELECT call_back_url FROM blnk.balance_monitors WHERE monitor_id = $1`, created.MonitorID).Scan(&stored))
+	assert.Equal(t, "https://example.com/hook", stored, "an update that cannot carry a callback URL must not clear it")
+}
+
+// value is the human-readable half of the threshold and is a float64 in Go, but
+// the column was a BIGINT, so a fractional threshold failed at the database.
+func TestCreateMonitor_FractionalThreshold_RealDB(t *testing.T) {
+	ds := openRealTestDB(t)
+	balance := legacyTestBalance(t, ds)
+
+	created, err := ds.CreateMonitor(model.BalanceMonitor{
+		BalanceID: balance.BalanceID,
+		Condition: model.AlertCondition{Field: "balance", Operator: "<", Value: 100.5, Precision: 100, PreciseValue: big.NewInt(10050)},
+	})
+	require.NoError(t, err, "a fractional threshold is a normal thing to want")
+
+	stored, err := ds.GetMonitorByID(created.MonitorID)
+	require.NoError(t, err)
+	assert.Equal(t, 100.5, stored.Condition.Value)
+	assert.Equal(t, big.NewInt(10050), stored.Condition.PreciseValue)
+}
+
+// The check constraint stores equality as '=', but compare() only knew '==',
+// which the same constraint rejects. Equality monitors were unusable.
+func TestCheckCondition_EqualityOperator_RealDB(t *testing.T) {
+	ds := openRealTestDB(t)
+	balance := legacyTestBalance(t, ds)
+
+	created, err := ds.CreateMonitor(model.BalanceMonitor{
+		BalanceID: balance.BalanceID,
+		Condition: model.AlertCondition{Field: "balance", Operator: "=", Value: 100, Precision: 1, PreciseValue: big.NewInt(100)},
+	})
+	require.NoError(t, err)
+
+	stored, err := ds.GetMonitorByID(created.MonitorID)
+	require.NoError(t, err)
+
+	exactly := &model.Balance{Balance: big.NewInt(100)}
+	exactly.InitializeBalanceFields()
+	other := &model.Balance{Balance: big.NewInt(101)}
+	other.InitializeBalanceFields()
+
+	assert.True(t, stored.CheckCondition(exactly), "an equality monitor must fire on an equal balance")
+	assert.False(t, stored.CheckCondition(other))
+}

--- a/database/balance_monitor_stale_balance_test.go
+++ b/database/balance_monitor_stale_balance_test.go
@@ -1,0 +1,43 @@
+package database
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/blnkfinance/blnk/model"
+)
+
+// A monitor's list is cached per balance, so for a few minutes after a monitor
+// is moved a node can still evaluate it against the balance it used to watch.
+// Versions count per balance, so without the balance guard that stale
+// evaluation pins state_version above anything the monitor's own balance will
+// reach for thousands of transactions, and the monitor goes silent.
+func TestTransitionMonitorState_IgnoresAnotherBalance_RealDB(t *testing.T) {
+	ds := openRealTestDB(t)
+	ctx := context.Background()
+	_, busy := seedMonitor(t, ds)  // stands in for an old, busy balance
+	_, fresh := seedMonitor(t, ds) // and a freshly created one
+
+	monitor, err := ds.CreateMonitor(model.BalanceMonitor{
+		BalanceID: busy,
+		Condition: model.AlertCondition{Field: "balance", Operator: "<", Value: 100, Precision: 1, PreciseValue: big.NewInt(100)},
+	})
+	require.NoError(t, err)
+
+	// The operator moves the monitor to the fresh balance. This re-arms it.
+	monitor.BalanceID = fresh
+	require.NoError(t, ds.UpdateMonitor(&monitor))
+
+	// A node whose cached monitor list for the busy balance has not expired yet
+	// evaluates the monitor against the balance it no longer watches.
+	_, err = ds.TransitionMonitorState(ctx, monitor.MonitorID, busy, true, 5000)
+	require.NoError(t, err)
+
+	// Now a genuine crossing on the balance the monitor actually watches.
+	owned, err := ds.TransitionMonitorState(ctx, monitor.MonitorID, fresh, true, 3)
+	require.NoError(t, err)
+	require.True(t, owned, "a real crossing on the monitor's own balance must not be fenced out by an evaluation for a different balance")
+}

--- a/database/balance_monitor_state_test.go
+++ b/database/balance_monitor_state_test.go
@@ -1,0 +1,434 @@
+/*
+Copyright 2024 Blnk Finance Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package database
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"math/big"
+	"os"
+	"regexp"
+	"sync"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blnkfinance/blnk/model"
+)
+
+const transitionQuery = `
+		UPDATE blnk.balance_monitors
+		SET condition_state = $2, state_version = $3, state_changed_at = NOW()
+		WHERE monitor_id = $1
+		  AND balance_id = $4
+		  AND condition_state IS DISTINCT FROM $2
+		  AND state_version < $3
+	`
+
+const releaseQuery = `
+		UPDATE blnk.balance_monitors
+		SET condition_state = FALSE, state_changed_at = NOW()
+		WHERE monitor_id = $1
+		  AND balance_id = $3
+		  AND state_version = $2
+		  AND condition_state = TRUE
+	`
+
+func TestTransitionMonitorState_OwnsTheTransition(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectExec(regexp.QuoteMeta(transitionQuery)).
+		WithArgs("mon_123", true, int64(7), "bln_123").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	owned, err := Datasource{Conn: db}.TransitionMonitorState(context.Background(), "mon_123", "bln_123", true, 7)
+	assert.NoError(t, err)
+	assert.True(t, owned)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestTransitionMonitorState_NoRowMeansSomebodyElseOwnsIt(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectExec(regexp.QuoteMeta(transitionQuery)).
+		WithArgs("mon_123", true, int64(7), "bln_123").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	owned, err := Datasource{Conn: db}.TransitionMonitorState(context.Background(), "mon_123", "bln_123", true, 7)
+	assert.NoError(t, err)
+	assert.False(t, owned)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestTransitionMonitorState_Error(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectExec(regexp.QuoteMeta(transitionQuery)).
+		WithArgs("mon_123", false, int64(7), "bln_123").
+		WillReturnError(errors.New("connection reset"))
+
+	owned, err := Datasource{Conn: db}.TransitionMonitorState(context.Background(), "mon_123", "bln_123", false, 7)
+	assert.Error(t, err)
+	assert.False(t, owned)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestReleaseMonitorState(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectExec(regexp.QuoteMeta(releaseQuery)).
+		WithArgs("mon_123", int64(7), "bln_123").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	assert.NoError(t, Datasource{Conn: db}.ReleaseMonitorState(context.Background(), "mon_123", "bln_123", 7))
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// seedMonitor creates the ledger, balance and monitor a state test needs and
+// returns the monitor ID.
+func seedMonitor(t *testing.T, ds Datasource) (string, string) {
+	t.Helper()
+
+	ledger, err := ds.CreateLedger(model.Ledger{Name: gofakeit.UUID()})
+	require.NoError(t, err)
+
+	balance, err := ds.CreateBalance(model.Balance{LedgerID: ledger.LedgerID, Currency: "USD"})
+	require.NoError(t, err)
+
+	monitor, err := ds.CreateMonitor(model.BalanceMonitor{
+		BalanceID:   balance.BalanceID,
+		Description: "edge state test",
+		Condition: model.AlertCondition{
+			Field:        "balance",
+			Operator:     "<",
+			Value:        100,
+			Precision:    1,
+			PreciseValue: big.NewInt(100),
+		},
+	})
+	require.NoError(t, err)
+
+	return monitor.MonitorID, balance.BalanceID
+}
+
+func readMonitorState(t *testing.T, ds Datasource, monitorID string) (bool, int64) {
+	t.Helper()
+	var state bool
+	var version int64
+	err := ds.Conn.QueryRow(`SELECT condition_state, state_version FROM blnk.balance_monitors WHERE monitor_id = $1`, monitorID).
+		Scan(&state, &version)
+	require.NoError(t, err)
+	return state, version
+}
+
+// TestTransitionMonitorState_ConcurrentEvaluations_RealDB is the test the edge
+// design rests on. Post-commit monitor checks run in detached goroutines, so
+// several evaluations of the same monitor can race; exactly one of them may be
+// told it owns the crossing, or the consumer gets the duplicate alerts the
+// feature exists to remove.
+func TestTransitionMonitorState_ConcurrentEvaluations_RealDB(t *testing.T) {
+	ds := openRealTestDB(t)
+	ctx := context.Background()
+	monitorID, balanceID := seedMonitor(t, ds)
+
+	const racers = 24
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	owners := 0
+	start := make(chan struct{})
+
+	for i := 1; i <= racers; i++ {
+		wg.Add(1)
+		go func(version int64) {
+			defer wg.Done()
+			<-start
+			owned, err := ds.TransitionMonitorState(ctx, monitorID, balanceID, true, version)
+			if err != nil {
+				t.Errorf("transition failed: %v", err)
+				return
+			}
+			if owned {
+				mu.Lock()
+				owners++
+				mu.Unlock()
+			}
+		}(int64(i))
+	}
+
+	close(start)
+	wg.Wait()
+
+	assert.Equal(t, 1, owners, "exactly one concurrent evaluation may own the false -> true crossing")
+
+	state, version := readMonitorState(t, ds, monitorID)
+	assert.True(t, state, "the monitor must be left triggered")
+	assert.LessOrEqual(t, version, int64(racers))
+}
+
+// TestTransitionMonitorState_VersionFence_RealDB pins that an evaluation running
+// on an older balance cannot flip the state back. Without the fence it would
+// alert on a balance that has already recovered, and then swallow the next
+// genuine crossing.
+func TestTransitionMonitorState_VersionFence_RealDB(t *testing.T) {
+	ds := openRealTestDB(t)
+	ctx := context.Background()
+	monitorID, balanceID := seedMonitor(t, ds)
+
+	owned, err := ds.TransitionMonitorState(ctx, monitorID, balanceID, true, 10)
+	require.NoError(t, err)
+	require.True(t, owned)
+
+	// A goroutine that evaluated balance version 6 finally gets scheduled.
+	owned, err = ds.TransitionMonitorState(ctx, monitorID, balanceID, false, 6)
+	require.NoError(t, err)
+	assert.False(t, owned, "a stale evaluation must not own a transition")
+
+	state, version := readMonitorState(t, ds, monitorID)
+	assert.True(t, state, "a stale evaluation must not move the state")
+	assert.Equal(t, int64(10), version)
+
+	// The genuine recovery, on a newer version, still re-arms.
+	owned, err = ds.TransitionMonitorState(ctx, monitorID, balanceID, false, 11)
+	require.NoError(t, err)
+	assert.True(t, owned)
+
+	state, version = readMonitorState(t, ds, monitorID)
+	assert.False(t, state)
+	assert.Equal(t, int64(11), version)
+}
+
+func TestReleaseMonitorState_RealDB(t *testing.T) {
+	ds := openRealTestDB(t)
+	ctx := context.Background()
+	monitorID, balanceID := seedMonitor(t, ds)
+
+	owned, err := ds.TransitionMonitorState(ctx, monitorID, balanceID, true, 4)
+	require.NoError(t, err)
+	require.True(t, owned)
+
+	// A release for a version we no longer hold must not disarm anything.
+	require.NoError(t, ds.ReleaseMonitorState(ctx, monitorID, balanceID, 3))
+	state, _ := readMonitorState(t, ds, monitorID)
+	assert.True(t, state, "a release fenced to another version must do nothing")
+
+	require.NoError(t, ds.ReleaseMonitorState(ctx, monitorID, balanceID, 4))
+	state, version := readMonitorState(t, ds, monitorID)
+	assert.False(t, state, "releasing our own transition re-arms the monitor")
+	assert.Equal(t, int64(4), version, "the version stays put so the next evaluation still fences correctly")
+}
+
+// TestUpdateMonitor_RearmsState_RealDB pins the documented lifecycle rule: the
+// condition has been replaced, so state carried against the old one is dropped.
+func TestUpdateMonitor_RearmsState_RealDB(t *testing.T) {
+	ds := openRealTestDB(t)
+	ctx := context.Background()
+	monitorID, balanceID := seedMonitor(t, ds)
+
+	owned, err := ds.TransitionMonitorState(ctx, monitorID, balanceID, true, 5)
+	require.NoError(t, err)
+	require.True(t, owned)
+
+	monitor, err := ds.GetMonitorByID(monitorID)
+	require.NoError(t, err)
+	require.True(t, monitor.ConditionState, "GetMonitorByID must report the stored state")
+
+	monitor.Condition.Operator = ">"
+	monitor.Trigger = model.TriggerLevel
+	require.NoError(t, ds.UpdateMonitor(monitor))
+
+	state, version := readMonitorState(t, ds, monitorID)
+	assert.False(t, state, "updating a monitor re-arms it")
+	assert.Equal(t, int64(0), version)
+
+	reread, err := ds.GetMonitorByID(monitorID)
+	require.NoError(t, err)
+	assert.Equal(t, model.TriggerLevel, reread.Trigger)
+}
+
+// TestCreateMonitor_DefaultsToEdge_RealDB pins the new default at the storage
+// layer, where the migration's column default and the insert have to agree.
+func TestCreateMonitor_DefaultsToEdge_RealDB(t *testing.T) {
+	ds := openRealTestDB(t)
+	monitorID, _ := seedMonitor(t, ds)
+
+	monitor, err := ds.GetMonitorByID(monitorID)
+	require.NoError(t, err)
+	assert.Equal(t, model.TriggerEdge, monitor.Trigger)
+	assert.False(t, monitor.ConditionState)
+}
+
+// TestMonitorTriggerColumnDefault_RealDB pins the promise the migration makes to
+// monitors that already exist: they adopt edge and start armed, so one whose
+// condition already holds alerts once on its balance's next transaction.
+func TestMonitorTriggerColumnDefault_RealDB(t *testing.T) {
+	ds := openRealTestDB(t)
+	_, balanceID := seedMonitor(t, ds)
+
+	// An insert that names none of the new columns, the way a row written before
+	// this migration looks once the migration has run.
+	legacyID := model.GenerateUUIDWithSuffix("mon")
+	_, err := ds.Conn.Exec(`
+		INSERT INTO blnk.balance_monitors (monitor_id, balance_id, field, operator, value, description, call_back_url, created_at)
+		VALUES ($1, $2, 'balance', '<', 100, 'legacy row', '', NOW())
+	`, legacyID, balanceID)
+	require.NoError(t, err)
+
+	var trigger string
+	var state bool
+	var version int64
+	require.NoError(t, ds.Conn.QueryRow(
+		`SELECT trigger_type, condition_state, state_version FROM blnk.balance_monitors WHERE monitor_id = $1`, legacyID,
+	).Scan(&trigger, &state, &version))
+
+	assert.Equal(t, model.TriggerEdge, trigger)
+	assert.False(t, state, "an existing monitor starts armed")
+	assert.Equal(t, int64(0), version)
+}
+
+// TestMonitorTriggerCheckConstraint_RealDB keeps the table as the last word on
+// what is storable, whatever slips past the API.
+func TestMonitorTriggerCheckConstraint_RealDB(t *testing.T) {
+	ds := openRealTestDB(t)
+	monitorID, _ := seedMonitor(t, ds)
+
+	_, err := ds.Conn.Exec(`UPDATE blnk.balance_monitors SET trigger_type = 'sometimes' WHERE monitor_id = $1`, monitorID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "balance_monitors_trigger_type_check")
+
+	for _, valid := range []string{model.TriggerEdge, model.TriggerLevel} {
+		_, err := ds.Conn.Exec(`UPDATE blnk.balance_monitors SET trigger_type = $2 WHERE monitor_id = $1`, monitorID, valid)
+		assert.NoError(t, err, "trigger %q must be storable", valid)
+	}
+}
+
+// TestCreateMonitor_KeepsAnExplicitTrigger_RealDB guards the normalisation from
+// coercing a real choice into the default.
+func TestCreateMonitor_KeepsAnExplicitTrigger_RealDB(t *testing.T) {
+	ds := openRealTestDB(t)
+
+	ledger, err := ds.CreateLedger(model.Ledger{Name: gofakeit.UUID()})
+	require.NoError(t, err)
+	balance, err := ds.CreateBalance(model.Balance{LedgerID: ledger.LedgerID, Currency: "USD"})
+	require.NoError(t, err)
+
+	created, err := ds.CreateMonitor(model.BalanceMonitor{
+		BalanceID: balance.BalanceID,
+		Trigger:   model.TriggerLevel,
+		Condition: model.AlertCondition{Field: "balance", Operator: "<", Value: 100, Precision: 1, PreciseValue: big.NewInt(100)},
+	})
+	require.NoError(t, err)
+
+	stored, err := ds.GetMonitorByID(created.MonitorID)
+	require.NoError(t, err)
+	assert.Equal(t, model.TriggerLevel, stored.Trigger)
+}
+
+// TestGetBalanceMonitors_CarriesTheTrigger_RealDB covers the read the evaluation
+// path actually uses, which is a different query from GetMonitorByID.
+func TestGetBalanceMonitors_CarriesTheTrigger_RealDB(t *testing.T) {
+	ds := openRealTestDB(t)
+	ctx := context.Background()
+	monitorID, balanceID := seedMonitor(t, ds)
+
+	owned, err := ds.TransitionMonitorState(ctx, monitorID, balanceID, true, 3)
+	require.NoError(t, err)
+	require.True(t, owned)
+
+	monitors, err := ds.GetBalanceMonitors(balanceID)
+	require.NoError(t, err)
+	require.Len(t, monitors, 1)
+	assert.Equal(t, model.TriggerEdge, monitors[0].Trigger)
+	assert.True(t, monitors[0].ConditionState)
+
+	all, err := ds.GetAllMonitors()
+	require.NoError(t, err)
+	found := false
+	for _, m := range all {
+		if m.MonitorID == monitorID {
+			assert.Equal(t, model.TriggerEdge, m.Trigger)
+			assert.True(t, m.ConditionState)
+			found = true
+		}
+	}
+	assert.True(t, found, "GetAllMonitors must return the monitor it just stored")
+}
+
+// BenchmarkTransitionMonitorState measures what an edge monitor adds to a
+// committed balance update. The steady-state case is the one that matters: a
+// monitor whose condition has not changed matches no rows and writes nothing,
+// and that is what almost every transaction sees.
+func BenchmarkTransitionMonitorState(b *testing.B) {
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		dsn = defaultRealTestDSN
+	}
+	db, err := sql.Open("postgres", dsn)
+	if err != nil {
+		b.Skipf("real database unavailable: %v", err)
+	}
+	if err := db.Ping(); err != nil {
+		b.Skipf("real database unavailable: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	ds := Datasource{Conn: db}
+
+	ledger, err := ds.CreateLedger(model.Ledger{Name: gofakeit.UUID()})
+	if err != nil {
+		b.Fatal(err)
+	}
+	balance, err := ds.CreateBalance(model.Balance{LedgerID: ledger.LedgerID, Currency: "USD"})
+	if err != nil {
+		b.Fatal(err)
+	}
+	monitor, err := ds.CreateMonitor(model.BalanceMonitor{
+		BalanceID: balance.BalanceID,
+		Condition: model.AlertCondition{Field: "balance", Operator: "<", Value: 100, Precision: 1, PreciseValue: big.NewInt(100)},
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+	ctx := context.Background()
+
+	b.Run("steady state (no transition)", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if _, err := ds.TransitionMonitorState(ctx, monitor.MonitorID, balance.BalanceID, false, int64(i+1)); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("alternating (every call transitions)", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if _, err := ds.TransitionMonitorState(ctx, monitor.MonitorID, balance.BalanceID, i%2 == 0, int64(i+1)); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}

--- a/database/balance_test.go
+++ b/database/balance_test.go
@@ -1238,7 +1238,7 @@ func TestGetMonitorByID_Success(t *testing.T) {
 	ds := Datasource{Conn: db}
 
 	query := `
-		SELECT monitor_id, balance_id, field, operator, value, precision, precise_value, description, call_back_url, created_at
+		SELECT monitor_id, balance_id, field, operator, value, COALESCE(precision, 0), COALESCE(precise_value, 0), description, call_back_url, created_at
 		FROM blnk.balance_monitors WHERE monitor_id = $1
 	`
 
@@ -1271,7 +1271,7 @@ func TestGetMonitorByID_NotFound(t *testing.T) {
 	ds := Datasource{Conn: db}
 
 	query := `
-		SELECT monitor_id, balance_id, field, operator, value, precision, precise_value, description, call_back_url, created_at
+		SELECT monitor_id, balance_id, field, operator, value, COALESCE(precision, 0), COALESCE(precise_value, 0), description, call_back_url, created_at
 		FROM blnk.balance_monitors WHERE monitor_id = $1
 	`
 
@@ -1298,16 +1298,16 @@ func TestGetAllMonitors_Success(t *testing.T) {
 	ds := Datasource{Conn: db}
 
 	query := `
-		SELECT monitor_id, balance_id, field, operator, value, description, call_back_url, created_at
+		SELECT monitor_id, balance_id, field, operator, value, description, call_back_url, created_at, COALESCE(precision, 0), COALESCE(precise_value, 0)
 		FROM blnk.balance_monitors
 	`
 
 	mock.ExpectQuery(regexp.QuoteMeta(query)).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"monitor_id", "balance_id", "field", "operator", "value", "description", "call_back_url", "created_at",
+			"monitor_id", "balance_id", "field", "operator", "value", "description", "call_back_url", "created_at", "precision", "precise_value",
 		}).
-			AddRow("mon_1", "bln_1", "balance", "<", 1000.0, "Alert 1", "https://example.com/1", time.Now()).
-			AddRow("mon_2", "bln_2", "credit_balance", ">", 5000.0, "Alert 2", "https://example.com/2", time.Now()))
+			AddRow("mon_1", "bln_1", "balance", "<", 1000.0, "Alert 1", "https://example.com/1", time.Now(), 100, int64(100000)).
+			AddRow("mon_2", "bln_2", "credit_balance", ">", 5000.0, "Alert 2", "https://example.com/2", time.Now(), 100, int64(500000)))
 
 	monitors, err := ds.GetAllMonitors()
 	assert.NoError(t, err)
@@ -1327,13 +1327,13 @@ func TestGetAllMonitors_Empty(t *testing.T) {
 	ds := Datasource{Conn: db}
 
 	query := `
-		SELECT monitor_id, balance_id, field, operator, value, description, call_back_url, created_at
+		SELECT monitor_id, balance_id, field, operator, value, description, call_back_url, created_at, COALESCE(precision, 0), COALESCE(precise_value, 0)
 		FROM blnk.balance_monitors
 	`
 
 	mock.ExpectQuery(regexp.QuoteMeta(query)).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"monitor_id", "balance_id", "field", "operator", "value", "description", "call_back_url", "created_at",
+			"monitor_id", "balance_id", "field", "operator", "value", "description", "call_back_url", "created_at", "precision", "precise_value",
 		}))
 
 	monitors, err := ds.GetAllMonitors()
@@ -1352,7 +1352,7 @@ func TestGetBalanceMonitors_Success(t *testing.T) {
 	ds := Datasource{Conn: db}
 
 	query := `
-		SELECT monitor_id, balance_id, field, operator, value, description, call_back_url, created_at, precision, precise_value
+		SELECT monitor_id, balance_id, field, operator, value, description, call_back_url, created_at, COALESCE(precision, 0), COALESCE(precise_value, 0)
 		FROM blnk.balance_monitors WHERE balance_id = $1
 	`
 
@@ -1383,7 +1383,7 @@ func TestGetBalanceMonitors_Empty(t *testing.T) {
 	ds := Datasource{Conn: db}
 
 	query := `
-		SELECT monitor_id, balance_id, field, operator, value, description, call_back_url, created_at, precision, precise_value
+		SELECT monitor_id, balance_id, field, operator, value, description, call_back_url, created_at, COALESCE(precision, 0), COALESCE(precise_value, 0)
 		FROM blnk.balance_monitors WHERE balance_id = $1
 	`
 
@@ -1422,12 +1422,12 @@ func TestUpdateMonitor_Success(t *testing.T) {
 
 	query := `
 		UPDATE blnk.balance_monitors
-		SET balance_id = $2, field = $3, operator = $4, value = $5, description = $6, call_back_url = $7
+		SET balance_id = $2, field = $3, operator = $4, value = $5, description = $6
 		WHERE monitor_id = $1
 	`
 
 	mock.ExpectExec(regexp.QuoteMeta(query)).
-		WithArgs(monitor.MonitorID, monitor.BalanceID, monitor.Condition.Field, monitor.Condition.Operator, monitor.Condition.Value, monitor.Description, monitor.CallBackURL).
+		WithArgs(monitor.MonitorID, monitor.BalanceID, monitor.Condition.Field, monitor.Condition.Operator, monitor.Condition.Value, monitor.Description).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	err = ds.UpdateMonitor(monitor)
@@ -1457,12 +1457,12 @@ func TestUpdateMonitor_NotFound(t *testing.T) {
 
 	query := `
 		UPDATE blnk.balance_monitors
-		SET balance_id = $2, field = $3, operator = $4, value = $5, description = $6, call_back_url = $7
+		SET balance_id = $2, field = $3, operator = $4, value = $5, description = $6
 		WHERE monitor_id = $1
 	`
 
 	mock.ExpectExec(regexp.QuoteMeta(query)).
-		WithArgs(monitor.MonitorID, monitor.BalanceID, monitor.Condition.Field, monitor.Condition.Operator, monitor.Condition.Value, monitor.Description, monitor.CallBackURL).
+		WithArgs(monitor.MonitorID, monitor.BalanceID, monitor.Condition.Field, monitor.Condition.Operator, monitor.Condition.Value, monitor.Description).
 		WillReturnResult(sqlmock.NewResult(0, 0))
 
 	err = ds.UpdateMonitor(monitor)

--- a/database/balance_test.go
+++ b/database/balance_test.go
@@ -1148,10 +1148,10 @@ func TestCreateMonitor_Success(t *testing.T) {
 	}
 
 	mock.ExpectExec(regexp.QuoteMeta(`
-		INSERT INTO blnk.balance_monitors (monitor_id, balance_id, field, operator, value, precision, precise_value, description, call_back_url, created_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+		INSERT INTO blnk.balance_monitors (monitor_id, balance_id, field, operator, value, precision, precise_value, description, call_back_url, created_at, trigger_type)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
 	`)).
-		WithArgs(sqlmock.AnyArg(), monitor.BalanceID, monitor.Condition.Field, monitor.Condition.Operator, monitor.Condition.Value, monitor.Condition.Precision, monitor.Condition.PreciseValue.String(), monitor.Description, monitor.CallBackURL, sqlmock.AnyArg()).
+		WithArgs(sqlmock.AnyArg(), monitor.BalanceID, monitor.Condition.Field, monitor.Condition.Operator, monitor.Condition.Value, monitor.Condition.Precision, monitor.Condition.PreciseValue.String(), monitor.Description, monitor.CallBackURL, sqlmock.AnyArg(), model.TriggerEdge).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	createdMonitor, err := ds.CreateMonitor(monitor)
@@ -1181,10 +1181,10 @@ func TestCreateMonitor_UniqueViolation(t *testing.T) {
 	}
 
 	mock.ExpectExec(regexp.QuoteMeta(`
-		INSERT INTO blnk.balance_monitors (monitor_id, balance_id, field, operator, value, precision, precise_value, description, call_back_url, created_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+		INSERT INTO blnk.balance_monitors (monitor_id, balance_id, field, operator, value, precision, precise_value, description, call_back_url, created_at, trigger_type)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
 	`)).
-		WithArgs(sqlmock.AnyArg(), monitor.BalanceID, monitor.Condition.Field, monitor.Condition.Operator, monitor.Condition.Value, sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WithArgs(sqlmock.AnyArg(), monitor.BalanceID, monitor.Condition.Field, monitor.Condition.Operator, monitor.Condition.Value, sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), model.TriggerEdge).
 		WillReturnError(&pq.Error{Code: "23505", Message: "unique_violation"})
 
 	_, err = ds.CreateMonitor(monitor)
@@ -1214,10 +1214,10 @@ func TestCreateMonitor_ForeignKeyViolation(t *testing.T) {
 	}
 
 	mock.ExpectExec(regexp.QuoteMeta(`
-		INSERT INTO blnk.balance_monitors (monitor_id, balance_id, field, operator, value, precision, precise_value, description, call_back_url, created_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+		INSERT INTO blnk.balance_monitors (monitor_id, balance_id, field, operator, value, precision, precise_value, description, call_back_url, created_at, trigger_type)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
 	`)).
-		WithArgs(sqlmock.AnyArg(), monitor.BalanceID, monitor.Condition.Field, monitor.Condition.Operator, monitor.Condition.Value, sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WithArgs(sqlmock.AnyArg(), monitor.BalanceID, monitor.Condition.Field, monitor.Condition.Operator, monitor.Condition.Value, sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), model.TriggerEdge).
 		WillReturnError(&pq.Error{Code: "23503", Message: "foreign_key_violation"})
 
 	_, err = ds.CreateMonitor(monitor)
@@ -1238,16 +1238,16 @@ func TestGetMonitorByID_Success(t *testing.T) {
 	ds := Datasource{Conn: db}
 
 	query := `
-		SELECT monitor_id, balance_id, field, operator, value, COALESCE(precision, 0), COALESCE(precise_value, 0), description, call_back_url, created_at
+		SELECT monitor_id, balance_id, field, operator, value, COALESCE(precision, 0), COALESCE(precise_value, 0), description, call_back_url, created_at, trigger_type, condition_state
 		FROM blnk.balance_monitors WHERE monitor_id = $1
 	`
 
 	mock.ExpectQuery(regexp.QuoteMeta(query)).
 		WithArgs("mon_123").
 		WillReturnRows(sqlmock.NewRows([]string{
-			"monitor_id", "balance_id", "field", "operator", "value", "precision", "precise_value", "description", "call_back_url", "created_at",
+			"monitor_id", "balance_id", "field", "operator", "value", "precision", "precise_value", "description", "call_back_url", "created_at", "trigger_type", "condition_state",
 		}).AddRow(
-			"mon_123", "bln_123", "balance", "<", 1000.0, 100, int64(100000), "Low balance alert", "https://example.com/webhook", time.Now(),
+			"mon_123", "bln_123", "balance", "<", 1000.0, 100, int64(100000), "Low balance alert", "https://example.com/webhook", time.Now(), model.TriggerEdge, false,
 		))
 
 	monitor, err := ds.GetMonitorByID("mon_123")
@@ -1271,7 +1271,7 @@ func TestGetMonitorByID_NotFound(t *testing.T) {
 	ds := Datasource{Conn: db}
 
 	query := `
-		SELECT monitor_id, balance_id, field, operator, value, COALESCE(precision, 0), COALESCE(precise_value, 0), description, call_back_url, created_at
+		SELECT monitor_id, balance_id, field, operator, value, COALESCE(precision, 0), COALESCE(precise_value, 0), description, call_back_url, created_at, trigger_type, condition_state
 		FROM blnk.balance_monitors WHERE monitor_id = $1
 	`
 
@@ -1298,16 +1298,16 @@ func TestGetAllMonitors_Success(t *testing.T) {
 	ds := Datasource{Conn: db}
 
 	query := `
-		SELECT monitor_id, balance_id, field, operator, value, description, call_back_url, created_at, COALESCE(precision, 0), COALESCE(precise_value, 0)
+		SELECT monitor_id, balance_id, field, operator, value, description, call_back_url, created_at, trigger_type, condition_state, COALESCE(precision, 0), COALESCE(precise_value, 0)
 		FROM blnk.balance_monitors
 	`
 
 	mock.ExpectQuery(regexp.QuoteMeta(query)).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"monitor_id", "balance_id", "field", "operator", "value", "description", "call_back_url", "created_at", "precision", "precise_value",
+			"monitor_id", "balance_id", "field", "operator", "value", "description", "call_back_url", "created_at", "trigger_type", "condition_state", "precision", "precise_value",
 		}).
-			AddRow("mon_1", "bln_1", "balance", "<", 1000.0, "Alert 1", "https://example.com/1", time.Now(), 100, int64(100000)).
-			AddRow("mon_2", "bln_2", "credit_balance", ">", 5000.0, "Alert 2", "https://example.com/2", time.Now(), 100, int64(500000)))
+			AddRow("mon_1", "bln_1", "balance", "<", 1000.0, "Alert 1", "https://example.com/1", time.Now(), model.TriggerEdge, false, 100, int64(100000)).
+			AddRow("mon_2", "bln_2", "credit_balance", ">", 5000.0, "Alert 2", "https://example.com/2", time.Now(), model.TriggerLevel, true, 100, int64(500000)))
 
 	monitors, err := ds.GetAllMonitors()
 	assert.NoError(t, err)
@@ -1327,13 +1327,13 @@ func TestGetAllMonitors_Empty(t *testing.T) {
 	ds := Datasource{Conn: db}
 
 	query := `
-		SELECT monitor_id, balance_id, field, operator, value, description, call_back_url, created_at, COALESCE(precision, 0), COALESCE(precise_value, 0)
+		SELECT monitor_id, balance_id, field, operator, value, description, call_back_url, created_at, trigger_type, condition_state, COALESCE(precision, 0), COALESCE(precise_value, 0)
 		FROM blnk.balance_monitors
 	`
 
 	mock.ExpectQuery(regexp.QuoteMeta(query)).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"monitor_id", "balance_id", "field", "operator", "value", "description", "call_back_url", "created_at", "precision", "precise_value",
+			"monitor_id", "balance_id", "field", "operator", "value", "description", "call_back_url", "created_at", "trigger_type", "condition_state", "precision", "precise_value",
 		}))
 
 	monitors, err := ds.GetAllMonitors()
@@ -1352,17 +1352,17 @@ func TestGetBalanceMonitors_Success(t *testing.T) {
 	ds := Datasource{Conn: db}
 
 	query := `
-		SELECT monitor_id, balance_id, field, operator, value, description, call_back_url, created_at, COALESCE(precision, 0), COALESCE(precise_value, 0)
+		SELECT monitor_id, balance_id, field, operator, value, description, call_back_url, created_at, COALESCE(precision, 0), COALESCE(precise_value, 0), trigger_type, condition_state
 		FROM blnk.balance_monitors WHERE balance_id = $1
 	`
 
 	mock.ExpectQuery(regexp.QuoteMeta(query)).
 		WithArgs("bln_123").
 		WillReturnRows(sqlmock.NewRows([]string{
-			"monitor_id", "balance_id", "field", "operator", "value", "description", "call_back_url", "created_at", "precision", "precise_value",
+			"monitor_id", "balance_id", "field", "operator", "value", "description", "call_back_url", "created_at", "precision", "precise_value", "trigger_type", "condition_state",
 		}).
-			AddRow("mon_1", "bln_123", "balance", "<", 1000.0, "Low alert", "https://example.com/1", time.Now(), 100, int64(100000)).
-			AddRow("mon_2", "bln_123", "debit_balance", ">", 500.0, "High debit", "https://example.com/2", time.Now(), 100, int64(50000)))
+			AddRow("mon_1", "bln_123", "balance", "<", 1000.0, "Low alert", "https://example.com/1", time.Now(), 100, int64(100000), model.TriggerEdge, false).
+			AddRow("mon_2", "bln_123", "debit_balance", ">", 500.0, "High debit", "https://example.com/2", time.Now(), 100, int64(50000), model.TriggerLevel, true))
 
 	monitors, err := ds.GetBalanceMonitors("bln_123")
 	assert.NoError(t, err)
@@ -1383,14 +1383,14 @@ func TestGetBalanceMonitors_Empty(t *testing.T) {
 	ds := Datasource{Conn: db}
 
 	query := `
-		SELECT monitor_id, balance_id, field, operator, value, description, call_back_url, created_at, COALESCE(precision, 0), COALESCE(precise_value, 0)
+		SELECT monitor_id, balance_id, field, operator, value, description, call_back_url, created_at, COALESCE(precision, 0), COALESCE(precise_value, 0), trigger_type, condition_state
 		FROM blnk.balance_monitors WHERE balance_id = $1
 	`
 
 	mock.ExpectQuery(regexp.QuoteMeta(query)).
 		WithArgs("bln_no_monitors").
 		WillReturnRows(sqlmock.NewRows([]string{
-			"monitor_id", "balance_id", "field", "operator", "value", "description", "call_back_url", "created_at", "precision", "precise_value",
+			"monitor_id", "balance_id", "field", "operator", "value", "description", "call_back_url", "created_at", "precision", "precise_value", "trigger_type", "condition_state",
 		}))
 
 	monitors, err := ds.GetBalanceMonitors("bln_no_monitors")
@@ -1422,12 +1422,13 @@ func TestUpdateMonitor_Success(t *testing.T) {
 
 	query := `
 		UPDATE blnk.balance_monitors
-		SET balance_id = $2, field = $3, operator = $4, value = $5, description = $6
+		SET balance_id = $2, field = $3, operator = $4, value = $5, description = $6,
+		    trigger_type = $7, condition_state = FALSE, state_version = 0, state_changed_at = NULL
 		WHERE monitor_id = $1
 	`
 
 	mock.ExpectExec(regexp.QuoteMeta(query)).
-		WithArgs(monitor.MonitorID, monitor.BalanceID, monitor.Condition.Field, monitor.Condition.Operator, monitor.Condition.Value, monitor.Description).
+		WithArgs(monitor.MonitorID, monitor.BalanceID, monitor.Condition.Field, monitor.Condition.Operator, monitor.Condition.Value, monitor.Description, model.TriggerEdge).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	err = ds.UpdateMonitor(monitor)
@@ -1457,12 +1458,13 @@ func TestUpdateMonitor_NotFound(t *testing.T) {
 
 	query := `
 		UPDATE blnk.balance_monitors
-		SET balance_id = $2, field = $3, operator = $4, value = $5, description = $6
+		SET balance_id = $2, field = $3, operator = $4, value = $5, description = $6,
+		    trigger_type = $7, condition_state = FALSE, state_version = 0, state_changed_at = NULL
 		WHERE monitor_id = $1
 	`
 
 	mock.ExpectExec(regexp.QuoteMeta(query)).
-		WithArgs(monitor.MonitorID, monitor.BalanceID, monitor.Condition.Field, monitor.Condition.Operator, monitor.Condition.Value, monitor.Description).
+		WithArgs(monitor.MonitorID, monitor.BalanceID, monitor.Condition.Field, monitor.Condition.Operator, monitor.Condition.Value, monitor.Description, model.TriggerEdge).
 		WillReturnResult(sqlmock.NewResult(0, 0))
 
 	err = ds.UpdateMonitor(monitor)

--- a/database/mocks/repo_mocks.go
+++ b/database/mocks/repo_mocks.go
@@ -414,6 +414,16 @@ func (m *MockDataSource) DeleteMonitor(id string) error {
 	return args.Error(0)
 }
 
+func (m *MockDataSource) TransitionMonitorState(ctx context.Context, monitorID, balanceID string, conditionMet bool, balanceVersion int64) (bool, error) {
+	args := m.Called(ctx, monitorID, balanceID, conditionMet, balanceVersion)
+	return args.Bool(0), args.Error(1)
+}
+
+func (m *MockDataSource) ReleaseMonitorState(ctx context.Context, monitorID, balanceID string, balanceVersion int64) error {
+	args := m.Called(ctx, monitorID, balanceID, balanceVersion)
+	return args.Error(0)
+}
+
 // Identity methods
 
 func (m *MockDataSource) CreateIdentity(identity model.Identity) (model.Identity, error) {

--- a/database/repository.go
+++ b/database/repository.go
@@ -132,6 +132,12 @@ type balanceMonitor interface {
 	GetBalanceMonitors(balanceID string) ([]model.BalanceMonitor, error)      // Retrieves monitors for a specific balance
 	UpdateMonitor(monitor *model.BalanceMonitor) error                        // Updates a balance monitor
 	DeleteMonitor(id string) error                                            // Deletes a balance monitor
+
+	// TransitionMonitorState records an observed condition value against a
+	// balance version and reports whether this call owned the transition.
+	TransitionMonitorState(ctx context.Context, monitorID, balanceID string, conditionMet bool, balanceVersion int64) (bool, error)
+	// ReleaseMonitorState re-arms a monitor whose owned transition could not be delivered.
+	ReleaseMonitorState(ctx context.Context, monitorID, balanceID string, balanceVersion int64) error
 }
 
 // identity defines methods for handling identities.

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -17,41 +17,53 @@ package cache
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/blnkfinance/blnk/config"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
+// testKey gives each test its own key. The cache is a shared Redis, so fixed
+// keys made these tests depend on execution order and on what an earlier run
+// left behind.
+func testKey(t *testing.T) string {
+	t.Helper()
+	return fmt.Sprintf("cachetest:%s:%d", t.Name(), time.Now().UnixNano())
+}
+
+// newTestCache configures the package and returns a cache. Every test needs
+// this: config.MockConfig validates before it stores, so configuring with an
+// empty Configuration is a no-op, and a test that did that only worked when
+// another test had already left a usable config in the global store.
+func newTestCache(t *testing.T) Cache {
+	t.Helper()
+
+	config.ConfigStore.Store(&config.Configuration{
+		Redis:              config.RedisConfig{Dns: "localhost:6379"},
+		Queue:              config.QueueConfig{WebhookQueue: "webhook_queue", NumberOfQueues: 1},
+		Server:             config.ServerConfig{SecretKey: "some-secret"},
+		TokenizationSecret: "12345678901234567890123456789012",
+	})
+
+	cache, err := NewCache()
+	require.NoError(t, err)
+	require.NotNil(t, cache)
+	return cache
+}
+
 func TestSet(t *testing.T) {
-	cnf := &config.Configuration{
-		Redis: config.RedisConfig{
-			Dns: "localhost:6379",
-		},
-		Queue: config.QueueConfig{
-			WebhookQueue:   "webhook_queue",
-			NumberOfQueues: 1,
-		},
-		Server: config.ServerConfig{SecretKey: "some-secret"},
-		AccountNumberGeneration: config.AccountNumberGenerationConfig{
-			HttpService: config.AccountGenerationHttpService{
-				Url: "http://example.com/generateAccount",
-			},
-		},
-	}
-
-	config.ConfigStore.Store(cnf)
 	ctx := context.Background()
-	mockCache, err := NewCache()
-	assert.NoError(t, err)
+	mockCache := newTestCache(t)
 
-	key := "testKey"
+	key := testKey(t)
 	value := "testValue"
 
 	// Test setting a value
-	err = mockCache.Set(ctx, key, value, 10*time.Minute)
+	err := mockCache.Set(ctx, key, value, 10*time.Minute)
 	assert.NoError(t, err)
 
 	// Test setting a value with zero TTL (should fail or behave differently)
@@ -60,14 +72,12 @@ func TestSet(t *testing.T) {
 }
 
 func TestGet(t *testing.T) {
-	config.MockConfig(&config.Configuration{})
 	ctx := context.Background()
-	mockCache, err := NewCache()
-	assert.NoError(t, err)
+	mockCache := newTestCache(t)
 
-	key := "testKey"
+	key := testKey(t)
 	setValue := map[string]string{"hello": "world"}
-	err = mockCache.Set(ctx, key, setValue, 10*time.Minute)
+	err := mockCache.Set(ctx, key, setValue, 10*time.Minute)
 	assert.NoError(t, err)
 
 	// Test getting an existing value
@@ -78,32 +88,28 @@ func TestGet(t *testing.T) {
 
 	var getValue1 map[string]string
 	// Test getting a non-existent key
-	err = mockCache.Get(ctx, "nonExistentKey", &getValue1)
+	err = mockCache.Get(ctx, testKey(t)+":absent", &getValue1)
 	assert.NoError(t, err) // Assuming Get returns no error for non-existent keys
 	assert.Empty(t, getValue1)
 }
 
 func TestGetNonExistentKey(t *testing.T) {
-	config.MockConfig(&config.Configuration{})
 	ctx := context.Background()
-	mockCache, err := NewCache()
-	assert.NoError(t, err)
+	mockCache := newTestCache(t)
 
 	var getValue map[string]string
-	err = mockCache.Get(ctx, "nonExistentKey", &getValue)
+	err := mockCache.Get(ctx, testKey(t)+":absent", &getValue)
 	assert.NoError(t, err) // Assuming Get returns no error for non-existent keys
 	assert.Empty(t, getValue)
 }
 
 func TestDelete(t *testing.T) {
-	config.MockConfig(&config.Configuration{})
 	ctx := context.Background()
-	mockCache, err := NewCache()
-	assert.NoError(t, err)
+	mockCache := newTestCache(t)
 
-	key := "testKey"
+	key := testKey(t)
 	value := "testValue"
-	err = mockCache.Set(ctx, key, value, 10*time.Minute)
+	err := mockCache.Set(ctx, key, value, 10*time.Minute)
 	if err != nil {
 		return
 	}
@@ -119,6 +125,6 @@ func TestDelete(t *testing.T) {
 	assert.Empty(t, getValue)
 
 	// Test deleting a non-existent key
-	err = mockCache.Delete(ctx, "nonExistentKey")
+	err = mockCache.Delete(ctx, testKey(t)+":absent")
 	assert.NoError(t, err)
 }

--- a/model/balance.go
+++ b/model/balance.go
@@ -16,6 +16,7 @@ limitations under the License.
 package model
 
 import (
+	"fmt"
 	"math/big"
 	"sync"
 	"time"
@@ -46,6 +47,31 @@ type Balance struct {
 	AllocationStrategy    string                 `json:"allocation_strategy,omitempty"`
 }
 
+// Trigger modes for a BalanceMonitor.
+//
+// TriggerEdge fires once when the condition goes from false to true and stays
+// silent until it has evaluated false again. TriggerLevel fires on every
+// committed balance update while the condition holds.
+const (
+	TriggerEdge  = "edge"
+	TriggerLevel = "level"
+)
+
+// NormalizeTrigger resolves a caller-supplied trigger mode, filling in the
+// default for an unset one and rejecting anything else. It is the only place
+// that knows what the default is, so the API, the datasource and the read path
+// cannot drift apart on it.
+func NormalizeTrigger(trigger string) (string, error) {
+	switch trigger {
+	case "":
+		return TriggerEdge, nil
+	case TriggerEdge, TriggerLevel:
+		return trigger, nil
+	default:
+		return "", fmt.Errorf("trigger must be either %q or %q", TriggerEdge, TriggerLevel)
+	}
+}
+
 type BalanceMonitor struct {
 	MonitorID   string         `json:"monitor_id"`
 	BalanceID   string         `json:"balance_id"`
@@ -53,6 +79,22 @@ type BalanceMonitor struct {
 	CallBackURL string         `json:"-"`
 	CreatedAt   time.Time      `json:"created_at"`
 	Condition   AlertCondition `json:"condition"`
+	Trigger     string         `json:"trigger,omitempty"`
+	// ConditionState is the last observed truth value of the condition. It is
+	// owned by the evaluation path and is never authoritative on a cached copy;
+	// read it from a TransitionMonitorState result, not from here.
+	ConditionState bool `json:"condition_state"`
+}
+
+// TriggerMode is the read side of NormalizeTrigger: it never fails, because a
+// stored row or a cache entry written before the field existed must still
+// resolve to something, and the default is the safe reading.
+func (bm *BalanceMonitor) TriggerMode() string {
+	trigger, err := NormalizeTrigger(bm.Trigger)
+	if err != nil {
+		return TriggerEdge
+	}
+	return trigger
 }
 
 type LineageMapping struct {

--- a/model/model.go
+++ b/model/model.go
@@ -83,7 +83,10 @@ func compare(value *big.Int, condition string, compareTo *big.Int) bool {
 		return cmp <= 0
 	case "!=":
 		return cmp != 0
-	case "==":
+	// The table's check constraint stores equality as '=', so that is the
+	// spelling monitors actually carry; '==' is accepted as well because the
+	// API has always advertised it.
+	case "=", "==":
 		return cmp == 0
 	}
 	return false

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -504,6 +504,16 @@ func TestBalanceMonitor_CheckCondition(t *testing.T) {
 	assert.False(t, result)
 }
 
+func TestBalanceMonitor_TriggerMode(t *testing.T) {
+	// An empty trigger is what a row written before the column existed, and a
+	// cache entry encoded before the field existed, both decode to. Both must
+	// behave as edge rather than silently keeping the old level behaviour.
+	assert.Equal(t, TriggerEdge, (&BalanceMonitor{}).TriggerMode())
+	assert.Equal(t, TriggerEdge, (&BalanceMonitor{Trigger: TriggerEdge}).TriggerMode())
+	assert.Equal(t, TriggerLevel, (&BalanceMonitor{Trigger: TriggerLevel}).TriggerMode())
+	assert.Equal(t, TriggerEdge, (&BalanceMonitor{Trigger: "nonsense"}).TriggerMode())
+}
+
 func TestExternalTransaction_ToInternalTransaction(t *testing.T) {
 	extTxn := &ExternalTransaction{
 		ID:          "ext123",

--- a/sql/1788542465.sql
+++ b/sql/1788542465.sql
@@ -1,0 +1,25 @@
+-- Copyright 2024 Blnk Finance Authors.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- AlertCondition.Value is a float64 and is the human-readable threshold that
+-- pairs with precision, but the column was a BIGINT: a monitor on "balance <
+-- 100.50" failed at the database and surfaced as a 500. precise_value carries
+-- the value the ledger actually compares against, so widening this column
+-- changes no evaluation, it only stops rejecting thresholds the API accepts.
+
+-- +migrate Up
+ALTER TABLE blnk.balance_monitors ALTER COLUMN value TYPE DOUBLE PRECISION;
+
+-- +migrate Down
+ALTER TABLE blnk.balance_monitors ALTER COLUMN value TYPE BIGINT USING ROUND(value);

--- a/sql/1788542466.sql
+++ b/sql/1788542466.sql
@@ -1,0 +1,35 @@
+-- Copyright 2024 Blnk Finance Authors.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Edge-triggered balance monitors (#318). condition_state is the last observed
+-- truth value of the monitor's condition; state_version is the balance version
+-- that produced it, which lets a concurrent evaluation running on an older
+-- balance be discarded instead of flipping the state back.
+--
+-- Existing monitors adopt 'edge' and start armed, so a monitor whose condition
+-- already holds fires once on its balance's next transaction and then goes quiet.
+
+-- +migrate Up
+ALTER TABLE blnk.balance_monitors ADD COLUMN trigger_type TEXT NOT NULL DEFAULT 'edge';
+ALTER TABLE blnk.balance_monitors ADD CONSTRAINT balance_monitors_trigger_type_check CHECK (trigger_type IN ('edge', 'level'));
+ALTER TABLE blnk.balance_monitors ADD COLUMN condition_state BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE blnk.balance_monitors ADD COLUMN state_version BIGINT NOT NULL DEFAULT 0;
+ALTER TABLE blnk.balance_monitors ADD COLUMN state_changed_at TIMESTAMP;
+
+-- +migrate Down
+ALTER TABLE blnk.balance_monitors DROP CONSTRAINT IF EXISTS balance_monitors_trigger_type_check;
+ALTER TABLE blnk.balance_monitors DROP COLUMN state_changed_at;
+ALTER TABLE blnk.balance_monitors DROP COLUMN state_version;
+ALTER TABLE blnk.balance_monitors DROP COLUMN condition_state;
+ALTER TABLE blnk.balance_monitors DROP COLUMN trigger_type;


### PR DESCRIPTION
Closes #318.

> Builds on #391, which should merge first. Until it does, this diff includes its three commits. The feature is the last two.

Balance monitors fire on every committed balance update while their condition holds. A wallet below its low-balance threshold sends a webhook on every debit instead of one alert when it crosses.

Monitors now take a `trigger`:

- `edge` fires once when the condition goes from false to true, then stays quiet until it has been false again.
- `level` keeps the current behaviour.

As agreed on #318, `edge` is the default.

```jsonc
POST /balance-monitors
{
  "balance_id": "bln_...",
  "trigger": "edge",  // optional, defaults to "edge"
  "condition": { "field": "balance", "operator": "<", "value": 100, "precision": 100 }
}
```

The read endpoints return `trigger` and `condition_state`.

## How it works

Monitor checks run in goroutines after the balance lock is released, so evaluations of one monitor can run at the same time and arrive out of order. The state change is therefore a single conditional `UPDATE`, and only the evaluation that changes the row sends the webhook:

```sql
UPDATE blnk.balance_monitors
   SET condition_state = $2, state_version = $3, state_changed_at = NOW()
 WHERE monitor_id = $1
   AND balance_id = $4                      -- skip evaluations for a balance the monitor has left
   AND condition_state IS DISTINCT FROM $2  -- one concurrent evaluation wins
   AND state_version < $3                   -- skip evaluations older than the last one applied
```

`$3` is the balance's `version`, which only increases after a successful write. The `balance_id` check matters because versions are counted per balance. Without it, a stale evaluation from a monitor's previous balance could store a version the new balance won't reach for a long time, and the monitor would go quiet.

If the webhook can't be enqueued, the transition is rolled back so the next transaction can retry the same crossing.

Level monitors do no extra database work. Edge monitors add one indexed single-row update per monitor per committed balance update, outside the lock. Against a real Postgres that costs 0.13 ms when nothing changes and 0.89 ms on a crossing.

## Upgrade behaviour needs your call

Existing monitors migrate as `edge` with `condition_state = false`. A monitor whose condition already holds fires once on its balance's next transaction, then goes quiet. An install with many wallets already past their threshold gets one alert per monitor at upgrade.

The alternative is to migrate existing monitors as `level` and default only new ones to `edge`. That avoids the one-time burst, but old and new monitors would then behave differently with nothing in the API to tell them apart. I went with the burst and am happy to switch.

## Testing

- **Concurrency:** 24 goroutines race one crossing against real Postgres, and exactly one sends.
- **Property tests:** random balance walks where the expected alert count is computed independently of the implementation. Edge never sends more than level.
- **Coverage:** every condition field and operator, inflight commit and void, the batch path, and moved, duplicate and deleted monitors.
- **Guards:** each check in the `UPDATE` was removed in turn, and a test failed every time.
- **Live run** with `blnk start` and `blnk workers`: the same ledger activity delivered 2 webhooks from an edge monitor and 3 from a level one.

`trigger` will need a line in `blnkfinance/docs`. I'll open that once the API shape is settled.
