### PR TITLE
fix(redis): recycle idle pooled connections before server timeout

### DIFF
--- a/blnk.go
+++ b/blnk.go
@@ -62,26 +62,22 @@ var SQLFiles embed.FS
 
 // initializeRedisClients sets up both the Redis client and Asynq client
 func initializeRedisClients(config *config.Configuration) (redis.UniversalClient, *asynq.Client, error) {
-	redisClient, err := redis_db.NewRedisClient([]string{config.Redis.Dns}, config.Redis.SkipTLSVerify, &redis_db.PoolConfig{
-		PoolSize:     config.Redis.PoolSize,
-		MinIdleConns: config.Redis.MinIdleConns,
-	})
+	pool := &redis_db.PoolConfig{
+		PoolSize:        config.Redis.PoolSize,
+		MinIdleConns:    config.Redis.MinIdleConns,
+		ConnMaxIdleTime: config.Redis.ConnMaxIdleTime,
+	}
+
+	redisClient, err := redis_db.NewRedisClient([]string{config.Redis.Dns}, config.Redis.SkipTLSVerify, pool)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	redisOption, err := redis_db.ParseRedisURL(config.Redis.Dns, config.Redis.SkipTLSVerify)
+	connOpt, err := redis_db.NewConnOpt(config.Redis.Dns, config.Redis.SkipTLSVerify, pool)
 	if err != nil {
 		return nil, nil, err
 	}
-
-	asynqClient := asynq.NewClient(asynq.RedisClientOpt{
-		Addr:      redisOption.Addr,
-		Password:  redisOption.Password,
-		DB:        redisOption.DB,
-		TLSConfig: redisOption.TLSConfig,
-		PoolSize:  config.Redis.PoolSize,
-	})
+	asynqClient := asynq.NewClient(connOpt)
 
 	return redisClient.Client(), asynqClient, nil
 }

--- a/cmd/workers.go
+++ b/cmd/workers.go
@@ -393,20 +393,28 @@ func initializeWebhookQueues() map[string]int {
 	return queues
 }
 
-func initializeWebhookWorkerServer(conf *config.Configuration, queues map[string]int) (*asynq.Server, error) {
-	redisOption, err := redis_db.ParseRedisURL(conf.Redis.Dns, conf.Redis.SkipTLSVerify)
+// workerRedisConnOpt builds an asynq connection option whose pooled
+// connections are recycled before managed Redis/Valkey idle-closes them.
+func workerRedisConnOpt(conf *config.Configuration) (redis_db.ConnOpt, error) {
+	connOpt, err := redis_db.NewConnOpt(conf.Redis.Dns, conf.Redis.SkipTLSVerify, &redis_db.PoolConfig{
+		PoolSize:        conf.Redis.PoolSize,
+		MinIdleConns:    conf.Redis.MinIdleConns,
+		ConnMaxIdleTime: conf.Redis.ConnMaxIdleTime,
+	})
 	if err != nil {
-		return nil, fmt.Errorf("error parsing Redis URL: %v", err)
+		return redis_db.ConnOpt{}, fmt.Errorf("error parsing Redis URL: %v", err)
+	}
+	return connOpt, nil
+}
+
+func initializeWebhookWorkerServer(conf *config.Configuration, queues map[string]int) (*asynq.Server, error) {
+	connOpt, err := workerRedisConnOpt(conf)
+	if err != nil {
+		return nil, err
 	}
 
 	return asynq.NewServer(
-		asynq.RedisClientOpt{
-			Addr:      redisOption.Addr,
-			Password:  redisOption.Password,
-			DB:        redisOption.DB,
-			TLSConfig: redisOption.TLSConfig,
-			PoolSize:  conf.Redis.PoolSize,
-		},
+		connOpt,
 		asynq.Config{
 			Concurrency:     conf.Queue.WebhookConcurrency,
 			Queues:          queues,
@@ -418,19 +426,13 @@ func initializeWebhookWorkerServer(conf *config.Configuration, queues map[string
 }
 
 func initializeWorkerServer(conf *config.Configuration, queues map[string]int) (*asynq.Server, error) {
-	redisOption, err := redis_db.ParseRedisURL(conf.Redis.Dns, conf.Redis.SkipTLSVerify)
+	connOpt, err := workerRedisConnOpt(conf)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing Redis URL: %v", err)
+		return nil, err
 	}
 
 	return asynq.NewServer(
-		asynq.RedisClientOpt{
-			Addr:      redisOption.Addr,
-			Password:  redisOption.Password,
-			DB:        redisOption.DB,
-			TLSConfig: redisOption.TLSConfig,
-			PoolSize:  conf.Redis.PoolSize,
-		},
+		connOpt,
 		asynq.Config{
 			Concurrency:     conf.Queue.TransactionWorkerConcurrency,
 			Queues:          queues,
@@ -440,19 +442,13 @@ func initializeWorkerServer(conf *config.Configuration, queues map[string]int) (
 }
 
 func initializeHotWorkerServer(conf *config.Configuration, queues map[string]int) (*asynq.Server, error) {
-	redisOption, err := redis_db.ParseRedisURL(conf.Redis.Dns, conf.Redis.SkipTLSVerify)
+	connOpt, err := workerRedisConnOpt(conf)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing Redis URL: %v", err)
+		return nil, err
 	}
 
 	return asynq.NewServer(
-		asynq.RedisClientOpt{
-			Addr:      redisOption.Addr,
-			Password:  redisOption.Password,
-			DB:        redisOption.DB,
-			TLSConfig: redisOption.TLSConfig,
-			PoolSize:  conf.Redis.PoolSize,
-		},
+		connOpt,
 		asynq.Config{
 			Concurrency:     conf.Queue.HotQueueConcurrency,
 			Queues:          queues,
@@ -621,16 +617,13 @@ func setupWorkerServers(b *blnkInstance, conf *config.Configuration) (*asynq.Ser
 }
 
 func startMonitoringServer(conf *config.Configuration) *http.Server {
-	redisOption, _ := redis_db.ParseRedisURL(conf.Redis.Dns, conf.Redis.SkipTLSVerify)
+	connOpt, err := workerRedisConnOpt(conf)
+	if err != nil {
+		logrus.Errorf("monitoring server redis setup failed: %v", err)
+	}
 	asynqmonHandler := asynqmon.New(asynqmon.Options{
-		RootPath: "/monitoring",
-		RedisConnOpt: asynq.RedisClientOpt{
-			Addr:      redisOption.Addr,
-			Password:  redisOption.Password,
-			DB:        redisOption.DB,
-			TLSConfig: redisOption.TLSConfig,
-			PoolSize:  conf.Redis.PoolSize,
-		},
+		RootPath:     "/monitoring",
+		RedisConnOpt: connOpt,
 	})
 
 	monitoringMux := http.NewServeMux()

--- a/config/config.go
+++ b/config/config.go
@@ -93,8 +93,9 @@ var (
 	}
 
 	defaultRedis = RedisConfig{
-		PoolSize:     100,
-		MinIdleConns: 20,
+		PoolSize:        100,
+		MinIdleConns:    20,
+		ConnMaxIdleTime: 2 * time.Minute,
 	}
 
 	defaultDatabase = DataSourceConfig{
@@ -142,6 +143,10 @@ type RedisConfig struct {
 	SkipTLSVerify bool   `json:"skip_tls_verify" envconfig:"BLNK_REDIS_SKIP_TLS_VERIFY"`
 	PoolSize      int    `json:"pool_size"       envconfig:"BLNK_REDIS_POOL_SIZE"`
 	MinIdleConns  int    `json:"min_idle_conns"  envconfig:"BLNK_REDIS_MIN_IDLE_CONNS"`
+	// ConnMaxIdleTime must stay below any server or proxy idle timeout
+	// (managed Redis/Valkey services commonly use 300s) so pooled connections
+	// are recycled before the remote end closes them ("write: broken pipe").
+	ConnMaxIdleTime time.Duration `json:"conn_max_idle_time" envconfig:"BLNK_REDIS_CONN_MAX_IDLE_TIME"`
 }
 
 type TypeSenseConfig struct {
@@ -520,6 +525,9 @@ func (cnf *Configuration) setRedisDefaults() {
 	}
 	if cnf.Redis.MinIdleConns == 0 {
 		cnf.Redis.MinIdleConns = defaultRedis.MinIdleConns
+	}
+	if cnf.Redis.ConnMaxIdleTime == 0 {
+		cnf.Redis.ConnMaxIdleTime = defaultRedis.ConnMaxIdleTime
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -380,6 +380,28 @@ func TestTypeSenseBackpressureRetryIntervalDefault(t *testing.T) {
 	}
 }
 
+func TestRedisConnMaxIdleTimeDefault(t *testing.T) {
+	cnf := Configuration{
+		ProjectName: "Test Project",
+		DataSource:  DataSourceConfig{Dns: "some-dns"},
+		Redis:       RedisConfig{Dns: "localhost:6379"},
+	}
+	if err := cnf.validateAndAddDefaults(); err != nil {
+		t.Fatalf("validateAndAddDefaults failed: %v", err)
+	}
+	if cnf.Redis.ConnMaxIdleTime != 2*time.Minute {
+		t.Fatalf("default Redis conn max idle time = %v, want 2m", cnf.Redis.ConnMaxIdleTime)
+	}
+
+	cnf.Redis.ConnMaxIdleTime = 45 * time.Second
+	if err := cnf.validateAndAddDefaults(); err != nil {
+		t.Fatalf("validateAndAddDefaults failed: %v", err)
+	}
+	if cnf.Redis.ConnMaxIdleTime != 45*time.Second {
+		t.Fatalf("explicit Redis conn max idle time = %v, want 45s", cnf.Redis.ConnMaxIdleTime)
+	}
+}
+
 // TestUploadWhitelistHostsParsing verifies parsing of the comma-separated
 // whitelist: trimming, scheme-tolerance, case-folding, de-duplication, and
 // deny-by-default (empty -> nil).

--- a/internal/redis-db/idle_conn_test.go
+++ b/internal/redis-db/idle_conn_test.go
@@ -1,0 +1,175 @@
+package redis_db
+
+import (
+	"context"
+	"net"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const testRedisAddr = "localhost:6379"
+
+func TestStalePooledConnAfterIdleClose(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	requireLocalRedis(t)
+
+	serverIdle := 400 * time.Millisecond
+	err := evalAfterIdle(t, &redis.Options{
+		Addr:         testRedisAddr,
+		PoolSize:     1,
+		MinIdleConns: 0,
+		// go-redis retries 3 times by default (-1 disables, 0 means default).
+		// Production hits the same failure once every pooled conn is stale:
+		// each retry pops another dead socket until retries are exhausted.
+		MaxRetries:      -1,
+		ConnMaxIdleTime: -1, // never recycle idle conns: Core before the ConnMaxIdleTime fix
+		Dialer:          idleBreakDialer(serverIdle),
+	}, serverIdle*2)
+	if err == nil {
+		t.Fatal("expected broken pipe; pool reused a conn idle longer than the server timeout")
+	}
+}
+
+func TestPooledConnRecycledBeforeIdleClose(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	requireLocalRedis(t)
+
+	serverIdle := 400 * time.Millisecond
+	err := evalAfterIdle(t, &redis.Options{
+		Addr:            testRedisAddr,
+		PoolSize:        1,
+		MinIdleConns:    0,
+		MaxRetries:      -1, // no retries, so success cannot come from redialing
+		ConnMaxIdleTime: serverIdle / 2,
+		Dialer:          idleBreakDialer(serverIdle),
+	}, serverIdle*2)
+	if err != nil {
+		t.Fatalf("pool should have discarded the idle conn before reuse: %v", err)
+	}
+}
+
+// TestNewRedisClientSetsConnMaxIdleTime pins the fix at the constructor
+// level: every pool Core builds must recycle idle conns before a managed
+// Redis/Valkey server can close them (TestStalePooledConnAfterIdleClose
+// shows the broken-pipe failure that otherwise results).
+func TestNewRedisClientSetsConnMaxIdleTime(t *testing.T) {
+	requireLocalRedis(t)
+
+	byDefault, err := NewRedisClient([]string{testRedisAddr}, false)
+	if err != nil {
+		t.Fatalf("NewRedisClient: %v", err)
+	}
+	t.Cleanup(func() { _ = byDefault.Client().Close() })
+	if got := standaloneOptions(t, byDefault.Client()).ConnMaxIdleTime; got != defaultConnMaxIdleTime {
+		t.Fatalf("default ConnMaxIdleTime = %v, want %v", got, defaultConnMaxIdleTime)
+	}
+
+	custom, err := NewRedisClient([]string{testRedisAddr}, false, &PoolConfig{ConnMaxIdleTime: 45 * time.Second})
+	if err != nil {
+		t.Fatalf("NewRedisClient with pool config: %v", err)
+	}
+	t.Cleanup(func() { _ = custom.Client().Close() })
+	if got := standaloneOptions(t, custom.Client()).ConnMaxIdleTime; got != 45*time.Second {
+		t.Fatalf("custom ConnMaxIdleTime = %v, want %v", got, 45*time.Second)
+	}
+}
+
+// TestNewConnOptSetsConnMaxIdleTime guards the asynq path, which previously
+// used asynq.RedisClientOpt and could not express ConnMaxIdleTime at all.
+func TestNewConnOptSetsConnMaxIdleTime(t *testing.T) {
+	connOpt, err := NewConnOpt(testRedisAddr, false)
+	if err != nil {
+		t.Fatalf("NewConnOpt: %v", err)
+	}
+	client, ok := connOpt.MakeRedisClient().(redis.UniversalClient)
+	if !ok {
+		t.Fatalf("MakeRedisClient returned %T; asynq requires redis.UniversalClient", connOpt.MakeRedisClient())
+	}
+	t.Cleanup(func() { _ = client.Close() })
+	if got := standaloneOptions(t, client).ConnMaxIdleTime; got != defaultConnMaxIdleTime {
+		t.Fatalf("asynq conn opt ConnMaxIdleTime = %v, want %v", got, defaultConnMaxIdleTime)
+	}
+}
+
+func standaloneOptions(t *testing.T, client redis.UniversalClient) *redis.Options {
+	t.Helper()
+	rdb, ok := client.(*redis.Client)
+	if !ok {
+		t.Fatalf("expected *redis.Client, got %T", client)
+	}
+	return rdb.Options()
+}
+
+func requireLocalRedis(t *testing.T) {
+	t.Helper()
+	rdb := redis.NewClient(&redis.Options{Addr: testRedisAddr})
+	t.Cleanup(func() { _ = rdb.Close() })
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := rdb.Ping(ctx).Err(); err != nil {
+		t.Skipf("redis not available at %s: %v", testRedisAddr, err)
+	}
+}
+
+func evalAfterIdle(t *testing.T, opts *redis.Options, idle time.Duration) error {
+	t.Helper()
+	rdb := redis.NewClient(opts)
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := rdb.Ping(ctx).Err(); err != nil {
+		t.Fatalf("warm ping: %v", err)
+	}
+	time.Sleep(idle)
+	return rdb.Eval(ctx, "return 1", nil).Err()
+}
+
+func idleBreakDialer(idle time.Duration) func(context.Context, string, string) (net.Conn, error) {
+	return func(ctx context.Context, network, address string) (net.Conn, error) {
+		var d net.Dialer
+		c, err := d.DialContext(ctx, network, address)
+		if err != nil {
+			return nil, err
+		}
+		return &idleBreakConn{Conn: c, idle: idle}, nil
+	}
+}
+
+type idleBreakConn struct {
+	net.Conn
+	idle     time.Duration
+	mu       sync.Mutex
+	lastUsed time.Time
+}
+
+func (c *idleBreakConn) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	stale := !c.lastUsed.IsZero() && time.Since(c.lastUsed) > c.idle
+	if !stale {
+		c.lastUsed = time.Now()
+	}
+	c.mu.Unlock()
+	if stale {
+		return 0, &net.OpError{Op: "write", Net: "tcp", Addr: c.RemoteAddr(), Err: syscall.EPIPE}
+	}
+	return c.Conn.Write(p)
+}
+
+func (c *idleBreakConn) Read(p []byte) (int, error) {
+	n, err := c.Conn.Read(p)
+	if n > 0 {
+		c.mu.Lock()
+		c.lastUsed = time.Now()
+		c.mu.Unlock()
+	}
+	return n, err
+}

--- a/internal/redis-db/redisdb.go
+++ b/internal/redis-db/redisdb.go
@@ -27,10 +27,39 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
+// defaultConnMaxIdleTime recycles pooled connections well before managed
+// Redis/Valkey services or intermediate proxies idle-close them (commonly
+// around 300s). Reusing a connection the server already closed surfaces as
+// "write: broken pipe" on the next command.
+const defaultConnMaxIdleTime = 2 * time.Minute
+
 // PoolConfig holds Redis connection pool settings.
 type PoolConfig struct {
 	PoolSize     int
 	MinIdleConns int
+	// ConnMaxIdleTime is how long a pooled connection may sit idle before it
+	// is discarded instead of reused. Zero applies defaultConnMaxIdleTime;
+	// negative disables recycling.
+	ConnMaxIdleTime time.Duration
+}
+
+// resolvePoolConfig applies defaults to an optional caller-supplied pool
+// config so every client construction path shares the same safety floor.
+func resolvePoolConfig(pool ...*PoolConfig) PoolConfig {
+	var pc PoolConfig
+	if len(pool) > 0 && pool[0] != nil {
+		pc = *pool[0]
+	}
+	if pc.PoolSize == 0 {
+		pc.PoolSize = 100
+	}
+	if pc.MinIdleConns == 0 {
+		pc.MinIdleConns = 20
+	}
+	if pc.ConnMaxIdleTime == 0 {
+		pc.ConnMaxIdleTime = defaultConnMaxIdleTime
+	}
+	return pc
 }
 
 // Redis struct holds the Redis client and addresses of Redis instances.
@@ -118,17 +147,7 @@ func NewRedisClient(addresses []string, skipTLSVerify bool, pool ...*PoolConfig)
 		return nil, errors.New("redis addresses list cannot be empty")
 	}
 
-	// Resolve pool config (use provided or defaults)
-	var pc PoolConfig
-	if len(pool) > 0 && pool[0] != nil {
-		pc = *pool[0]
-	}
-	if pc.PoolSize == 0 {
-		pc.PoolSize = 100
-	}
-	if pc.MinIdleConns == 0 {
-		pc.MinIdleConns = 20
-	}
+	pc := resolvePoolConfig(pool...)
 
 	var client redis.UniversalClient
 
@@ -141,6 +160,7 @@ func NewRedisClient(addresses []string, skipTLSVerify bool, pool ...*PoolConfig)
 
 		opts.PoolSize = pc.PoolSize
 		opts.MinIdleConns = pc.MinIdleConns
+		opts.ConnMaxIdleTime = pc.ConnMaxIdleTime
 
 		client = redis.NewClient(opts)
 	} else {
@@ -176,11 +196,12 @@ func NewRedisClient(addresses []string, skipTLSVerify bool, pool ...*PoolConfig)
 		}
 
 		client = redis.NewUniversalClient(&redis.UniversalOptions{
-			Addrs:        clusterAddrs,
-			Password:     password,
-			TLSConfig:    tlsConfig,
-			PoolSize:     pc.PoolSize,
-			MinIdleConns: pc.MinIdleConns,
+			Addrs:           clusterAddrs,
+			Password:        password,
+			TLSConfig:       tlsConfig,
+			PoolSize:        pc.PoolSize,
+			MinIdleConns:    pc.MinIdleConns,
+			ConnMaxIdleTime: pc.ConnMaxIdleTime,
 		})
 	}
 
@@ -208,4 +229,32 @@ func (r *Redis) Client() redis.UniversalClient {
 // - interface{}: The Redis client interface.
 func (r *Redis) MakeRedisClient() interface{} {
 	return r.client
+}
+
+// ConnOpt adapts a pooled go-redis client to asynq's RedisConnOpt interface
+// without importing asynq. asynq.RedisClientOpt cannot express
+// ConnMaxIdleTime, so clients built from it reuse connections that managed
+// Redis/Valkey already idle-closed ("write: broken pipe").
+type ConnOpt struct {
+	client redis.UniversalClient
+}
+
+// MakeRedisClient satisfies asynq.RedisConnOpt.
+func (o ConnOpt) MakeRedisClient() interface{} {
+	return o.client
+}
+
+// NewConnOpt builds an asynq-compatible connection option whose underlying
+// client recycles idle connections. Each call creates a dedicated client, so
+// an asynq consumer closing its connection does not tear down another's.
+func NewConnOpt(rawURL string, skipTLSVerify bool, pool ...*PoolConfig) (ConnOpt, error) {
+	opts, err := ParseRedisURL(rawURL, skipTLSVerify)
+	if err != nil {
+		return ConnOpt{}, err
+	}
+	pc := resolvePoolConfig(pool...)
+	opts.PoolSize = pc.PoolSize
+	opts.MinIdleConns = pc.MinIdleConns
+	opts.ConnMaxIdleTime = pc.ConnMaxIdleTime
+	return ConnOpt{client: redis.NewClient(opts)}, nil
 }

--- a/queue.go
+++ b/queue.go
@@ -114,13 +114,16 @@ func (q *Queue) EnqueueInflightAction(ctx context.Context, p InflightActionPaylo
 // Returns:
 // - *Queue: A pointer to the newly created Queue instance.
 func NewQueue(conf *config.Configuration, client *asynq.Client, redisClient redis.UniversalClient) *Queue {
-	redisOption, err := redis_db.ParseRedisURL(conf.Redis.Dns, conf.Redis.SkipTLSVerify)
+	connOpt, err := redis_db.NewConnOpt(conf.Redis.Dns, conf.Redis.SkipTLSVerify, &redis_db.PoolConfig{
+		PoolSize:        conf.Redis.PoolSize,
+		MinIdleConns:    conf.Redis.MinIdleConns,
+		ConnMaxIdleTime: conf.Redis.ConnMaxIdleTime,
+	})
 	if err != nil {
 		logrus.WithError(err).Fatal("failed to parse Redis URL")
 	}
 
-	queueOptions := asynq.RedisClientOpt{Addr: redisOption.Addr, Password: redisOption.Password, DB: redisOption.DB, TLSConfig: redisOption.TLSConfig, PoolSize: conf.Redis.PoolSize}
-	inspector := asynq.NewInspector(queueOptions)
+	inspector := asynq.NewInspector(connOpt)
 	return &Queue{
 		Client:    client,
 		Inspector: inspector,


### PR DESCRIPTION
Managed Redis/Valkey services and intermediate proxies close idle connections (commonly after ~300s) that go-redis and asynq pools still hold. Reusing one surfaces as "write: broken pipe" on the next command.

Add ConnMaxIdleTime to PoolConfig (default 2m, configurable via BLNK_REDIS_CONN_MAX_IDLE_TIME) and route every asynq consumer through a new ConnOpt whose client honors it, since asynq.RedisClientOpt cannot express pool idle recycling. Regression tests reproduce the broken pipe on a stale pool and pin the fix at the constructor level.