### PR TITLE
fix(monitors): seven defects that made balance monitors unreliable

### DIFF
--- a/api/balance_monitor_defects_e2e_test.go
+++ b/api/balance_monitor_defects_e2e_test.go
@@ -1,0 +1,189 @@
+/*
+Copyright 2024 Blnk Finance Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	model2 "github.com/blnkfinance/blnk/api/model"
+	"github.com/blnkfinance/blnk/config"
+	"github.com/blnkfinance/blnk/database"
+	"github.com/blnkfinance/blnk/internal/request"
+	"github.com/blnkfinance/blnk/model"
+)
+
+// execSQL runs a statement directly against the test database, for setting up
+// rows the API deliberately cannot produce.
+func execSQL(t *testing.T, cnf *config.Configuration, statement string, args ...interface{}) {
+	t.Helper()
+
+	ds, err := database.GetDBConnection(cnf)
+	require.NoError(t, err)
+	_, err = ds.Conn.ExecContext(context.Background(), statement, args...)
+	require.NoError(t, err)
+}
+
+// A monitor written before the precision migration carries NULLs. Reading it
+// used to fail, and because checkBalanceMonitors gives up when the fetch
+// errors, that one row silenced every other monitor on the same balance.
+func TestBalanceMonitor_LegacyRowDoesNotSilenceItsSiblings(t *testing.T) {
+	e := setupMonitorE2E(t)
+	funding, wallet := e.newBalance(t), e.newBalance(t)
+
+	e.createMonitorOn(t, wallet.BalanceID, "balance", ">", 500)
+
+	legacyID := model.GenerateUUIDWithSuffix("mon")
+	execSQL(t, e.cnf, `
+		INSERT INTO blnk.balance_monitors (monitor_id, balance_id, field, operator, value, description, call_back_url, created_at)
+		VALUES ($1, $2, 'balance', '>', 500, 'legacy', '', NOW())
+	`, legacyID, wallet.BalanceID)
+
+	e.transfer(t, funding.BalanceID, wallet.BalanceID, 900)
+
+	// Both monitors watch the same threshold, so both owe one alert.
+	e.awaitWebhooks(t, 2)
+}
+
+// The monitor cache is keyed by balance, so a moved monitor kept firing on the
+// balance it left until that balance's cached list expired.
+func TestBalanceMonitor_MovedMonitorStopsAlertingOnTheOldBalance(t *testing.T) {
+	e := setupMonitorE2E(t)
+	funding, oldWallet, newWallet := e.newBalance(t), e.newBalance(t), e.newBalance(t)
+
+	created := e.createMonitorOn(t, oldWallet.BalanceID, "balance", ">", 500)
+
+	// Put the old balance's monitor list in the cache.
+	e.transfer(t, funding.BalanceID, oldWallet.BalanceID, 100)
+	e.settle()
+	require.Equal(t, 0, e.webhooks())
+
+	payloadBytes, _ := request.ToJsonReq(&model.BalanceMonitor{
+		BalanceID: newWallet.BalanceID,
+		Condition: model.AlertCondition{Field: "balance", Operator: ">", Value: 500, Precision: 1},
+	})
+	resp, _ := SetUpTestRequest(TestRequest{
+		Payload: payloadBytes, Method: "PUT",
+		Route: fmt.Sprintf("/balance-monitors/%s", created.MonitorID), Router: e.router,
+	})
+	require.Equal(t, http.StatusOK, resp.Code)
+
+	e.transfer(t, funding.BalanceID, oldWallet.BalanceID, 900)
+	e.settle()
+	assert.Equal(t, 0, e.webhooks(), "a moved monitor must not keep alerting on the balance it left")
+
+	e.transfer(t, funding.BalanceID, newWallet.BalanceID, 900)
+	e.awaitWebhooks(t, 1)
+}
+
+func TestBalanceMonitor_FractionalThresholdEndToEnd(t *testing.T) {
+	e := setupMonitorE2E(t)
+	funding, wallet := e.newBalance(t), e.newBalance(t)
+
+	payloadBytes, _ := request.ToJsonReq(&model2.CreateBalanceMonitor{
+		BalanceId: wallet.BalanceID,
+		Condition: model2.MonitorCondition{Field: "balance", Operator: ">", Value: 10.5, Precision: 100},
+	})
+	var created model.BalanceMonitor
+	resp, _ := SetUpTestRequest(TestRequest{
+		Payload: payloadBytes, Response: &created,
+		Method: "POST", Route: "/balance-monitors", Router: e.router,
+	})
+	require.Equal(t, http.StatusCreated, resp.Code, "body: %s", resp.Body.String())
+	assert.Equal(t, 10.5, created.Condition.Value)
+
+	// precision 100 means the threshold is 1050 in the ledger's own units.
+	e.transferPrecise(t, funding.BalanceID, wallet.BalanceID, 10.40, 100)
+	e.settle()
+	assert.Equal(t, 0, e.webhooks(), "10.40 has not passed 10.50")
+
+	e.transferPrecise(t, funding.BalanceID, wallet.BalanceID, 0.20, 100)
+	e.awaitWebhooks(t, 1)
+}
+
+func TestBalanceMonitor_ZeroThresholdEndToEnd(t *testing.T) {
+	e := setupMonitorE2E(t)
+	funding, wallet := e.newBalance(t), e.newBalance(t)
+
+	e.createMonitorOn(t, wallet.BalanceID, "balance", ">", 0)
+
+	e.transfer(t, wallet.BalanceID, funding.BalanceID, 100)
+	e.settle()
+	assert.Equal(t, 0, e.webhooks(), "a negative balance is not above zero")
+
+	e.transfer(t, funding.BalanceID, wallet.BalanceID, 200)
+	e.awaitWebhooks(t, 1)
+}
+
+func TestBalanceMonitor_ListAndDetailAgreeOnThreshold(t *testing.T) {
+	e := setupMonitorE2E(t)
+	wallet := e.newBalance(t)
+
+	payloadBytes, _ := request.ToJsonReq(&model2.CreateBalanceMonitor{
+		BalanceId: wallet.BalanceID,
+		Condition: model2.MonitorCondition{Field: "balance", Operator: "<", Value: 100, Precision: 100},
+	})
+	var created model.BalanceMonitor
+	resp, _ := SetUpTestRequest(TestRequest{
+		Payload: payloadBytes, Response: &created,
+		Method: "POST", Route: "/balance-monitors", Router: e.router,
+	})
+	require.Equal(t, http.StatusCreated, resp.Code)
+
+	var detail model.BalanceMonitor
+	resp, _ = SetUpTestRequest(TestRequest{
+		Response: &detail, Method: "GET",
+		Route: fmt.Sprintf("/balance-monitors/%s", created.MonitorID), Router: e.router,
+	})
+	require.Equal(t, http.StatusOK, resp.Code)
+
+	var all []model.BalanceMonitor
+	resp, _ = SetUpTestRequest(TestRequest{
+		Response: &all, Method: "GET", Route: "/balance-monitors", Router: e.router,
+	})
+	require.Equal(t, http.StatusOK, resp.Code)
+
+	for _, listed := range all {
+		if listed.MonitorID != created.MonitorID {
+			continue
+		}
+		assert.Equal(t, detail.Condition.Precision, listed.Condition.Precision, "list and detail must agree on precision")
+		assert.Equal(t, detail.Condition.PreciseValue, listed.Condition.PreciseValue, "and on the threshold the ledger compares against")
+		return
+	}
+	t.Fatal("the monitor did not appear in the list endpoint")
+}
+
+// transferPrecise moves an amount at a given precision.
+func (e *monitorE2E) transferPrecise(t *testing.T, source, destination string, amount, precision float64) {
+	t.Helper()
+
+	payloadBytes, _ := request.ToJsonReq(&model2.RecordTransaction{
+		Amount: amount, Precision: precision, Reference: model.GenerateUUIDWithSuffix("ref"),
+		Description: "precise", Currency: "USD", Source: source, Destination: destination,
+		SkipQueue: true, AllowOverDraft: true,
+	})
+	resp, _ := SetUpTestRequest(TestRequest{
+		Payload: payloadBytes, Method: "POST", Route: "/transactions", Router: e.router,
+	})
+	require.Equal(t, http.StatusCreated, resp.Code, "body: %s", resp.Body.String())
+}

--- a/api/balance_monitor_e2e_test.go
+++ b/api/balance_monitor_e2e_test.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2024 Blnk Finance Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/gin-gonic/gin"
+	"github.com/hibiken/asynq"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blnkfinance/blnk"
+	model2 "github.com/blnkfinance/blnk/api/model"
+	"github.com/blnkfinance/blnk/config"
+	"github.com/blnkfinance/blnk/internal/request"
+	"github.com/blnkfinance/blnk/model"
+)
+
+// monitorE2E drives the whole path a real deployment takes: an HTTP request,
+// the ledger, the post-commit monitor check, and the webhook task that a worker
+// would pick up.
+type monitorE2E struct {
+	router    *gin.Engine
+	blnk      *blnk.Blnk
+	cnf       *config.Configuration
+	inspector *asynq.Inspector
+	queue     string
+}
+
+func setupMonitorE2E(t *testing.T) *monitorE2E {
+	t.Helper()
+
+	queue := fmt.Sprintf("monitor_e2e_%d", time.Now().UnixNano())
+	router, b, cnf := setupRouterWithConfig(t, func(cfg *config.Configuration) {
+		cfg.Queue.WebhookQueue = queue
+		// SendWebhook returns early when no URL is set, so the queue would stay
+		// empty however correct the monitor logic was.
+		cfg.Notification = config.Notification{Webhook: config.WebhookConfig{Url: "http://127.0.0.1:1/webhook"}}
+	})
+
+	inspector := asynq.NewInspector(asynq.RedisClientOpt{Addr: "localhost:6379"})
+	t.Cleanup(func() { _ = inspector.Close() })
+
+	return &monitorE2E{router: router, blnk: b, cnf: cnf, inspector: inspector, queue: queue}
+}
+
+// pendingTasks returns every pending task on this harness's queue. The ledger
+// puts its own webhooks on the same queue and a busy test overruns a single
+// page, so this pages to the end rather than sampling the first one.
+func (e *monitorE2E) pendingTasks() []*asynq.TaskInfo {
+	const pageSize = 200
+
+	var all []*asynq.TaskInfo
+	for page := 1; ; page++ {
+		batch, err := e.inspector.ListPendingTasks(e.queue, asynq.PageSize(pageSize), asynq.Page(page))
+		if err != nil {
+			return all
+		}
+		all = append(all, batch...)
+		if len(batch) < pageSize {
+			return all
+		}
+	}
+}
+
+// webhooks counts the balance.monitor tasks waiting on the queue. The payload,
+// not the queue depth, is what the assertions are about.
+func (e *monitorE2E) webhooks() int {
+	count := 0
+	for _, task := range e.pendingTasks() {
+		var hook struct {
+			Event string `json:"event"`
+		}
+		if err := json.Unmarshal(task.Payload, &hook); err != nil {
+			continue
+		}
+		if hook.Event == "balance.monitor" {
+			count++
+		}
+	}
+	return count
+}
+
+// awaitWebhooks waits for the detached post-commit goroutines to settle.
+func (e *monitorE2E) awaitWebhooks(t *testing.T, want int) {
+	t.Helper()
+	require.Eventually(t, func() bool { return e.webhooks() == want }, 5*time.Second, 25*time.Millisecond,
+		"expected %d webhooks, queue holds %d", want, e.webhooks())
+}
+
+// settle gives any further goroutine a chance to enqueue, so a test that asserts
+// "no more webhooks" is not just winning a race.
+func (e *monitorE2E) settle() { time.Sleep(300 * time.Millisecond) }
+
+func (e *monitorE2E) newBalance(t *testing.T) model.Balance {
+	t.Helper()
+
+	ledger, err := e.blnk.CreateLedger(model.Ledger{Name: gofakeit.Name()})
+	require.NoError(t, err)
+
+	balance, err := e.blnk.CreateBalance(context.Background(), model.Balance{LedgerID: ledger.LedgerID, Currency: "USD"})
+	require.NoError(t, err)
+
+	return balance
+}
+
+func (e *monitorE2E) createMonitorOn(t *testing.T, balanceID, field, operator string, value float64) model.BalanceMonitor {
+	t.Helper()
+
+	payloadBytes, _ := request.ToJsonReq(&model2.CreateBalanceMonitor{
+		BalanceId: balanceID,
+		Condition: model2.MonitorCondition{Field: field, Operator: operator, Value: value, Precision: 1},
+	})
+
+	var monitor model.BalanceMonitor
+	resp, _ := SetUpTestRequest(TestRequest{
+		Payload: payloadBytes, Response: &monitor,
+		Method: "POST", Route: "/balance-monitors", Router: e.router,
+	})
+	require.Equal(t, http.StatusCreated, resp.Code)
+	return monitor
+}
+
+// transfer moves amount from source to destination synchronously, so the
+// monitor check has run by the time the request returns.
+func (e *monitorE2E) transfer(t *testing.T, source, destination string, amount float64) {
+	t.Helper()
+
+	payloadBytes, _ := request.ToJsonReq(&model2.RecordTransaction{
+		Amount:      amount,
+		Precision:   1,
+		Reference:   gofakeit.UUID(),
+		Description: "monitor e2e",
+		Currency:    "USD",
+		Source:      source,
+		Destination: destination,
+		SkipQueue:   true,
+		// The funding balance is a plain ledger balance, not @world, so the
+		// debits that move the wallet have to be allowed to take it negative.
+		AllowOverDraft: true,
+	})
+
+	resp, _ := SetUpTestRequest(TestRequest{
+		Payload: payloadBytes,
+		Method:  "POST",
+		Route:   "/transactions",
+		Router:  e.router,
+	})
+	require.Equal(t, http.StatusCreated, resp.Code)
+}

--- a/api/model/balance.go
+++ b/api/model/balance.go
@@ -27,10 +27,10 @@ type CreateBalance struct {
 }
 
 type CreateBalanceMonitor struct {
-	BalanceId   string                 `json:"balance_id"`
-	Condition   MonitorCondition       `json:"condition"`
-	CallBackURL string                 `json:"call_back_url"`
-	MetaData    map[string]interface{} `json:"meta_data"`
+	BalanceId   string           `json:"balance_id"`
+	Condition   MonitorCondition `json:"condition"`
+	CallBackURL string           `json:"call_back_url"`
+	Description string           `json:"description"`
 }
 
 type MonitorCondition struct {

--- a/api/model/model.go
+++ b/api/model/model.go
@@ -260,9 +260,13 @@ func (b *CreateBalanceMonitor) ValidateCreateBalanceMonitor() error {
 func (c *MonitorCondition) ValidateMonitorCondition() error {
 	return validation.ValidateStruct(c,
 		validation.Field(&c.Field, validation.Required, validation.In("debit_balance", "credit_balance", "balance", "inflight_debit_balance", "inflight_credit_balance", "inflight_balance")),
-		validation.Field(&c.Operator, validation.Required),
+		validation.Field(&c.Operator, validation.Required, validation.In(">", "<", ">=", "<=", "=", "!=")),
 		validation.Field(&c.Precision, validation.Required, validation.By(validatePrecisionNotNegative)),
-		validation.Field(&c.Value, validation.Required),
+		// Value is deliberately not Required: ozzo treats a zero number as
+		// absent, which made every threshold at zero unexpressible -- no
+		// "balance > 0", no "balance != 0", no "balance <= 0". Precision keeps
+		// the rule because a zero multiplier is meaningless, a zero threshold
+		// is not.
 	)
 }
 
@@ -372,7 +376,7 @@ func (b *CreateBalanceMonitor) ToBalanceMonitor() model.BalanceMonitor {
 		Operator:  b.Condition.Operator,
 		Value:     b.Condition.Value,
 		Precision: b.Condition.Precision,
-	}, CallBackURL: b.CallBackURL}
+	}, CallBackURL: b.CallBackURL, Description: b.Description}
 }
 
 func (a *CreateAccount) ToAccount() model.Account {

--- a/api/model/model_test.go
+++ b/api/model/model_test.go
@@ -858,6 +858,46 @@ func TestToBalanceMonitor(t *testing.T) {
 	assert.Equal(t, createMonitor.Condition.Precision, monitor.Condition.Precision)
 }
 
+func TestValidateMonitorCondition_AllowsAZeroThreshold(t *testing.T) {
+	// "balance > 0" and "balance != 0" are the most natural monitors there are,
+	// and a validator that treats zero as absent made all of them impossible.
+	for _, operator := range []string{">", "<", ">=", "<=", "=", "!="} {
+		condition := MonitorCondition{Field: "balance", Operator: operator, Value: 0, Precision: 100}
+		assert.NoError(t, condition.ValidateMonitorCondition(), "zero is a threshold like any other (%s)", operator)
+	}
+}
+
+func TestValidateMonitorCondition_RejectsUnsupportedOperators(t *testing.T) {
+	base := func(operator string) MonitorCondition {
+		return MonitorCondition{Field: "balance", Operator: operator, Value: 100, Precision: 100}
+	}
+
+	// The whole set the table's check constraint stores, all of which
+	// model.compare can now evaluate.
+	for _, operator := range []string{">", "<", ">=", "<=", "=", "!="} {
+		condition := base(operator)
+		assert.NoError(t, condition.ValidateMonitorCondition(), "operator %q must be accepted", operator)
+	}
+
+	// An operator the ledger cannot evaluate used to be stored happily and then
+	// never fire, which is worse than a rejection.
+	for _, operator := range []string{"==", "=>", "gt", "~"} {
+		condition := base(operator)
+		assert.Error(t, condition.ValidateMonitorCondition(), "operator %q must be rejected", operator)
+	}
+}
+
+func TestToBalanceMonitor_CarriesDescription(t *testing.T) {
+	createMonitor := CreateBalanceMonitor{
+		BalanceId:   "bln_test_123",
+		Description: "low balance alert",
+		Condition:   MonitorCondition{Field: "balance", Operator: "<", Value: 1000, Precision: 100},
+	}
+
+	assert.Equal(t, "low balance alert", createMonitor.ToBalanceMonitor().Description,
+		"description is a column and is settable on update, so create must be able to set it too")
+}
+
 // TestSplitOnOneSideValidation pins that a transaction cannot split both
 // sides at once. SplitTransactionPrecise distributes over Sources when they
 // are present and Destinations otherwise, clearing both on the legs it

--- a/balance.go
+++ b/balance.go
@@ -455,16 +455,28 @@ func (l *Blnk) GetBalanceMonitors(ctx context.Context, balanceID string) ([]mode
 // Returns:
 // - error: An error if the monitor could not be updated.
 func (l *Blnk) UpdateMonitor(ctx context.Context, monitor *model.BalanceMonitor) error {
-	_, span := balanceTracer.Start(ctx, "UpdateMonitor")
+	ctx, span := balanceTracer.Start(ctx, "UpdateMonitor")
 	defer span.End()
 
-	err := l.datasource.UpdateMonitor(monitor)
+	// An update may move the monitor to a different balance, and the cache is
+	// keyed by balance: without the previous ID the monitor stays in the old
+	// balance's cached list and keeps being evaluated against a balance it no
+	// longer watches.
+	previous, err := l.datasource.GetMonitorByID(monitor.MonitorID)
 	if err != nil {
 		span.RecordError(err)
 		return err
 	}
 
+	if err := l.datasource.UpdateMonitor(monitor); err != nil {
+		span.RecordError(err)
+		return err
+	}
+
 	_ = l.cache.Delete(ctx, "monitors:"+monitor.BalanceID)
+	if previous.BalanceID != monitor.BalanceID {
+		_ = l.cache.Delete(ctx, "monitors:"+previous.BalanceID)
+	}
 
 	span.AddEvent("Monitor updated", trace.WithAttributes(attribute.String("monitor.id", monitor.MonitorID)))
 	return nil

--- a/balance_monitor_cache_test.go
+++ b/balance_monitor_cache_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2024 Blnk Finance Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package blnk
+
+import (
+	"context"
+	"math/big"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blnkfinance/blnk/config"
+	"github.com/blnkfinance/blnk/database/mocks"
+	"github.com/blnkfinance/blnk/model"
+)
+
+type monitorHarness struct {
+	blnk *Blnk
+	ds   *mocks.MockDataSource
+}
+
+func newMonitorHarness(t *testing.T) *monitorHarness {
+	t.Helper()
+
+	// Stored directly rather than through MockConfig, which runs the full
+	// validation this partial test configuration cannot satisfy.
+	config.ConfigStore.Store(&config.Configuration{
+		Redis:              config.RedisConfig{Dns: "localhost:6379"},
+		Queue:              config.QueueConfig{WebhookQueue: "monitor_cache_test", TransactionQueue: "monitor_cache_test_txn", IndexQueue: "monitor_cache_test_idx", NumberOfQueues: 1},
+		Server:             config.ServerConfig{SecretKey: "some-secret"},
+		TokenizationSecret: "12345678901234567890123456789012",
+	})
+
+	ds := new(mocks.MockDataSource)
+	b, err := NewBlnk(ds)
+	require.NoError(t, err)
+
+	return &monitorHarness{blnk: b, ds: ds}
+}
+
+// recordingCache notes which keys were invalidated.
+type recordingCache struct {
+	mu      sync.Mutex
+	deleted []string
+}
+
+func (c *recordingCache) Set(_ context.Context, _ string, _ interface{}, _ time.Duration) error {
+	return nil
+}
+func (c *recordingCache) Get(_ context.Context, _ string, _ interface{}) error { return nil }
+func (c *recordingCache) Delete(_ context.Context, key string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.deleted = append(c.deleted, key)
+	return nil
+}
+
+// The monitor cache is keyed by balance. An update that moves a monitor to a
+// different balance has to invalidate both, or the monitor stays in the old
+// balance's cached list and keeps being evaluated against a balance it no
+// longer watches.
+func TestUpdateMonitor_InvalidatesBothBalancesWhenMoved(t *testing.T) {
+	h := newMonitorHarness(t)
+	recorder := &recordingCache{}
+	h.blnk.cache = recorder
+
+	stored := &model.BalanceMonitor{
+		MonitorID: "mon_move",
+		BalanceID: "bln_old",
+		Condition: model.AlertCondition{Field: "balance", Operator: "<", PreciseValue: big.NewInt(100)},
+	}
+	h.ds.On("GetMonitorByID", "mon_move").Return(stored, nil).Once()
+	h.ds.On("UpdateMonitor", mock.Anything).Return(nil).Once()
+
+	moved := &model.BalanceMonitor{
+		MonitorID: "mon_move",
+		BalanceID: "bln_new",
+		Condition: model.AlertCondition{Field: "balance", Operator: "<", PreciseValue: big.NewInt(100)},
+	}
+	require.NoError(t, h.blnk.UpdateMonitor(context.Background(), moved))
+
+	assert.ElementsMatch(t, []string{"monitors:bln_new", "monitors:bln_old"}, recorder.deleted)
+	h.ds.AssertExpectations(t)
+}
+
+func TestUpdateMonitor_InvalidatesOnceWhenTheBalanceIsUnchanged(t *testing.T) {
+	h := newMonitorHarness(t)
+	recorder := &recordingCache{}
+	h.blnk.cache = recorder
+
+	stored := &model.BalanceMonitor{MonitorID: "mon_same", BalanceID: "bln_same"}
+	h.ds.On("GetMonitorByID", "mon_same").Return(stored, nil).Once()
+	h.ds.On("UpdateMonitor", mock.Anything).Return(nil).Once()
+
+	require.NoError(t, h.blnk.UpdateMonitor(context.Background(), &model.BalanceMonitor{
+		MonitorID: "mon_same", BalanceID: "bln_same",
+	}))
+
+	assert.Equal(t, []string{"monitors:bln_same"}, recorder.deleted)
+}

--- a/balance_test.go
+++ b/balance_test.go
@@ -394,8 +394,8 @@ func TestGetAllMonitors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating Blnk instance: %s", err)
 	}
-	rows := sqlmock.NewRows([]string{"monitor_id", "balance_id", "field", "operator", "value", "description", "call_back_url", "created_at"}).
-		AddRow("test-monitor", gofakeit.UUID(), "field", "operator", 100, "Test Monitor", gofakeit.URL(), time.Now())
+	rows := sqlmock.NewRows([]string{"monitor_id", "balance_id", "field", "operator", "value", "description", "call_back_url", "created_at", "precision", "precise_value"}).
+		AddRow("test-monitor", gofakeit.UUID(), "field", "operator", 100, "Test Monitor", gofakeit.URL(), time.Now(), 100, 100000)
 
 	mock.ExpectQuery("SELECT .* FROM blnk.balance_monitors").WillReturnRows(rows)
 
@@ -447,7 +447,11 @@ func TestUpdateMonitor(t *testing.T) {
 	}
 	monitor := &model.BalanceMonitor{MonitorID: "test-monitor", BalanceID: "test-balance", Description: "Updated Monitor"}
 
-	mock.ExpectExec("UPDATE blnk.balance_monitors").WithArgs(monitor.MonitorID, monitor.BalanceID, monitor.Condition.Field, monitor.Condition.Operator, monitor.Condition.Value, monitor.Description, monitor.CallBackURL).WillReturnResult(sqlmock.NewResult(1, 1))
+	previous := sqlmock.NewRows([]string{"monitor_id", "balance_id", "field", "operator", "value", "precision", "precise_value", "description", "call_back_url", "created_at"}).
+		AddRow(monitor.MonitorID, monitor.BalanceID, "balance", "<", 100, 100, 10000, "Test Monitor", gofakeit.URL(), time.Now())
+	mock.ExpectQuery("SELECT .* FROM blnk.balance_monitors WHERE monitor_id =").WithArgs(monitor.MonitorID).WillReturnRows(previous)
+
+	mock.ExpectExec("UPDATE blnk.balance_monitors").WithArgs(monitor.MonitorID, monitor.BalanceID, monitor.Condition.Field, monitor.Condition.Operator, monitor.Condition.Value, monitor.Description).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	err = d.UpdateMonitor(context.Background(), monitor)
 
@@ -473,7 +477,7 @@ func TestDeleteMonitor(t *testing.T) {
 
 	rows := sqlmock.NewRows([]string{"monitor_id", "balance_id", "field", "operator", "value", "precision", "precise_value", "description", "call_back_url", "created_at"}).
 		AddRow(monitorID, balanceID, "balance", ">", 100.0, 100.0, int64(10000), "test", "http://test.com", time.Now())
-	mock.ExpectQuery("SELECT monitor_id, balance_id, field, operator, value, precision, precise_value, description, call_back_url, created_at FROM blnk.balance_monitors WHERE monitor_id =").
+	mock.ExpectQuery("SELECT .* FROM blnk.balance_monitors WHERE monitor_id =").
 		WithArgs(monitorID).WillReturnRows(rows)
 
 	mock.ExpectExec("DELETE FROM blnk.balance_monitors WHERE monitor_id =").WithArgs(monitorID).WillReturnResult(sqlmock.NewResult(1, 1))

--- a/database/balance.go
+++ b/database/balance.go
@@ -1168,7 +1168,7 @@ func (d Datasource) GetMonitorByID(id string) (*model.BalanceMonitor, error) {
 
 	// Query the database to get the monitor details by MonitorID
 	row := d.Conn.QueryRowContext(context.Background(), `
-		SELECT monitor_id, balance_id, field, operator, value, precision, precise_value, description, call_back_url, created_at
+		SELECT monitor_id, balance_id, field, operator, value, COALESCE(precision, 0), COALESCE(precise_value, 0), description, call_back_url, created_at
 		FROM blnk.balance_monitors WHERE monitor_id = $1
 	`, id)
 
@@ -1205,7 +1205,7 @@ func (d Datasource) GetMonitorByID(id string) (*model.BalanceMonitor, error) {
 func (d Datasource) GetAllMonitors() ([]model.BalanceMonitor, error) {
 	// Query the database for all balance monitors
 	rows, err := d.Conn.QueryContext(context.Background(), `
-		SELECT monitor_id, balance_id, field, operator, value, description, call_back_url, created_at
+		SELECT monitor_id, balance_id, field, operator, value, description, call_back_url, created_at, COALESCE(precision, 0), COALESCE(precise_value, 0)
 		FROM blnk.balance_monitors
 	`)
 	if err != nil {
@@ -1219,11 +1219,12 @@ func (d Datasource) GetAllMonitors() ([]model.BalanceMonitor, error) {
 
 	// Iterate through each row in the result set
 	for rows.Next() {
+		var preciseValue int64
 		monitor := model.BalanceMonitor{}   // Create an empty BalanceMonitor object
 		condition := model.AlertCondition{} // Create an empty AlertCondition object (part of the monitor)
 
 		// Scan the row into the monitor and condition fields
-		err = rows.Scan(&monitor.MonitorID, &monitor.BalanceID, &condition.Field, &condition.Operator, &condition.Value, &monitor.Description, &monitor.CallBackURL, &monitor.CreatedAt)
+		err = rows.Scan(&monitor.MonitorID, &monitor.BalanceID, &condition.Field, &condition.Operator, &condition.Value, &monitor.Description, &monitor.CallBackURL, &monitor.CreatedAt, &condition.Precision, &preciseValue)
 		if err != nil {
 			// Return an error if scanning fails
 			return nil, apierror.NewAPIError(apierror.ErrInternalServer, "Failed to scan monitor data", err)
@@ -1231,6 +1232,7 @@ func (d Datasource) GetAllMonitors() ([]model.BalanceMonitor, error) {
 
 		// Assign the scanned AlertCondition to the monitor
 		monitor.Condition = condition
+		monitor.Condition.PreciseValue = big.NewInt(preciseValue)
 
 		// Append the monitor to the slice
 		monitors = append(monitors, monitor)
@@ -1258,7 +1260,7 @@ func (d Datasource) GetAllMonitors() ([]model.BalanceMonitor, error) {
 func (d Datasource) GetBalanceMonitors(balanceID string) ([]model.BalanceMonitor, error) {
 	// Query the database for monitors associated with the given balance ID
 	rows, err := d.Conn.QueryContext(context.Background(), `
-		SELECT monitor_id, balance_id, field, operator, value, description, call_back_url, created_at, precision, precise_value
+		SELECT monitor_id, balance_id, field, operator, value, description, call_back_url, created_at, COALESCE(precision, 0), COALESCE(precise_value, 0)
 		FROM blnk.balance_monitors WHERE balance_id = $1
 	`, balanceID)
 	if err != nil {
@@ -1302,8 +1304,10 @@ func (d Datasource) GetBalanceMonitors(balanceID string) ([]model.BalanceMonitor
 }
 
 // UpdateMonitor updates an existing balance monitor in the database.
-// It updates fields such as `balance_id`, `field`, `operator`, `value`, `description`, and `call_back_url`
-// for the monitor identified by `monitor_id`.
+//
+// call_back_url is deliberately not written: BalanceMonitor.CallBackURL is
+// tagged json:"-", so a request can never populate it, and writing it here only
+// ever cleared the URL the monitor was created with.
 //
 // Parameters:
 // - monitor: A pointer to the `BalanceMonitor` object containing the updated values.
@@ -1314,9 +1318,9 @@ func (d Datasource) UpdateMonitor(monitor *model.BalanceMonitor) error {
 	// Execute the SQL update statement, replacing the placeholder values with the monitor's data
 	result, err := d.Conn.ExecContext(context.Background(), `
 		UPDATE blnk.balance_monitors
-		SET balance_id = $2, field = $3, operator = $4, value = $5, description = $6, call_back_url = $7
+		SET balance_id = $2, field = $3, operator = $4, value = $5, description = $6
 		WHERE monitor_id = $1
-	`, monitor.MonitorID, monitor.BalanceID, monitor.Condition.Field, monitor.Condition.Operator, monitor.Condition.Value, monitor.Description, monitor.CallBackURL)
+	`, monitor.MonitorID, monitor.BalanceID, monitor.Condition.Field, monitor.Condition.Operator, monitor.Condition.Value, monitor.Description)
 	// If an error occurred during execution, return an internal server error
 	if err != nil {
 		return apierror.NewAPIError(apierror.ErrInternalServer, "Failed to update monitor", err)

--- a/database/balance_monitor_legacy_rows_test.go
+++ b/database/balance_monitor_legacy_rows_test.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2024 Blnk Finance Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package database
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/blnkfinance/blnk/model"
+)
+
+func legacyTestBalance(t *testing.T, ds Datasource) model.Balance {
+	t.Helper()
+	ledger, err := ds.CreateLedger(model.Ledger{Name: gofakeit.UUID()})
+	require.NoError(t, err)
+	balance, err := ds.CreateBalance(model.Balance{LedgerID: ledger.LedgerID, Currency: "USD"})
+	require.NoError(t, err)
+	return balance
+}
+
+// precision and precise_value were added as nullable columns, so every monitor
+// created before that migration carries NULLs. Scanning them into plain Go
+// numbers failed the whole read, and because checkBalanceMonitors gives up on
+// that error, one such row silenced every monitor on its balance.
+func TestGetMonitors_ToleratesNullPrecision_RealDB(t *testing.T) {
+	ds := openRealTestDB(t)
+	balance := legacyTestBalance(t, ds)
+
+	legacyID := model.GenerateUUIDWithSuffix("mon")
+	_, err := ds.Conn.Exec(`
+		INSERT INTO blnk.balance_monitors (monitor_id, balance_id, field, operator, value, description, call_back_url, created_at)
+		VALUES ($1, $2, 'balance', '<', 100, 'written before the precision migration', '', NOW())
+	`, legacyID, balance.BalanceID)
+	require.NoError(t, err)
+
+	one, err := ds.GetMonitorByID(legacyID)
+	require.NoError(t, err, "a legacy row must still be readable")
+	assert.Equal(t, float64(0), one.Condition.Precision)
+	assert.Equal(t, big.NewInt(0), one.Condition.PreciseValue)
+
+	monitors, err := ds.GetBalanceMonitors(balance.BalanceID)
+	require.NoError(t, err, "one legacy row must not take down the balance's whole monitor list")
+	require.Len(t, monitors, 1)
+	assert.Equal(t, legacyID, monitors[0].MonitorID)
+	assert.NotNil(t, monitors[0].Condition.PreciseValue, "a nil threshold would panic the comparison")
+
+	all, err := ds.GetAllMonitors()
+	require.NoError(t, err)
+	assert.NotEmpty(t, all)
+}
+
+// GetAllMonitors omitted precision and precise_value, so the list endpoint
+// reported a different threshold from the single-monitor endpoint.
+func TestGetAllMonitors_CarriesPrecision_RealDB(t *testing.T) {
+	ds := openRealTestDB(t)
+	balance := legacyTestBalance(t, ds)
+
+	created, err := ds.CreateMonitor(model.BalanceMonitor{
+		BalanceID: balance.BalanceID,
+		Condition: model.AlertCondition{Field: "balance", Operator: "<", Value: 100, Precision: 100, PreciseValue: big.NewInt(10000)},
+	})
+	require.NoError(t, err)
+
+	one, err := ds.GetMonitorByID(created.MonitorID)
+	require.NoError(t, err)
+
+	all, err := ds.GetAllMonitors()
+	require.NoError(t, err)
+
+	var listed *model.BalanceMonitor
+	for i := range all {
+		if all[i].MonitorID == created.MonitorID {
+			listed = &all[i]
+		}
+	}
+	require.NotNil(t, listed, "the monitor must appear in the list")
+	assert.Equal(t, one.Condition.Precision, listed.Condition.Precision)
+	assert.Equal(t, one.Condition.PreciseValue, listed.Condition.PreciseValue)
+}
+
+// BalanceMonitor.CallBackURL is tagged json:"-", so an update can never carry
+// one. Writing it anyway meant every update cleared the URL the monitor was
+// created with.
+func TestUpdateMonitor_PreservesCallbackURL_RealDB(t *testing.T) {
+	ds := openRealTestDB(t)
+	balance := legacyTestBalance(t, ds)
+
+	created, err := ds.CreateMonitor(model.BalanceMonitor{
+		BalanceID:   balance.BalanceID,
+		CallBackURL: "https://example.com/hook",
+		Condition:   model.AlertCondition{Field: "balance", Operator: "<", Value: 100, Precision: 1, PreciseValue: big.NewInt(100)},
+	})
+	require.NoError(t, err)
+
+	update := model.BalanceMonitor{
+		MonitorID: created.MonitorID,
+		BalanceID: balance.BalanceID,
+		Condition: model.AlertCondition{Field: "balance", Operator: "<", Value: 200},
+	}
+	require.NoError(t, ds.UpdateMonitor(&update))
+
+	var stored string
+	require.NoError(t, ds.Conn.QueryRow(
+		`SELECT call_back_url FROM blnk.balance_monitors WHERE monitor_id = $1`, created.MonitorID).Scan(&stored))
+	assert.Equal(t, "https://example.com/hook", stored, "an update that cannot carry a callback URL must not clear it")
+}
+
+// value is the human-readable half of the threshold and is a float64 in Go, but
+// the column was a BIGINT, so a fractional threshold failed at the database.
+func TestCreateMonitor_FractionalThreshold_RealDB(t *testing.T) {
+	ds := openRealTestDB(t)
+	balance := legacyTestBalance(t, ds)
+
+	created, err := ds.CreateMonitor(model.BalanceMonitor{
+		BalanceID: balance.BalanceID,
+		Condition: model.AlertCondition{Field: "balance", Operator: "<", Value: 100.5, Precision: 100, PreciseValue: big.NewInt(10050)},
+	})
+	require.NoError(t, err, "a fractional threshold is a normal thing to want")
+
+	stored, err := ds.GetMonitorByID(created.MonitorID)
+	require.NoError(t, err)
+	assert.Equal(t, 100.5, stored.Condition.Value)
+	assert.Equal(t, big.NewInt(10050), stored.Condition.PreciseValue)
+}
+
+// The check constraint stores equality as '=', but compare() only knew '==',
+// which the same constraint rejects. Equality monitors were unusable.
+func TestCheckCondition_EqualityOperator_RealDB(t *testing.T) {
+	ds := openRealTestDB(t)
+	balance := legacyTestBalance(t, ds)
+
+	created, err := ds.CreateMonitor(model.BalanceMonitor{
+		BalanceID: balance.BalanceID,
+		Condition: model.AlertCondition{Field: "balance", Operator: "=", Value: 100, Precision: 1, PreciseValue: big.NewInt(100)},
+	})
+	require.NoError(t, err)
+
+	stored, err := ds.GetMonitorByID(created.MonitorID)
+	require.NoError(t, err)
+
+	exactly := &model.Balance{Balance: big.NewInt(100)}
+	exactly.InitializeBalanceFields()
+	other := &model.Balance{Balance: big.NewInt(101)}
+	other.InitializeBalanceFields()
+
+	assert.True(t, stored.CheckCondition(exactly), "an equality monitor must fire on an equal balance")
+	assert.False(t, stored.CheckCondition(other))
+}

--- a/database/balance_test.go
+++ b/database/balance_test.go
@@ -1238,7 +1238,7 @@ func TestGetMonitorByID_Success(t *testing.T) {
 	ds := Datasource{Conn: db}
 
 	query := `
-		SELECT monitor_id, balance_id, field, operator, value, precision, precise_value, description, call_back_url, created_at
+		SELECT monitor_id, balance_id, field, operator, value, COALESCE(precision, 0), COALESCE(precise_value, 0), description, call_back_url, created_at
 		FROM blnk.balance_monitors WHERE monitor_id = $1
 	`
 
@@ -1271,7 +1271,7 @@ func TestGetMonitorByID_NotFound(t *testing.T) {
 	ds := Datasource{Conn: db}
 
 	query := `
-		SELECT monitor_id, balance_id, field, operator, value, precision, precise_value, description, call_back_url, created_at
+		SELECT monitor_id, balance_id, field, operator, value, COALESCE(precision, 0), COALESCE(precise_value, 0), description, call_back_url, created_at
 		FROM blnk.balance_monitors WHERE monitor_id = $1
 	`
 
@@ -1298,16 +1298,16 @@ func TestGetAllMonitors_Success(t *testing.T) {
 	ds := Datasource{Conn: db}
 
 	query := `
-		SELECT monitor_id, balance_id, field, operator, value, description, call_back_url, created_at
+		SELECT monitor_id, balance_id, field, operator, value, description, call_back_url, created_at, COALESCE(precision, 0), COALESCE(precise_value, 0)
 		FROM blnk.balance_monitors
 	`
 
 	mock.ExpectQuery(regexp.QuoteMeta(query)).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"monitor_id", "balance_id", "field", "operator", "value", "description", "call_back_url", "created_at",
+			"monitor_id", "balance_id", "field", "operator", "value", "description", "call_back_url", "created_at", "precision", "precise_value",
 		}).
-			AddRow("mon_1", "bln_1", "balance", "<", 1000.0, "Alert 1", "https://example.com/1", time.Now()).
-			AddRow("mon_2", "bln_2", "credit_balance", ">", 5000.0, "Alert 2", "https://example.com/2", time.Now()))
+			AddRow("mon_1", "bln_1", "balance", "<", 1000.0, "Alert 1", "https://example.com/1", time.Now(), 100, int64(100000)).
+			AddRow("mon_2", "bln_2", "credit_balance", ">", 5000.0, "Alert 2", "https://example.com/2", time.Now(), 100, int64(500000)))
 
 	monitors, err := ds.GetAllMonitors()
 	assert.NoError(t, err)
@@ -1327,13 +1327,13 @@ func TestGetAllMonitors_Empty(t *testing.T) {
 	ds := Datasource{Conn: db}
 
 	query := `
-		SELECT monitor_id, balance_id, field, operator, value, description, call_back_url, created_at
+		SELECT monitor_id, balance_id, field, operator, value, description, call_back_url, created_at, COALESCE(precision, 0), COALESCE(precise_value, 0)
 		FROM blnk.balance_monitors
 	`
 
 	mock.ExpectQuery(regexp.QuoteMeta(query)).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"monitor_id", "balance_id", "field", "operator", "value", "description", "call_back_url", "created_at",
+			"monitor_id", "balance_id", "field", "operator", "value", "description", "call_back_url", "created_at", "precision", "precise_value",
 		}))
 
 	monitors, err := ds.GetAllMonitors()
@@ -1352,7 +1352,7 @@ func TestGetBalanceMonitors_Success(t *testing.T) {
 	ds := Datasource{Conn: db}
 
 	query := `
-		SELECT monitor_id, balance_id, field, operator, value, description, call_back_url, created_at, precision, precise_value
+		SELECT monitor_id, balance_id, field, operator, value, description, call_back_url, created_at, COALESCE(precision, 0), COALESCE(precise_value, 0)
 		FROM blnk.balance_monitors WHERE balance_id = $1
 	`
 
@@ -1383,7 +1383,7 @@ func TestGetBalanceMonitors_Empty(t *testing.T) {
 	ds := Datasource{Conn: db}
 
 	query := `
-		SELECT monitor_id, balance_id, field, operator, value, description, call_back_url, created_at, precision, precise_value
+		SELECT monitor_id, balance_id, field, operator, value, description, call_back_url, created_at, COALESCE(precision, 0), COALESCE(precise_value, 0)
 		FROM blnk.balance_monitors WHERE balance_id = $1
 	`
 
@@ -1422,12 +1422,12 @@ func TestUpdateMonitor_Success(t *testing.T) {
 
 	query := `
 		UPDATE blnk.balance_monitors
-		SET balance_id = $2, field = $3, operator = $4, value = $5, description = $6, call_back_url = $7
+		SET balance_id = $2, field = $3, operator = $4, value = $5, description = $6
 		WHERE monitor_id = $1
 	`
 
 	mock.ExpectExec(regexp.QuoteMeta(query)).
-		WithArgs(monitor.MonitorID, monitor.BalanceID, monitor.Condition.Field, monitor.Condition.Operator, monitor.Condition.Value, monitor.Description, monitor.CallBackURL).
+		WithArgs(monitor.MonitorID, monitor.BalanceID, monitor.Condition.Field, monitor.Condition.Operator, monitor.Condition.Value, monitor.Description).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	err = ds.UpdateMonitor(monitor)
@@ -1457,12 +1457,12 @@ func TestUpdateMonitor_NotFound(t *testing.T) {
 
 	query := `
 		UPDATE blnk.balance_monitors
-		SET balance_id = $2, field = $3, operator = $4, value = $5, description = $6, call_back_url = $7
+		SET balance_id = $2, field = $3, operator = $4, value = $5, description = $6
 		WHERE monitor_id = $1
 	`
 
 	mock.ExpectExec(regexp.QuoteMeta(query)).
-		WithArgs(monitor.MonitorID, monitor.BalanceID, monitor.Condition.Field, monitor.Condition.Operator, monitor.Condition.Value, monitor.Description, monitor.CallBackURL).
+		WithArgs(monitor.MonitorID, monitor.BalanceID, monitor.Condition.Field, monitor.Condition.Operator, monitor.Condition.Value, monitor.Description).
 		WillReturnResult(sqlmock.NewResult(0, 0))
 
 	err = ds.UpdateMonitor(monitor)

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -17,41 +17,53 @@ package cache
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/blnkfinance/blnk/config"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
+// testKey gives each test its own key. The cache is a shared Redis, so fixed
+// keys made these tests depend on execution order and on what an earlier run
+// left behind.
+func testKey(t *testing.T) string {
+	t.Helper()
+	return fmt.Sprintf("cachetest:%s:%d", t.Name(), time.Now().UnixNano())
+}
+
+// newTestCache configures the package and returns a cache. Every test needs
+// this: config.MockConfig validates before it stores, so configuring with an
+// empty Configuration is a no-op, and a test that did that only worked when
+// another test had already left a usable config in the global store.
+func newTestCache(t *testing.T) Cache {
+	t.Helper()
+
+	config.ConfigStore.Store(&config.Configuration{
+		Redis:              config.RedisConfig{Dns: "localhost:6379"},
+		Queue:              config.QueueConfig{WebhookQueue: "webhook_queue", NumberOfQueues: 1},
+		Server:             config.ServerConfig{SecretKey: "some-secret"},
+		TokenizationSecret: "12345678901234567890123456789012",
+	})
+
+	cache, err := NewCache()
+	require.NoError(t, err)
+	require.NotNil(t, cache)
+	return cache
+}
+
 func TestSet(t *testing.T) {
-	cnf := &config.Configuration{
-		Redis: config.RedisConfig{
-			Dns: "localhost:6379",
-		},
-		Queue: config.QueueConfig{
-			WebhookQueue:   "webhook_queue",
-			NumberOfQueues: 1,
-		},
-		Server: config.ServerConfig{SecretKey: "some-secret"},
-		AccountNumberGeneration: config.AccountNumberGenerationConfig{
-			HttpService: config.AccountGenerationHttpService{
-				Url: "http://example.com/generateAccount",
-			},
-		},
-	}
-
-	config.ConfigStore.Store(cnf)
 	ctx := context.Background()
-	mockCache, err := NewCache()
-	assert.NoError(t, err)
+	mockCache := newTestCache(t)
 
-	key := "testKey"
+	key := testKey(t)
 	value := "testValue"
 
 	// Test setting a value
-	err = mockCache.Set(ctx, key, value, 10*time.Minute)
+	err := mockCache.Set(ctx, key, value, 10*time.Minute)
 	assert.NoError(t, err)
 
 	// Test setting a value with zero TTL (should fail or behave differently)
@@ -60,14 +72,12 @@ func TestSet(t *testing.T) {
 }
 
 func TestGet(t *testing.T) {
-	config.MockConfig(&config.Configuration{})
 	ctx := context.Background()
-	mockCache, err := NewCache()
-	assert.NoError(t, err)
+	mockCache := newTestCache(t)
 
-	key := "testKey"
+	key := testKey(t)
 	setValue := map[string]string{"hello": "world"}
-	err = mockCache.Set(ctx, key, setValue, 10*time.Minute)
+	err := mockCache.Set(ctx, key, setValue, 10*time.Minute)
 	assert.NoError(t, err)
 
 	// Test getting an existing value
@@ -78,32 +88,28 @@ func TestGet(t *testing.T) {
 
 	var getValue1 map[string]string
 	// Test getting a non-existent key
-	err = mockCache.Get(ctx, "nonExistentKey", &getValue1)
+	err = mockCache.Get(ctx, testKey(t)+":absent", &getValue1)
 	assert.NoError(t, err) // Assuming Get returns no error for non-existent keys
 	assert.Empty(t, getValue1)
 }
 
 func TestGetNonExistentKey(t *testing.T) {
-	config.MockConfig(&config.Configuration{})
 	ctx := context.Background()
-	mockCache, err := NewCache()
-	assert.NoError(t, err)
+	mockCache := newTestCache(t)
 
 	var getValue map[string]string
-	err = mockCache.Get(ctx, "nonExistentKey", &getValue)
+	err := mockCache.Get(ctx, testKey(t)+":absent", &getValue)
 	assert.NoError(t, err) // Assuming Get returns no error for non-existent keys
 	assert.Empty(t, getValue)
 }
 
 func TestDelete(t *testing.T) {
-	config.MockConfig(&config.Configuration{})
 	ctx := context.Background()
-	mockCache, err := NewCache()
-	assert.NoError(t, err)
+	mockCache := newTestCache(t)
 
-	key := "testKey"
+	key := testKey(t)
 	value := "testValue"
-	err = mockCache.Set(ctx, key, value, 10*time.Minute)
+	err := mockCache.Set(ctx, key, value, 10*time.Minute)
 	if err != nil {
 		return
 	}
@@ -119,6 +125,6 @@ func TestDelete(t *testing.T) {
 	assert.Empty(t, getValue)
 
 	// Test deleting a non-existent key
-	err = mockCache.Delete(ctx, "nonExistentKey")
+	err = mockCache.Delete(ctx, testKey(t)+":absent")
 	assert.NoError(t, err)
 }

--- a/model/model.go
+++ b/model/model.go
@@ -83,7 +83,10 @@ func compare(value *big.Int, condition string, compareTo *big.Int) bool {
 		return cmp <= 0
 	case "!=":
 		return cmp != 0
-	case "==":
+	// The table's check constraint stores equality as '=', so that is the
+	// spelling monitors actually carry; '==' is accepted as well because the
+	// API has always advertised it.
+	case "=", "==":
 		return cmp == 0
 	}
 	return false

--- a/sql/1788542465.sql
+++ b/sql/1788542465.sql
@@ -1,0 +1,25 @@
+-- Copyright 2024 Blnk Finance Authors.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- AlertCondition.Value is a float64 and is the human-readable threshold that
+-- pairs with precision, but the column was a BIGINT: a monitor on "balance <
+-- 100.50" failed at the database and surfaced as a 500. precise_value carries
+-- the value the ledger actually compares against, so widening this column
+-- changes no evaluation, it only stops rejecting thresholds the API accepts.
+
+-- +migrate Up
+ALTER TABLE blnk.balance_monitors ALTER COLUMN value TYPE DOUBLE PRECISION;
+
+-- +migrate Down
+ALTER TABLE blnk.balance_monitors ALTER COLUMN value TYPE BIGINT USING ROUND(value);


### PR DESCRIPTION
I found these while building edge-triggered monitors for #318. They are pre-existing bugs that don't depend on that feature, so they are split out to review and merge on their own. #388 builds on this PR.

## Fixes

1. **One old monitor could silence every monitor on its balance.** Monitors created before `precision` and `precise_value` existed have NULL in both columns. Reading one failed the whole query, and `checkBalanceMonitors` gives up when the query fails. Both columns are now read with `COALESCE(..., 0)`.
2. **Equality monitors never fired.** The check constraint stores `=`, but `compare()` only handled `==`. It now accepts both, and the API returns 400 for an operator the ledger can't evaluate.
3. **Every update cleared the callback URL.** `CallBackURL` is tagged `json:"-"`, so a request can't set it, but `UpdateMonitor` wrote it anyway. The update no longer touches that column.
4. **A moved monitor kept firing on its old balance.** The monitor cache is keyed by balance, and only the new balance was invalidated, so the old balance kept evaluating the monitor for up to five minutes. Both are invalidated now.
5. **A zero threshold was rejected.** `validation.Required` treats `0` as missing, so `balance > 0` returned 400.
6. **A fractional threshold returned 500.** `value` was `BIGINT`, so `balance < 100.50` failed in the database. It is now `DOUBLE PRECISION`. Evaluation uses `precise_value`, so no existing monitor behaves differently.
7. **The list endpoint disagreed with the detail endpoint.** `GetAllMonitors` didn't select `precision` or `precise_value`.

The create payload also drops `meta_data`, which had no column and was silently discarded, and accepts `description`, which only an update could set before.

## On upgrade

Monitors already stored with `=` will start firing. That is what they were created to do, but it is a change.

## Also included

The `internal/cache` tests configured the package with an empty `Configuration`, which `MockConfig` silently ignores, so they only passed when `TestSet` ran first and panicked under `-shuffle`. Each test now sets its own config. It's a separate commit, so it's easy to drop.

## Testing

Every fix has a unit test or a test against real Postgres. Five of them also have an end-to-end test that goes through the HTTP API, the ledger and the webhook queue: the legacy row, the moved monitor, zero and fractional thresholds, and list versus detail.

Locally the full suite passes, `-race -shuffle=on` passes on the changed packages outside `api`, and `golangci-lint` reports no new issues.
